### PR TITLE
Catch set/modify after get errors

### DIFF
--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -45,7 +45,7 @@ ixseps2 = -1
 #  - electrons after other species, so the density can be set by quasineutrality
 #  - zero_current after thermal force, so the electric field includes the force on the electrons
 components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, e,
-              thermal_force, zero_current, sheath_boundary, collisions, recycling, reactions,
+              zero_current, sheath_boundary, thermal_force, collisions, recycling, reactions,
               neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?

--- a/src/adas_reaction.cxx
+++ b/src/adas_reaction.cxx
@@ -118,12 +118,12 @@ BoutReal OpenADASRateCoefficient::evaluate(BoutReal T, BoutReal n) {
 void OpenADAS::calculate_rates(Options& electron, Options& from_ion, Options& to_ion) {
   AUTO_TRACE();
 
-  Field3D Ne = get<Field3D>(electron["density"]);
-  Field3D Te = get<Field3D>(electron["temperature"]);
+  Field3D Ne = GET_VALUE(Field3D, electron["density"]);
+  Field3D Te = GET_VALUE(Field3D, electron["temperature"]);
 
-  Field3D N1 = get<Field3D>(from_ion["density"]);
-  Field3D T1 = get<Field3D>(from_ion["temperature"]);
-  Field3D V1 = get<Field3D>(from_ion["velocity"]);
+  Field3D N1 = GET_VALUE(Field3D, from_ion["density"]);
+  Field3D T1 = GET_VALUE(Field3D, from_ion["temperature"]);
+  Field3D V1 = GET_VALUE(Field3D, from_ion["velocity"]);
   auto AA = get<BoutReal>(from_ion["AA"]);
 
   ASSERT1(AA == get<BoutReal>(to_ion["AA"]));
@@ -176,11 +176,11 @@ void OpenADASChargeExchange::calculate_rates(Options& electron, Options& from_A,
 
   // Note: Using electron temperature and density,
   // because ADAS website states that all rates are a function of Te
-  const Field3D Te = get<Field3D>(electron["temperature"]);
-  const Field3D Ne = get<Field3D>(electron["density"]);
+  const Field3D Te = GET_VALUE(Field3D, electron["temperature"]);
+  const Field3D Ne = GET_VALUE(Field3D, electron["density"]);
 
-  const Field3D Na = get<Field3D>(from_A["density"]);
-  const Field3D Nb = get<Field3D>(from_B["density"]);
+  const Field3D Na = GET_VALUE(Field3D, from_A["density"]);
+  const Field3D Nb = GET_VALUE(Field3D, from_B["density"]);
 
   const Field3D reaction_rate = cellAverage(
       [&](BoutReal na, BoutReal nb, BoutReal ne, BoutReal te) {
@@ -203,7 +203,7 @@ void OpenADASChargeExchange::calculate_rates(Options& electron, Options& from_A,
 
     // Energy
     const Field3D energy_exchange =
-        reaction_rate * (3. / 2) * get<Field3D>(from_A["temperature"]);
+      reaction_rate * (3. / 2) * GET_VALUE(Field3D, from_A["temperature"]);
     subtract(from_A["energy_source"], energy_exchange);
     add(to_A["energy_source"], energy_exchange);
   }
@@ -215,14 +215,14 @@ void OpenADASChargeExchange::calculate_rates(Options& electron, Options& from_A,
 
     // Momentum
     const Field3D momentum_exchange =
-        reaction_rate * get<BoutReal>(from_B["AA"]) * get<Field3D>(from_B["velocity"]);
+      reaction_rate * get<BoutReal>(from_B["AA"]) * GET_VALUE(Field3D, from_B["velocity"]);
 
     subtract(from_B["momentum_source"], momentum_exchange);
     add(to_B["momentum_source"], momentum_exchange);
 
     // Energy
     const Field3D energy_exchange =
-        reaction_rate * (3. / 2) * get<Field3D>(from_B["temperature"]);
+      reaction_rate * (3. / 2) * GET_VALUE(Field3D, from_B["temperature"]);
     subtract(from_B["energy_source"], energy_exchange);
     add(to_B["energy_source"], energy_exchange);
   }

--- a/src/diamagnetic_drift.cxx
+++ b/src/diamagnetic_drift.cxx
@@ -4,14 +4,14 @@
 
 using bout::globals::mesh;
 
-DiamagneticDrift::DiamagneticDrift(std::string name, Options &alloptions, Solver *UNUSED(solver)) {
+DiamagneticDrift::DiamagneticDrift(std::string name, Options& alloptions,
+                                   Solver* UNUSED(solver)) {
 
   // Get options for this component
   auto& options = alloptions[name];
-  
-  bndry_flux = options["bndry_flux"]
-                   .doc("Allow fluxes through boundary?")
-                   .withDefault<bool>(true);
+
+  bndry_flux =
+      options["bndry_flux"].doc("Allow fluxes through boundary?").withDefault<bool>(true);
 
   // Read curvature vector
   Curlb_B.covariant = false; // Contravariant
@@ -19,12 +19,12 @@ DiamagneticDrift::DiamagneticDrift(std::string name, Options &alloptions, Solver
     Curlb_B.x = Curlb_B.y = Curlb_B.z = 0.0;
   }
 
-  if (Options::root()["mesh"]["paralleltransform"].withDefault<std::string>(
-          "none") == "shifted") {
+  if (Options::root()["mesh"]["paralleltransform"].withDefault<std::string>("none")
+      == "shifted") {
     Field2D I;
     if (mesh->get(I, "sinty"))
       I = 0.0;
-    
+
     Curlb_B.z += I * Curlb_B.x;
   }
 
@@ -34,7 +34,7 @@ DiamagneticDrift::DiamagneticDrift(std::string name, Options &alloptions, Solver
   const auto& units = alloptions["units"];
   BoutReal Bnorm = get<BoutReal>(units["Tesla"]);
   BoutReal Lnorm = get<BoutReal>(units["meters"]);
-  
+
   Curlb_B.x /= Bnorm;
   Curlb_B.y *= SQ(Lnorm);
   Curlb_B.z *= SQ(Lnorm);
@@ -42,10 +42,10 @@ DiamagneticDrift::DiamagneticDrift(std::string name, Options &alloptions, Solver
   Curlb_B *= 2. / mesh->getCoordinates()->Bxy;
 }
 
-void DiamagneticDrift::transform(Options &state) {
+void DiamagneticDrift::transform(Options& state) {
   // Iterate through all subsections
   Options& allspecies = state["species"];
-    
+
   for (auto& kv : allspecies.getChildren()) {
     Options& species = allspecies[kv.first]; // Note: Need non-const
 
@@ -54,28 +54,25 @@ void DiamagneticDrift::transform(Options &state) {
 
     // Calculate diamagnetic drift velocity for this species
     auto q = get<BoutReal>(species["charge"]);
-    auto T = get<Field3D>(species["temperature"]);
+    auto T = GET_VALUE(Field3D, species["temperature"]);
 
     // Diamagnetic drift velocity
     Vector3D vD = (T / q) * Curlb_B;
 
     if (species.isSet("density")) {
-      auto N = get<Field3D>(species["density"]);
-      
-      subtract(species["density_source"],
-          FV::Div_f_v(N, vD, bndry_flux));
+      auto N = GET_VALUE(Field3D, species["density"]);
+
+      subtract(species["density_source"], FV::Div_f_v(N, vD, bndry_flux));
     }
 
     if (species.isSet("pressure")) {
       auto P = get<Field3D>(species["pressure"]);
-      subtract(species["energy_source"],
-               (5. / 2) * FV::Div_f_v(P, vD, bndry_flux));
+      subtract(species["energy_source"], (5. / 2) * FV::Div_f_v(P, vD, bndry_flux));
     }
 
     if (species.isSet("momentum")) {
       auto NV = get<Field3D>(species["momentum"]);
-      subtract(species["momentum_source"],
-               FV::Div_f_v(NV, vD, bndry_flux));
+      subtract(species["momentum_source"], FV::Div_f_v(NV, vD, bndry_flux));
     }
   }
 }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -207,7 +207,8 @@ void EvolveMomentum::transform(Options &state) {
 
   set(species["momentum"], NV);
 
-  Field3D N = floor(getNonFinal<Field3D>(species["density"]), 1e-5);
+  // Not using density boundary condition
+  Field3D N = floor(getNoBoundary<Field3D>(species["density"]), 1e-5);
   BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
   V = NV / (AA * N);

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -207,7 +207,7 @@ void EvolveMomentum::transform(Options &state) {
 
   set(species["momentum"], NV);
 
-  Field3D N = floor(get<Field3D>(species["density"]), 1e-5);
+  Field3D N = floor(getNonFinal<Field3D>(species["density"]), 1e-5);
   BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
   V = NV / (AA * N);

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -77,7 +77,7 @@ void EvolvePressure::transform(Options& state) {
   set(species["pressure"], P);
 
   // Calculate temperature
-  N = get<Field3D>(species["density"]);
+  N = getNonFinal<Field3D>(species["density"]);
   T = P / floor(N, 1e-5);
   T.applyBoundary("neumann");
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -77,7 +77,8 @@ void EvolvePressure::transform(Options& state) {
   set(species["pressure"], P);
 
   // Calculate temperature
-  N = getNonFinal<Field3D>(species["density"]);
+  // Not using density boundary condition
+  N = getNoBoundary<Field3D>(species["density"]);
   T = P / floor(N, 1e-5);
   T.applyBoundary("neumann");
 

--- a/src/noflow_boundary.cxx
+++ b/src/noflow_boundary.cxx
@@ -25,8 +25,8 @@ void NoFlowBoundary::transform(Options& state) {
       continue; // Skip variables which are not set
     }
 
-    // Note: Value not final because we're going to set it
-    Field3D var = getNonFinal<Field3D>(species[field]);
+    // Note: Not assuming boundary is set because we're going to set it
+    Field3D var = GET_NOBOUNDARY(Field3D, species[field]);
     var.clearParallelSlices();
 
     if (noflow_lower_y) {
@@ -51,7 +51,8 @@ void NoFlowBoundary::transform(Options& state) {
       }
     }
 
-    set<Field3D>(species[field], var);
+    // Promise that we're only modifying the boundary
+    setBoundary<Field3D>(species[field], var);
   }
 
   // Apply zero-value boundary conditions to flows
@@ -60,7 +61,7 @@ void NoFlowBoundary::transform(Options& state) {
       continue; // Skip variables which are not set
     }
 
-    Field3D var = getNonFinal<Field3D>(species[field]);
+    Field3D var = GET_NOBOUNDARY(Field3D, species[field]);
     var.clearParallelSlices();
 
     if (noflow_lower_y) {
@@ -85,6 +86,7 @@ void NoFlowBoundary::transform(Options& state) {
       }
     }
 
-    set<Field3D>(species[field], var);
+    // Promise that we're only modifying the boundary
+    setBoundary<Field3D>(species[field], var);
   }
 }

--- a/src/noflow_boundary.cxx
+++ b/src/noflow_boundary.cxx
@@ -25,7 +25,8 @@ void NoFlowBoundary::transform(Options& state) {
       continue; // Skip variables which are not set
     }
 
-    Field3D var = get<Field3D>(species[field]);
+    // Note: Value not final because we're going to set it
+    Field3D var = getNonFinal<Field3D>(species[field]);
     var.clearParallelSlices();
 
     if (noflow_lower_y) {
@@ -59,7 +60,7 @@ void NoFlowBoundary::transform(Options& state) {
       continue; // Skip variables which are not set
     }
 
-    Field3D var = get<Field3D>(species[field]);
+    Field3D var = getNonFinal<Field3D>(species[field]);
     var.clearParallelSlices();
 
     if (noflow_lower_y) {

--- a/src/quasineutral.cxx
+++ b/src/quasineutral.cxx
@@ -30,12 +30,13 @@ void Quasineutral::transform(Options &state) {
       // Start with no charge
       Field3D(0.0),
       [this](Field3D value,
-         const std::map<std::string, Options>::value_type &name_species) {
+             const std::map<std::string, Options>::value_type &name_species) {
         const Options &species = name_species.second;
         // Add other species which have density and charge
         if (name_species.first != name and species.isSet("charge") and
             species.isSet("density")) {
-          return value + get<Field3D>(species["density"]) *
+          // Note: Not assuming that the boundary has been set
+          return value + getNoBoundary<Field3D>(species["density"]) *
                              get<BoutReal>(species["charge"]);
         }
         return value;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -58,7 +58,7 @@ void Recycling::transform(Options& state) {
     Options& species_to = state["species"][channel.to];
     // Get the sources, so the values can be added
     Field3D density_source = species_to.isSet("density_source")
-                                 ? get<Field3D>(species_to["density_source"])
+                                 ? getNonFinal<Field3D>(species_to["density_source"])
                                  : 0.0;
 
     // Lower Y boundary

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -82,13 +82,13 @@ void SheathBoundary::transform(Options &state) {
 
   Options& allspecies = state["species"];
   Options& electrons = allspecies["e"];
-  
+
   // Need electron properties
   // Not const because boundary conditions will be set
-  Field3D Ne = get<Field3D>(electrons["density"]);
-  Field3D Te = get<Field3D>(electrons["temperature"]);
+  Field3D Ne = getNonFinal<Field3D>(electrons["density"]);
+  Field3D Te = getNonFinal<Field3D>(electrons["temperature"]);
   Field3D Pe =
-      electrons.isSet("pressure") ? get<Field3D>(electrons["pressure"]) : Te * Ne;
+      electrons.isSet("pressure") ? getNonFinal<Field3D>(electrons["pressure"]) : Te * Ne;
 
   // Ratio of specific heats
   const BoutReal electron_adiabatic =
@@ -99,17 +99,17 @@ void SheathBoundary::transform(Options &state) {
       electrons.isSet("AA") ? get<BoutReal>(electrons["AA"]) : SI::Me / SI::Mp;
 
   // This is for applying boundary conditions
-  Field3D Ve = electrons.isSet("velocity") ? get<Field3D>(electrons["velocity"]) : 0.0;
-  
+  Field3D Ve = electrons.isSet("velocity") ? getNonFinal<Field3D>(electrons["velocity"]) : 0.0;
+
   Coordinates *coord = mesh->getCoordinates();
-  
+
   //////////////////////////////////////////////////////////////////
   // Electrostatic potential
   // If phi is set, use free boundary condition
   // If phi not set, calculate assuming zero current
   Field3D phi;
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
-    phi = get<Field3D>(state["fields"]["phi"]);
+    phi = getNonFinal<Field3D>(state["fields"]["phi"]);
   } else {
     // Calculate potential phi assuming zero current
     // Note: This is equation (22) in Tskhakaya 2005, with I = 0
@@ -129,10 +129,10 @@ void SheathBoundary::transform(Options &state) {
         continue; // Skip electrons and non-charged ions
       }
       
-      const Field3D Ni = get<Field3D>(species["density"]);
-      const Field3D Ti = get<Field3D>(species["temperature"]);
-      const BoutReal Mi = get<BoutReal>(species["AA"]);
-      const BoutReal Zi = get<BoutReal>(species["charge"]);
+      const Field3D Ni = getNonFinal<Field3D>(species["density"]);
+      const Field3D Ti = getNonFinal<Field3D>(species["temperature"]);
+      const BoutReal Mi = getNonFinal<BoutReal>(species["AA"]);
+      const BoutReal Zi = getNonFinal<BoutReal>(species["charge"]);
 
       const BoutReal adiabatic = species.isSet("adiabatic")
                                      ? get<BoutReal>(species["adiabatic"])
@@ -258,7 +258,7 @@ void SheathBoundary::transform(Options &state) {
   // Electrons
 
   Field3D electron_energy_source =
-      electrons.isSet("energy_source") ? get<Field3D>(electrons["energy_source"]) : 0.0;
+      electrons.isSet("energy_source") ? getNonFinal<Field3D>(electrons["energy_source"]) : 0.0;
 
   if (lower_y) {
     for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
@@ -403,19 +403,19 @@ void SheathBoundary::transform(Options &state) {
                                      : 5. / 3; // Ratio of specific heats (ideal gas)
 
     // Density and temperature boundary conditions will be imposed (free)
-    Field3D Ni = get<Field3D>(species["density"]);
-    Field3D Ti = get<Field3D>(species["temperature"]);
-    Field3D Pi = species.isSet("pressure") ? get<Field3D>(species["pressure"]) : Ni * Ti;
+    Field3D Ni = getNonFinal<Field3D>(species["density"]);
+    Field3D Ti = getNonFinal<Field3D>(species["temperature"]);
+    Field3D Pi = species.isSet("pressure") ? getNonFinal<Field3D>(species["pressure"]) : Ni * Ti;
 
     // Get the velocity and momentum
     // These will be modified at the boundaries
     // and then put back into the state
-    Field3D Vi = species.isSet("velocity") ? get<Field3D>(species["velocity"]) : 0.0;
-    Field3D NVi = species.isSet("momentum") ? get<Field3D>(species["momentum"]) : Mi * Ni * Vi;
+    Field3D Vi = species.isSet("velocity") ? getNonFinal<Field3D>(species["velocity"]) : 0.0;
+    Field3D NVi = species.isSet("momentum") ? getNonFinal<Field3D>(species["momentum"]) : Mi * Ni * Vi;
 
     // Energy source will be modified
     Field3D energy_source =
-        species.isSet("energy_source") ? get<Field3D>(species["energy_source"]) : 0.0;
+        species.isSet("energy_source") ? getNonFinal<Field3D>(species["energy_source"]) : 0.0;
 
     if (lower_y) {
       for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {

--- a/src/thermal_force.cxx
+++ b/src/thermal_force.cxx
@@ -12,7 +12,8 @@ void ThermalForce::transform(Options& state) {
     // Electron-ion collisions
 
     Options& electrons = allspecies["e"];
-    const Field3D Te = get<Field3D>(electrons["temperature"]);
+    // Need Te boundary to take gradient
+    const Field3D Te = GET_VALUE(Field3D, electrons["temperature"]);
     const Field3D Grad_Te = Grad_par(Te);
 
     for (auto& kv : allspecies.getChildren()) {
@@ -26,7 +27,8 @@ void ThermalForce::transform(Options& state) {
       }
 
       const BoutReal Z = get<BoutReal>(species["charge"]);
-      const Field3D nz = get<Field3D>(species["density"]);
+      // Don't need density boundary
+      const Field3D nz = GET_NOBOUNDARY(Field3D, species["density"]);
 
       Field3D ion_force = nz * (0.71 * SQ(Z)) * Grad_Te;
 
@@ -95,11 +97,11 @@ void ThermalForce::transform(Options& state) {
         // This follows Stangeby, page 298 and following
 
         const BoutReal mi = get<BoutReal>((*light)["AA"]);
-        const Field3D Ti = get<Field3D>((*light)["temperature"]);
+        const Field3D Ti = GET_VALUE(Field3D, (*light)["temperature"]);
 
         const BoutReal mz = get<BoutReal>((*heavy)["AA"]);
         const BoutReal Z = get<BoutReal>((*heavy)["charge"]);
-        const Field3D nz = get<Field3D>((*heavy)["density"]);
+        const Field3D nz = GET_NOBOUNDARY(Field3D, (*heavy)["density"]);
 
         if (Z == 0.0) {
           continue; // Check that the charge is not zero

--- a/src/upstream_density_feedback.cxx
+++ b/src/upstream_density_feedback.cxx
@@ -6,7 +6,8 @@ using bout::globals::mesh;
 void UpstreamDensityFeedback::transform(Options& state) {
   Options& species = state["species"][name];
 
-  Field3D N = get<Field3D>(species["density"]);
+  // Doesn't need all boundaries to be set
+  Field3D N = getNoBoundary<Field3D>(species["density"]);
 
   auto time = get<BoutReal>(state["time"]);
   

--- a/src/zero_current.cxx
+++ b/src/zero_current.cxx
@@ -7,9 +7,13 @@ void ZeroCurrent::transform(Options &state) {
   AUTO_TRACE();
 
   // Get the electron pressure
+  // Note: The pressure boundary can be set in sheath boundary condition
+  //       which depends on the electron velocity being set here first.
   Options& electrons = state["species"]["e"];
-  Field3D Pe = get<Field3D>(electrons["pressure"]);
-  Field3D Ne = get<Field3D>(electrons["density"]);
+  Field3D Pe = getNoBoundary<Field3D>(electrons["pressure"]);
+  Pe.applyBoundary("neumann");
+
+  Field3D Ne = getNoBoundary<Field3D>(electrons["density"]);
 
   ASSERT1(get<BoutReal>(electrons["charge"]) == -1.0);
 
@@ -37,7 +41,7 @@ void ZeroCurrent::transform(Options &state) {
       continue; // Needs both density and charge to experience a force
     }
     
-    const Field3D N = get<Field3D>(species["density"]);
+    const Field3D N = getNoBoundary<Field3D>(species["density"]);
     const BoutReal charge = get<BoutReal>(species["charge"]);
 
     add(species["momentum_source"],
@@ -46,7 +50,7 @@ void ZeroCurrent::transform(Options &state) {
     if (species.isSet("velocity")) {
       // If velocity is set, update the ion current
       
-      const Field3D V = get<Field3D>(species["velocity"]);
+      const Field3D V = getNoBoundary<Field3D>(species["velocity"]);
       
       if (!ion_current.isAllocated()) {
         // Not yet allocated -> Set to the value

--- a/tests/unit/test_component.cxx
+++ b/tests/unit/test_component.cxx
@@ -54,3 +54,57 @@ TEST(ComponentTest, GetThrowsIncompatibleValue) {
   ASSERT_THROW(get<int>(option), BoutException);
 }
 
+TEST(ComponentTest, SetInteger) {
+  Options option;
+
+  set<int>(option, 3);
+
+  ASSERT_EQ(getNonFinal<int>(option), 3);
+}
+
+TEST(ComponentTest, SetAfterGetThrows) {
+  Options option;
+
+  option = 42;
+
+  ASSERT_EQ(get<int>(option), 42);
+
+  // Setting after get should fail
+  ASSERT_THROW(set<int>(option, 3), BoutException);
+}
+
+TEST(ComponentTest, SetAfterGetNonFinal) {
+  Options option;
+
+  option = 42;
+
+  ASSERT_EQ(getNonFinal<int>(option), 42);
+
+  set<int>(option, 3); // Doesn't throw
+
+  ASSERT_EQ(getNonFinal<int>(option), 3);
+}
+
+TEST(ComponentTest, SetBoundaryAfterGetThrows) {
+  Options option;
+
+  option = 42;
+
+  ASSERT_EQ(get<int>(option), 42);
+
+  // Setting after get should fail because get indicates an assumption
+  // that all values are final including boundary cells.
+  ASSERT_THROW(setBoundary<int>(option, 3), BoutException);
+}
+
+TEST(ComponentTest, SetBoundaryAfterGetNoBoundary) {
+  Options option;
+
+  option = 42;
+
+  ASSERT_EQ(getNoBoundary<int>(option), 42);
+
+  setBoundary<int>(option, 3); // ok because boundary not assumed final
+
+  ASSERT_EQ(getNonFinal<int>(option), 3);
+}

--- a/tests/unit/test_component_scheduler.cxx
+++ b/tests/unit/test_component_scheduler.cxx
@@ -14,8 +14,9 @@ struct TestMultiply : public Component {
   
   void transform(Options &state) {
     // Note: Using set<>() and get<>() for quicker access, avoiding printing
+    //       getNonFinal needs to be used because we set the value afterwards
     set(state["answer"],
-        get<int>(state["answer"]) * 2);
+        getNonFinal<int>(state["answer"]) * 2);
   }
 };
 


### PR DESCRIPTION
If a value is modified after it has already been used, an exception will now be raised.
Requires some more variations on `get` and `set`, to indicate the assumptions being made about the values in the domain and boundary.