### PR TITLE
Add evolve_log option

### DIFF
--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -40,12 +40,15 @@ private:
   
   Field3D N;            ///< Species density (normalised, evolving)
 
-  bool bndry_flux;      // Allow flows through boundaries?
-  bool poloidal_flows;  // Include ExB flow in Y direction?
+  bool bndry_flux;      ///< Allow flows through boundaries?
+  bool poloidal_flows;  ///< Include ExB flow in Y direction?
 
-  bool low_n_diffuse;   // Parallel diffusion at low density
-  bool low_n_diffuse_perp;  // Perpendicular diffusion at low density
-  bool hyper_z;  // Hyper-diffusion in Z
+  bool low_n_diffuse;   ///< Parallel diffusion at low density
+  bool low_n_diffuse_perp;  ///< Perpendicular diffusion at low density
+  bool hyper_z;    ///< Hyper-diffusion in Z
+
+  bool evolve_log; ///< Evolve logarithm of density?
+  Field3D logN;    ///< Logarithm of density (if evolving)
 
   Field3D source; ///< External input source
   Field3D Sn; ///< Total density source

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -46,6 +46,9 @@ private:
   bool thermal_conduction;
   bool p_div_v; ///< Use p*Div(v) form? False -> v * Grad(p)
 
+  bool evolve_log; ///< Evolve logarithm of P?
+  Field3D logP;    ///< Natural logarithm of P
+
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 
   Field3D source; ///< External pressure source

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -70,7 +70,11 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
     const Field3D density1 = GET_NOBOUNDARY(Field3D, species1["density"]);
     const Field3D density2 = GET_NOBOUNDARY(Field3D, species2["density"]);
 
-    add(species2["collision_frequency"], nu_12 * (A1 / A2) * density1 / density2);
+    const Field3D nu = filledFrom(nu_12, [&](auto& i) {
+      return nu_12[i] * (A1 / A2) * density1[i] / floor(density2[i], 1e-5);
+    });
+
+    add(species2["collision_frequency"], nu);
 
     // Momentum exchange
     if (species1.isSet("velocity") or species2.isSet("velocity")) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -38,6 +38,9 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
       // Set logN from N input options
       initial_profile(std::string("P") + name, P);
       logP = log(P);
+    } else {
+      // Ignore these settings
+      Options::root()[std::string("P") + name].setConditionallyUsed();
     }
   } else {
     // Evolve the density in time

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -2,6 +2,7 @@
 #include <bout/constants.hxx>
 #include <bout/fv_ops.hxx>
 #include <difops.hxx>
+#include <initialprofiles.hxx>
 
 #include "../include/div_ops.hxx"
 #include "../include/evolve_pressure.hxx"
@@ -20,9 +21,28 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
     : name(name) {
   AUTO_TRACE();
 
-  solver->add(P, std::string("P") + name);
-
   auto& options = alloptions[name];
+
+  evolve_log = options["evolve_log"].doc("Evolve the logarithmof pressure?").withDefault<bool>(false);
+
+  if (evolve_log) {
+    // Evolve logarithm of density
+    solver->add(logP, std::string("logP") + name);
+    // Save the density to the restart file
+    // so the simulation can be restarted evolving density
+    get_restart_datafile()->addOnce(P, std::string("P") + name);
+    // Save density to output files
+    bout::globals::dump.addRepeat(P, std::string("P") + name);
+
+    if (!alloptions["hermes"]["restarting"]) {
+      // Set logN from N input options
+      initial_profile(std::string("P") + name, P);
+      logP = log(P);
+    }
+  } else {
+    // Evolve the density in time
+    solver->add(P, std::string("P") + name);
+  }
 
   bndry_flux = options["bndry_flux"]
                    .doc("Allow flows through radial boundaries")
@@ -67,12 +87,17 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
 void EvolvePressure::transform(Options& state) {
   AUTO_TRACE();
 
+  if (evolve_log) {
+    // Evolving logP, but most calculations use P
+    P = exp(logP);
+  } else {
+    // Check for low pressures, ensure that Pi >= 0
+    P = floor(P, 0.0);
+  }
+
   mesh->communicate(P);
 
   auto& species = state["species"][name];
-
-  // Check for low pressures, ensure that Pi >= 0
-  P = floor(P, 0.0);
 
   set(species["pressure"], P);
 
@@ -177,4 +202,8 @@ void EvolvePressure::finally(const Options& state) {
 #if CHECK > 1
   bout::checkFinite(ddt(P), std::string("ddt P") + name, "RGN_NOBNDRY");
 #endif
+
+  if (evolve_log) {
+    ddt(logP) = ddt(P) / P;
+  }
 }

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -294,8 +294,9 @@ void SheathBoundary::transform(Options &state) {
         const BoutReal gamma_e = 2 / (1. - Ge) + phisheath / tesheath;
 
         // Electron velocity into sheath (< 0)
-        const BoutReal vesheath =
-            -sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
+        const BoutReal vesheath = (tesheath < 1e-10) ?
+          0.0 :
+          -sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
 
         Ve[im] = 2 * vesheath - Ve[i];
 
@@ -346,8 +347,9 @@ void SheathBoundary::transform(Options &state) {
         const BoutReal gamma_e = 2 / (1. - Ge) + phisheath / tesheath;
 
         // Electron velocity into sheath (> 0)
-        const BoutReal vesheath =
-            sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
+        const BoutReal vesheath = (tesheath < 1e-10) ?
+          0.0 :
+          sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
 
         Ve[ip] = 2 * vesheath - Ve[i];
 


### PR DESCRIPTION
Density and pressure equations can evolve logN and logP, exponentiating each iteration to get the density and pressure.

This may allow more accurate calculation of low-density regions, and prevent negative values in a better way than imposing floors.