### PR TITLE
Noflow boundary, 1D examples

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -81,6 +81,48 @@ At the moment there is no attempt to limit these velocities, which has
 been found necessary in UEDGE to get physical results in better
 agreement with kinetic neutral models [Discussion, T.Rognlien].
 
+noflow_boundary
+~~~~~~~~~~~~~~~
+
+This is a species component which imposes a no-flow boundary condition
+on y (parallel) boundaries.
+
+- Zero-gradient boundary conditions are applied to `density`,
+  `temperature` and `pressure` fields, if they are set.
+- Zero-value boundary conditions are applied to `velocity` and
+  `momentum` if they are set.
+
+By default both yup and ydown boundaries are set, but can be turned
+off by setting `noflow_lower_y` or `noflow_upper_y` to `false`.
+
+Example: To set no-flow boundary condition on an ion `d+` at the lower
+y boundary, with a sheath boundary at the upper y boundary:
+
+.. code-block:: ini
+
+   [hermes]
+   components = d+, sheath_boundary
+
+   [d+]
+   type = noflow_boundary
+
+   noflow_lower_y = true   # This is the default
+   noflow_upper_y = false  # Turn off no-flow at upper y for d+ species
+
+   [sheath_boundary]
+   lower_y = false         # Turn off sheath lower boundary for all species
+   upper_y = true
+
+Note that currently `noflow_boundary` is set per-species, whereas
+`sheath_boundary` is applied to all species. This is because sheath
+boundary conditions couple all charged species together, and doesn't
+affect neutral species.
+
+The implementation is in `NoFlowBoundary`:
+
+.. doxygenstruct:: NoFlowBoundary
+   :members:
+
 Collective quantities
 ---------------------
 

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -39,6 +39,22 @@ evolve_pressure
 Evolves the pressure in time. This pressure is named `P<species>` where `<species>`
 is the short name of the evolving species e.g. `Pe`.
 
+By default parallel thermal conduction is included, which requires a collision
+time. If collisions are not calculated, then thermal conduction should be turned off
+by setting `thermal_conduction = false` in the input options.
+
+Notes:
+
+- Heat conduction through the boundary is turned off currently. This is because
+  heat losses are usually calculated at the sheath, so any additional heat conduction
+  would be in addition to the sheath heat transmission already included.
+
+The implementation is in `EvolvePressure`:
+
+.. doxygenstruct:: EvolvePressure
+   :members:
+
+
 Species parallel dynamics
 -------------------------
 

--- a/examples/1D-sheath-conduction/BOUT.inp
+++ b/examples/1D-sheath-conduction/BOUT.inp
@@ -1,0 +1,97 @@
+# 1D system with:
+#  - no-flow boundary on lower Y
+#  - sheath boundary on upper Y
+#  - Evolving electron and ion species
+#  - heat conduction
+#  - Uniform source of heat and particles throughout domain
+
+nout = 50
+timestep = 5000
+
+MXG = 0  # No guard cells in X
+
+[mesh]
+nx = 1
+ny = 200   # Resolution along field-line
+nz = 1
+
+length = 20           # Length of the domain in meters
+length_xpt = length   # Length from midplane to X-point [m]
+
+dy = length / ny
+
+ypos = y * length / (2*pi) # Y position [m]
+
+ixseps1 = -1
+ixseps2 = -1
+
+[hermes]
+# Evolve ion density, ion and electron pressure, then calculate force on ions due
+# to electron pressure by imposing zero current.
+components = i, e, sheath_boundary, zero_current, collisions
+
+loadmetric = false        # Use Rxy, Bpxy etc?
+normalise_metric = true  # Normalise the input metric?
+
+Nnorm = 1e19
+Bnorm = 1
+Tnorm = 100
+
+[solver]
+mxstep = 10000
+
+[sheath_boundary]
+
+lower_y = false
+upper_y = true
+
+####################################
+
+[i]  # Ions
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+charge = 1
+AA = 1.0
+
+thermal_conduction = true  # in evolve_pressure
+
+diagnose = true
+
+[Ni]
+
+function = 1
+
+flux = 4e23  # Particles per m^2 per second input
+source = (flux/(mesh:length_xpt))*h(mesh:length_xpt - mesh:ypos)
+
+[Pi]
+function = 1
+
+powerflux = 2e7  # Input power flux in W/m^2
+
+source = (powerflux*2/3 / (mesh:length_xpt))*h(mesh:length_xpt - mesh:ypos)  # Input power as function of y
+
+[NVi]
+
+function = 0
+
+####################################
+
+[e] # Electrons
+type = quasineutral, evolve_pressure, noflow_boundary
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+
+thermal_conduction = true  # in evolve_pressure
+
+[Pe]
+
+function = Pi:function  # Same as ion pressure initially
+
+source = Pi:source  # Same as ion pressure source

--- a/examples/1D-sheath-conduction/README.md
+++ b/examples/1D-sheath-conduction/README.md
@@ -1,0 +1,14 @@
+1D flow with sheath boundary and heat conduction
+================================================
+
+Evolves two species, electrons and ions, with separate pressures
+(temperatures) but the same flow (zero current). The 1D system
+has a no-flow boundary on the lower Y boundary, and a sheath on
+the upper Y boundary.
+
+The simulation is driven by a uniform source of heat and particles,
+as sources in the `Ni`, `Pe` and `Pi` equations.
+
+This simulation does include heat conduction, and so also includes
+electron-ion collisions which transfer energy between them, but
+is otherwise the same as the `1D-sheath` example.

--- a/examples/1D-sheath/BOUT.inp
+++ b/examples/1D-sheath/BOUT.inp
@@ -1,0 +1,97 @@
+# 1D system with:
+#  - no-flow boundary on lower Y
+#  - sheath boundary on upper Y
+#  - Evolving electron and ion species
+#  - No heat conduction
+#  - Uniform source of heat and particles throughout domain
+
+nout = 50
+timestep = 5000
+
+MXG = 0  # No guard cells in X
+
+[mesh]
+nx = 1
+ny = 200   # Resolution along field-line
+nz = 1
+
+length = 20           # Length of the domain in meters
+length_xpt = length   # Length from midplane to X-point [m]
+
+dy = length / ny
+
+ypos = y * length / (2*pi) # Y position [m]
+
+ixseps1 = -1
+ixseps2 = -1
+
+[hermes]
+# Evolve ion density, ion and electron pressure, then calculate force on ions due
+# to electron pressure by imposing zero current.
+components = i, e, sheath_boundary, zero_current
+
+loadmetric = false        # Use Rxy, Bpxy etc?
+normalise_metric = true  # Normalise the input metric?
+
+Nnorm = 1e19
+Bnorm = 1
+Tnorm = 100
+
+[solver]
+mxstep = 10000
+
+[sheath_boundary]
+
+lower_y = false
+upper_y = true
+
+####################################
+
+[i]  # Ions
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+charge = 1
+AA = 1.0
+
+thermal_conduction = false  # in evolve_pressure
+
+diagnose = true
+
+[Ni]
+
+function = 1
+
+flux = 4e23  # Particles per m^2 per second input
+source = (flux/(mesh:length_xpt))*h(mesh:length_xpt - mesh:ypos) 
+
+[Pi]
+function = 1 
+
+powerflux = 2e7  # Input power flux in W/m^2
+
+source = (powerflux*2/3 / (mesh:length_xpt))*h(mesh:length_xpt - mesh:ypos)  # Input power as function of y
+
+[NVi]
+
+function = 0
+
+####################################
+
+[e] # Electrons
+type = quasineutral, evolve_pressure, noflow_boundary
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+
+thermal_conduction = false  # in evolve_pressure
+
+[Pe]
+
+function = Pi:function  # Same as ion pressure initially
+
+source = Pi:source  # Same as ion pressure source

--- a/examples/1D-sheath/README.md
+++ b/examples/1D-sheath/README.md
@@ -1,0 +1,12 @@
+1D flow with sheath boundary
+============================
+
+Evolves two species, electrons and ions, with separate pressures
+(temperatures) but the same flow (zero current). The 1D system
+has a no-flow boundary on the lower Y boundary, and a sheath on
+the upper Y boundary.
+
+The simulation is driven by a uniform source of heat and particles,
+as sources in the Ni, Pe and Pi equations.
+
+This simulation doesn't include heat conduction.

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -43,6 +43,7 @@
 #include "include/amjuel_hyd_ionisation.hxx"
 #include "include/amjuel_helium.hxx"
 #include "include/adas_neon.hxx"
+#include "include/noflow_boundary.hxx"
 
 #include "include/loadmetric.hxx"
 

--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -47,7 +47,8 @@ private:
   bool low_n_diffuse_perp;  // Perpendicular diffusion at low density
   bool hyper_z;  // Hyper-diffusion in Z
 
-  Field3D Sn; ///< Density source
+  Field3D source; ///< External input source
+  Field3D Sn; ///< Total density source
 };
 
 namespace {

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -40,6 +40,9 @@ private:
   bool thermal_conduction;
 
   Field3D kappa_par; ///< Parallel heat conduction coefficient
+
+  Field3D source; ///< External pressure source
+  Field3D Sp; ///< Total pressure source
 };
 
 namespace {

--- a/include/noflow_boundary.hxx
+++ b/include/noflow_boundary.hxx
@@ -1,0 +1,40 @@
+#pragma once
+#ifndef NOFLOW_BOUNDARY_H
+#define NOFLOW_BOUNDARY_H
+
+#include "component.hxx"
+
+struct NoFlowBoundary : public Component {
+  NoFlowBoundary(std::string name, Options& alloptions, Solver*) : name(name) {
+    AUTO_TRACE();
+
+    Options& options = alloptions[name];
+    noflow_lower_y = options["noflow_lower_y"]
+                         .doc("No-flow boundary on lower y?")
+                         .withDefault<bool>(true);
+    noflow_upper_y = options["noflow_upper_y"]
+                         .doc("No-flow boundary on upper y?")
+                         .withDefault<bool>(true);
+  }
+
+  /// Inputs
+  ///  - species
+  ///    - <name>
+  ///      - density      [Optional]
+  ///      - temperature  [Optional]
+  ///      - pressure     [Optional]
+  ///      - velocity     [Optional]
+  ///      - momentum     [Optional]
+  void transform(Options& state) override;
+
+private:
+  std::string name;    ///<
+  bool noflow_lower_y; ///< No-flow boundary on lower y?
+  bool noflow_upper_y; ///< No-flow boundary on upper y?
+};
+
+namespace {
+RegisterComponent<NoFlowBoundary> registercomponentnoflowboundary("noflow_boundary");
+}
+
+#endif // NOFLOW_BOUNDARY_H

--- a/include/sheath_boundary.hxx
+++ b/include/sheath_boundary.hxx
@@ -6,12 +6,17 @@
 
 /// Boundary condition at the wall in Y
 ///
+/// This is a collective component, because it couples all charged species
+///
 /// These are based on
 /// "Boundary conditions for the multi-ion magnetized plasma-wall transition"
 ///  by D.Tskhakaya, S.Kuhn. JNM 337-339 (2005), 405-409
 ///
-/// Note: The approximation used here is for ions having similar
-/// gyro-orbit sizes
+/// Notes:
+///   - The approximation used here is for ions having similar
+///     gyro-orbit sizes
+///   - No boundary condition is applied to neutral species
+///
 struct SheathBoundary : public Component {
   SheathBoundary(std::string name, Options &options, Solver *);
 

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -189,6 +189,14 @@ EvolveMomentum::EvolveMomentum(std::string name, Options &alloptions, Solver *so
                        .withDefault<bool>(true);
 
   V.setBoundary(std::string("V") + name);
+
+  if (options["diagnose"]
+          .doc("Output additional diagnostics?")
+          .withDefault<bool>(false)) {
+    bout::globals::dump.addRepeat(V, std::string("V") + name);
+
+    bout::globals::dump.addRepeat(ddt(NV), std::string("ddt(NV") + name + std::string(")"));
+  }
 }
 
 void EvolveMomentum::transform(Options &state) {
@@ -227,7 +235,7 @@ void EvolveMomentum::finally(const Options &state) {
   Field3D N = get<Field3D>(species["density"]);
   
   // Parallel flow
-  Field3D V = get<Field3D>(species["velocity"]);
+  V = get<Field3D>(species["velocity"]);
 
   // Typical wave speed used for numerical diffusion
   Field3D sound_speed;
@@ -238,7 +246,7 @@ void EvolveMomentum::finally(const Options &state) {
     sound_speed = sqrt(T);
   }
   
-  ddt(NV) -= FV::Div_par_fvv(N, V, sound_speed, false);
+  ddt(NV) -= FV::Div_par_fvv(N, V, sound_speed);
 
   // Parallel pressure gradient
   if (species.isSet("pressure")) {

--- a/src/makefile
+++ b/src/makefile
@@ -22,6 +22,7 @@ SOURCEC		= component.cxx component_scheduler.cxx ionisation.cxx radiation.cxx \
                   recycling.cxx \
                   amjuel_hyd_ionisation.cxx \
 		  amjuel_helium.cxx \
-                  adas_reaction.cxx
+                  adas_reaction.cxx \
+                  noflow_boundary.cxx
 
 include $(BOUT_TOP)/make.config

--- a/src/noflow_boundary.cxx
+++ b/src/noflow_boundary.cxx
@@ -1,0 +1,87 @@
+#include "../include/noflow_boundary.hxx"
+
+#include "bout/mesh.hxx"
+using bout::globals::mesh;
+
+namespace {
+Ind3D indexAt(const Field3D& f, int x, int y, int z) {
+  int ny = f.getNy();
+  int nz = f.getNz();
+  return Ind3D{(x * ny + y) * nz + z, ny, nz};
+}
+}
+
+void NoFlowBoundary::transform(Options& state) {
+  AUTO_TRACE();
+
+  // Make sure that the state has been set for this species
+  ASSERT1(state.isSection(name));
+
+  Options& species = state[name];
+
+  // Apply zero-gradient boundary conditions to state variables
+  for (const std::string field : {"density", "temperature", "pressure"}) {
+    if (!species.isSet(field)) {
+      continue; // Skip variables which are not set
+    }
+
+    Field3D var = get<Field3D>(species[field]);
+
+    if (noflow_lower_y) {
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(var, r.ind, mesh->ystart, jz);
+          auto im = i.ym();
+
+          var[im] = var[i];
+        }
+      }
+    }
+
+    if (noflow_upper_y) {
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(var, r.ind, mesh->yend, jz);
+          auto ip = i.yp();
+
+          var[ip] = var[i];
+        }
+      }
+    }
+
+    set<Field3D>(species[field], var);
+  }
+
+  // Apply zero-value boundary conditions to flows
+  for (const std::string field : {"velocity", "momentum"}) {
+    if (!species.isSet(field)) {
+      continue; // Skip variables which are not set
+    }
+
+    Field3D var = get<Field3D>(species[field]);
+
+    if (noflow_lower_y) {
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(var, r.ind, mesh->ystart, jz);
+          auto im = i.ym();
+
+          var[im] = - var[i];
+        }
+      }
+    }
+
+    if (noflow_upper_y) {
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(var, r.ind, mesh->yend, jz);
+          auto ip = i.yp();
+
+          var[ip] = - var[i];
+        }
+      }
+    }
+
+    set<Field3D>(species[field], var);
+  }
+}

--- a/src/noflow_boundary.cxx
+++ b/src/noflow_boundary.cxx
@@ -15,9 +15,9 @@ void NoFlowBoundary::transform(Options& state) {
   AUTO_TRACE();
 
   // Make sure that the state has been set for this species
-  ASSERT1(state.isSection(name));
+  ASSERT1(state["species"].isSection(name));
 
-  Options& species = state[name];
+  Options& species = state["species"][name];
 
   // Apply zero-gradient boundary conditions to state variables
   for (const std::string field : {"density", "temperature", "pressure"}) {
@@ -26,6 +26,7 @@ void NoFlowBoundary::transform(Options& state) {
     }
 
     Field3D var = get<Field3D>(species[field]);
+    var.clearParallelSlices();
 
     if (noflow_lower_y) {
       for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
@@ -59,6 +60,7 @@ void NoFlowBoundary::transform(Options& state) {
     }
 
     Field3D var = get<Field3D>(species[field]);
+    var.clearParallelSlices();
 
     if (noflow_lower_y) {
       for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {

--- a/tests/unit/test_noflow_boundary.cxx
+++ b/tests/unit/test_noflow_boundary.cxx
@@ -27,3 +27,4 @@ TEST_F(NoFlowBoundaryTest, CreateComponent) {
 
   NoFlowBoundary component("test", options, nullptr);
 }
+

--- a/tests/unit/test_noflow_boundary.cxx
+++ b/tests/unit/test_noflow_boundary.cxx
@@ -1,0 +1,29 @@
+
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+
+#include "../../include/noflow_boundary.hxx"
+
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+#include <bout/constants.hxx>
+#include <field_factory.hxx>  // For generating functions
+
+// Reuse the "standard" fixture for FakeMesh
+using NoFlowBoundaryTest = FakeMeshFixture;
+
+TEST_F(NoFlowBoundaryTest, CreateComponent) {
+  Options options;
+
+  NoFlowBoundary component("test", options, nullptr);
+}


### PR DESCRIPTION
Adding no-flow boundary condition so that simulations like SD1D can be run, with an upstream source and downstream sheath boundary.