### PR TITLE
Changes to pressure evolution and sheath boundary

### DIFF
--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -7,7 +7,7 @@
 #include "component.hxx"
 
 struct EvolvePressure : public Component {
-  EvolvePressure(std::string name, Options &options, Solver *solver);
+  EvolvePressure(std::string name, Options& options, Solver* solver);
 
   /// Inputs
   /// - species
@@ -20,7 +20,7 @@ struct EvolvePressure : public Component {
   ///     - pressure
   ///     - temperature   Requires density
   ///
-  void transform(Options &state) override;
+  void transform(Options& state) override;
 
   ///
   /// Optional inputs
@@ -32,13 +32,14 @@ struct EvolvePressure : public Component {
   ///     - collision_rate  (needed if thermal_conduction on)
   /// - fields
   ///   - phi      Electrostatic potential -> ExB drift
-  /// 
-  void finally(const Options &state) override;
+  ///
+  void finally(const Options& state) override;
+
 private:
   std::string name; ///< Short name of the species e.g. h+
 
-  Field3D P;     ///< Pressure (normalised) 
-  Field3D T, N;  ///< Temperature, density
+  Field3D P;    ///< Pressure (normalised)
+  Field3D T, N; ///< Temperature, density
 
   bool bndry_flux;
   bool poloidal_flows;
@@ -48,7 +49,7 @@ private:
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 
   Field3D source; ///< External pressure source
-  Field3D Sp; ///< Total pressure source
+  Field3D Sp;     ///< Total pressure source
 };
 
 namespace {
@@ -56,4 +57,3 @@ RegisterComponent<EvolvePressure> registercomponentevolvepressure("evolve_pressu
 }
 
 #endif // EVOLVE_PRESSURE_H
-

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -43,6 +43,7 @@ private:
   bool bndry_flux;
   bool poloidal_flows;
   bool thermal_conduction;
+  bool p_div_v; ///< Use p*Div(v) form? False -> v * Grad(p)
 
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -121,6 +121,9 @@ void EvolvePressure::finally(const Options& state) {
 
     } else {
       // Use V * Grad(P) form
+      // Note: A mixed form has been tried (on 1D neon example)
+      //       -(4/3)*FV::Div_par(P,V) + (1/3)*(V * Grad_par(P) - P * Div_par(V))
+      //       Caused heating of charged species near sheath like p_div_v
       ddt(P) -= (5. / 3) * FV::Div_par(P, V, sound_speed);
 
       ddt(P) += (2. / 3) * V * Grad_par(P);

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -77,7 +77,8 @@ void EvolvePressure::transform(Options &state) {
   // Calculate temperature
   N = get<Field3D>(species["density"]);
   T = P / floor(N, 1e-5);
-  T.applyBoundary();
+  T.applyBoundary("neumann");
+
   set(species["temperature"], T);
 }
 

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -476,6 +476,9 @@ void SheathBoundary::transform(Options &state) {
           BoutReal q =
               ((gamma_i - 1 - 1 / (adiabatic - 1)) * tisheath - 0.5 * Mi * C_i_sq)
               * nisheath * visheath;
+          if (q > 0.0) {
+            q = 0.0;
+          }
 
           // Multiply by cell area to get power
           BoutReal flux = q * (coord->J[i] + coord->J[im])
@@ -483,6 +486,7 @@ void SheathBoundary::transform(Options &state) {
 
           // Divide by volume of cell to get energy loss rate (< 0)
           BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+          ASSERT2(power <= 0.0);
 
           energy_source[i] += power;
         }
@@ -540,10 +544,14 @@ void SheathBoundary::transform(Options &state) {
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
-          // Note: Here this is negative because visheath < 0
+          // Note: Here this is positive because visheath > 0
           BoutReal q =
               ((gamma_i - 1 - 1 / (adiabatic - 1)) * tisheath - 0.5 * C_i_sq * Mi)
               * nisheath * visheath;
+
+          if (q < 0.0) {
+            q = 0.0;
+          }
 
           // Multiply by cell area to get power
           BoutReal flux = q * (coord->J[i] + coord->J[ip])
@@ -551,6 +559,8 @@ void SheathBoundary::transform(Options &state) {
 
           // Divide by volume of cell to get energy loss rate (> 0)
           BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+          ASSERT2(std::isfinite(power));
+          ASSERT2(power >= 0.0);
 
           energy_source[i] -= power; // Note: Sign negative because power > 0
         }

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -435,8 +435,8 @@ void SheathBoundary::transform(Options &state) {
           // Calculate sheath values at half-way points (cell edge)
           const BoutReal nesheath = 0.5 * (Ne[im] + Ne[i]);
           const BoutReal nisheath = 0.5 * (Ni[im] + Ni[i]);
-          const BoutReal tesheath = 0.5 * (Te[im] + Te[i]);  // electron temperature
-          const BoutReal tisheath = 0.5 * (Ti[im] + Ti[i]);  // ion temperature
+          const BoutReal tesheath = floor(0.5 * (Te[im] + Te[i]), 1e-5);  // electron temperature
+          const BoutReal tisheath = floor(0.5 * (Ti[im] + Ti[i]), 1e-5);  // ion temperature
 
           // Ion sheath heat transmission coefficient
           // Equation (22) in Tskhakaya 2005
@@ -509,8 +509,8 @@ void SheathBoundary::transform(Options &state) {
           // Calculate sheath values at half-way points (cell edge)
           const BoutReal nesheath = 0.5 * (Ne[ip] + Ne[i]);
           const BoutReal nisheath = 0.5 * (Ni[ip] + Ni[i]);
-          const BoutReal tesheath = 0.5 * (Te[ip] + Te[i]);  // electron temperature
-          const BoutReal tisheath = 0.5 * (Ti[ip] + Ti[i]);  // ion temperature
+          const BoutReal tesheath = floor(0.5 * (Te[ip] + Te[i]), 1e-5);  // electron temperature
+          const BoutReal tisheath = floor(0.5 * (Ti[ip] + Ti[i]), 1e-5);  // ion temperature
 
           // Ion sheath heat transmission coefficient
           //


### PR DESCRIPTION
- Changes to sheath boundary to make it more robust to low densities and temperatures, and limit gradients
- Change pressure equation formulation, to use v * Grad(p) rather than p * Div(v). This seems to help reduce spurious heating of charged ions near the sheath.
