### PR TITLE
Split zero current component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(HERMES_SOURCES
     src/loadmetric.cxx
     src/neutral_mixed.cxx
     src/full_velocity.cxx
+    src/electron_force_balance.cxx
     src/evolve_density.cxx
     src/vorticity.cxx
     src/evolve_pressure.cxx
@@ -80,6 +81,7 @@ set(HERMES_SOURCES
     include/component_scheduler.hxx
     include/diamagnetic_drift.hxx
     include/div_ops.hxx
+    include/electron_force_balance.hxx
     include/evolve_density.hxx
     include/evolve_momentum.hxx
     include/evolve_pressure.hxx

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -129,8 +129,26 @@ mass number, so should be divided by `AA` to obtain the particle flux.
 zero_current
 ~~~~~~~~~~~~
 
-This imposes a zero-current Ohm's law, calculating a parallel
-electric field which balances the electron pressure gradient and other forces:
+This calculates the parallel flow of one charged species so that there is no net current,
+using flows already calculated for other species. It is used like `quasineutral`:
+
+.. code-block:: ini
+
+   [hermes]
+   components = h+, ..., e, ...   # Note: e after all other species
+   
+   [e]
+   type = ..., zero_current,... # Set e:velocity
+
+   charge = -1 # Species must have a charge
+
+
+electron_force_balance
+~~~~~~~~~~~~~~~~~~~~~~
+
+This calculates a parallel electric field which balances the electron
+pressure gradient and other forces on the electrons (including
+collisional friction, thermal forces):
 
 .. math::
 
@@ -145,9 +163,9 @@ This electric field is then used to calculate a force on the other species:
 
 which is added to the ion's `momentum_source`. 
 
-The implementation is in `ZeroCurrent`:
+The implementation is in `ElectronForceBalance`:
 
-.. doxygenstruct:: ZeroCurrent
+.. doxygenstruct:: ElectronForceBalance
    :members:
 
 Neutral gas models

--- a/docs/sphinx/examples.rst
+++ b/docs/sphinx/examples.rst
@@ -26,15 +26,14 @@ of energy between them, or heat conduction.
    
    Evolution of pressure, starting from a top hat
 
-The model components are ions (i), electrons (e), and a constraint
-that the net current is zero. This constraint applies the electron
-pressure to the ion momentum equation, and sets the electron velocity
-to be equal to the ion velocity.
+The model components are ions (i) and electrons (e), and a component
+which uses the force on the electrons to calculate the parallel electric field,
+which transfers the force to the ions.
 
 .. code-block:: ini
 
    [hermes]
-   components = i, e, zero_current
+   components = i, e, electron_force_balance
 
 
 The ion density, pressure and momentum equations are evolved:
@@ -54,13 +53,14 @@ which solves the equations
    \frac{\partial}{\partial t}\left(n_iv_{||i}\right) =& -\nabla\cdot\left(n_iv_{||i} \mathbf{b}v_{||i}\right) - \partial_{||}p_i + E
    \end{aligned}
 
-The electron density is set to the ion density by quasineutrality,
-and only the electron pressure is evolved.
+The electron density is set to the ion density by quasineutrality, the
+parallel velocity is set by a zero current condition, and only the
+electron pressure is evolved.
 
 .. code-block:: ini
 
    [e] # Electrons
-   type = quasineutral, evolve_pressure
+   type = quasineutral, zero_current, evolve_pressure
 
 which adds the equations:
 

--- a/examples/1D-hydrogen/BOUT.inp
+++ b/examples/1D-hydrogen/BOUT.inp
@@ -41,10 +41,12 @@ ixseps2 = -1
 [hermes]
 # Notes:
 #  - electrons after other species, so the density can be set by quasineutrality
-#  - zero_current after thermal force, so the electric field includes the force on the electrons
+#    and velocity from zero-current condition
+#  - electron_force_balance after collisions, so the electric field includes forces
+#    on the electrons
 components = (d+, d, e,
-              zero_current, sheath_boundary, collisions, recycling, reactions,
-              neutral_parallel_diffusion)
+              sheath_boundary, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -135,7 +137,7 @@ function = 0.0001
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, zero_current, evolve_pressure, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-hydrogen/qn/BOUT.inp
+++ b/examples/1D-hydrogen/qn/BOUT.inp
@@ -41,10 +41,12 @@ ixseps2 = -1
 [hermes]
 # Notes:
 #  - electrons after other species, so the density can be set by quasineutrality
-#  - zero_current after thermal force, so the electric field includes the force on the electrons
+#    and velocity from zero-current condition
+#  - electron_force_balance after collisions, so the electric field includes forces
+#    on the electrons
 components = (d+, d, e,
-              zero_current, sheath_boundary, collisions, recycling, reactions,
-              neutral_parallel_diffusion)
+              sheath_boundary, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -139,7 +141,7 @@ function = 0.0001
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, zero_current, evolve_pressure, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-neon-source/BOUT.inp
+++ b/examples/1D-neon-source/BOUT.inp
@@ -1,0 +1,437 @@
+# 1D system with:
+#  - no-flow boundary on lower Y
+#  - sheath boundary on upper Y
+#  - Evolving electron and ion species
+#  - heat conduction
+#  - Uniform source of heat and particles throughout domain
+#  - Non-uniform grid, packed towards the target
+#  - Recycling of ions as atoms
+#  - Ionisation of neutrals as ions
+#  - Charge exchange between neutrals and ions
+#  - Feedback control of upstream density
+#  - Neon: atoms, 1+, 2+, 3+ and 4+ ions
+#  - Thermal force (simple expression)
+#
+#  Does not include recombination
+
+
+nout = 10
+timestep = 100
+
+MXG = 0  # No guard cells in X
+
+[mesh]
+nx = 1
+ny = 400   # Resolution along field-line
+nz = 1
+
+length = 30           # Length of the domain in meters
+length_xpt = 10   # Length from midplane to X-point [m]
+
+dymin = 0.1  # Minimum grid spacing near target, as fraction of average. Must be > 0 and < 1
+
+# Parallel grid spacing
+dy = (length / ny) * (1 + (1-dymin)*(1-y/pi))
+
+# Calculate where the source ends in grid index
+source = length_xpt / length
+y_xpt = pi * ( 2 - dymin - sqrt( (2-dymin)^2 - 4*(1-dymin)*source ) ) / (1 - dymin)
+
+ixseps1 = -1
+ixseps2 = -1
+
+[hermes]
+# Notes:
+#  - electrons after other species, so the density can be set by quasineutrality
+#  - zero_current after thermal force, so the electric field includes the force on the electrons
+components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, ne+5, ne+6, ne+7, ne+8, ne+9, ne+10, e,
+              zero_current, sheath_boundary, collisions, recycling, reactions,
+              neutral_parallel_diffusion)
+
+loadmetric = false        # Use Rxy, Bpxy etc?
+normalise_metric = true  # Normalise the input metric?
+
+Nnorm = 1e19
+Bnorm = 1
+Tnorm = 100
+
+[solver]
+type = beuler
+diagnose = true
+
+max_nonlinear_iterations = 10
+
+atol = 1e-7
+rtol = 1e-5
+
+predictor = false
+
+[sheath_boundary]
+
+lower_y = false
+upper_y = true
+
+[neutral_parallel_diffusion]
+
+dneut = 10   # (B / Bpol)^2 in neutral diffusion terms
+
+####################################
+
+[d+]  # Deuterium ions
+type = (evolve_density, evolve_pressure, evolve_momentum,
+        noflow_boundary, upstream_density_feedback)
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+charge = 1
+AA = 2
+
+density_upstream = 8e18  # Upstream density [m^-3]
+density_source_positive = false # Force source to be >= 0
+density_controller_i = 5e-4
+density_controller_p = 1e-2
+
+thermal_conduction = true  # in evolve_pressure
+
+diagnose = true
+
+recycle_as = d
+recycle_multiplier = 1.0  # Recycling fraction
+
+[Nd+]
+
+function = 1
+
+flux = 4e23  # Particles per m^2 per second input
+source = (flux/(mesh:length_xpt))*H(mesh:y_xpt - y)
+
+[Pd+]
+function = 1
+
+powerflux = 2.5e7  # Input power flux in W/m^2
+
+source = (powerflux*2/3 / (mesh:length_xpt))*H(mesh:y_xpt - y)  # Input power as function of y
+
+[NVd+]
+
+function = 0
+
+####################################
+
+[d]  # Deuterium atoms
+type = (evolve_density, evolve_pressure, evolve_momentum,
+        noflow_boundary)
+
+charge = 0
+AA = 2
+
+thermal_conduction = true
+
+[Nd]
+
+function = 0.001
+
+[Pd]
+
+function = 0.0001
+
+####################################
+[ne] # Neon neutral atoms
+type = (evolve_density, evolve_pressure, evolve_momentum,
+        noflow_boundary)
+
+charge = 0
+AA = 20
+
+[Nne]
+function = 1e-5
+
+#source = 1e19 * exp(-(y - 2*pi)^2) # source of neon near the target
+
+[Pne]
+function = 1e-7
+
+####################################
+
+[ne+] # Neon ions (1+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 1
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+[Nne+]
+function = 1e-5
+
+[Pne+]
+function = 1e-7
+
+####################################
+
+[ne+2] # Neon ions (2+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 2
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+[Nne+2]
+function = 1e-5
+
+[Pne+2]
+function = 1e-7
+
+####################################
+
+[ne+3] # Neon ions (3+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 3
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+[Nne+3]
+function = 1e-5
+
+[Pne+3]
+function = 1e-7
+
+####################################
+
+[ne+4] # Neon ions (4+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 4
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+4]
+function = 1e-5
+
+[Pne+4]
+function = 1e-7
+
+####################################
+
+[ne+5] # Neon ions (5+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 5
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+5]
+function = 1e-5
+
+[Pne+5]
+function = 1e-7
+
+####################################
+
+[ne+6] # Neon ions (6+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 6
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+6]
+function = 1e-5
+
+[Pne+6]
+function = 1e-7
+
+####################################
+
+[ne+7] # Neon ions (7+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 7
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+7]
+function = 1e-5
+
+[Pne+7]
+function = 1e-7
+
+####################################
+
+[ne+8] # Neon ions (8+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 8
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+8]
+function = 1e-5
+
+[Pne+8]
+function = 1e-7
+
+####################################
+
+[ne+9] # Neon ions (9+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 9
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+9]
+function = 1e-5
+
+[Pne+9]
+function = 1e-7
+
+####################################
+
+[ne+10] # Neon ions (10+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 10
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+10]
+function = 1e-5
+
+[Pne+10]
+function = 1e-7
+
+####################################
+
+[e] # Electrons
+type = quasineutral, evolve_pressure, noflow_boundary
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+
+thermal_conduction = true  # in evolve_pressure
+
+[Pe]
+
+function = `Pd+:function`  # Same as ion pressure initially
+
+source = `Pd+:source`  # Same as ion pressure source
+
+####################################
+
+[recycling]
+
+species = d+, ne+, ne+2, ne+3, ne+4, ne+5, ne+6, ne+7, ne+8, ne+9, ne+10
+
+[reactions]
+type = (
+        d + e -> d+ + 2e,     # Deuterium ionisation
+        d + d+ -> d+ + d,     # Charge exchange
+        
+        ne + e -> ne+ + 2e,   # Neon ionisation
+        ne+ + e -> ne,        # Neon+ recombination
+        ne+ + d -> ne + d+,   # Neon+ charge exchange recombination
+        
+        ne+ + e -> ne+2 + 2e, # Neon+ ionisation
+        ne+2 + e -> ne+,      # Neon+2 recombination
+        ne+2 + d -> ne+ + d+, # Neon+2 charge exchange recombination
+
+        ne+2 + e -> ne+3 + 2e, # Neon+2 ionisation
+        ne+3 + e -> ne+2,      # Neon+3 recombination
+        ne+3 + d -> ne+2 + d+, # Neon+3 charge exchange recombination
+
+        ne+3 + e -> ne+4 + 2e, # Neon+3 ionisation
+        ne+4 + e -> ne+3,      # Neon+4 recombination
+        ne+4 + d -> ne+3 + d+, # Neon+4 charge exchange recombination
+
+        ne+4 + e -> ne+5 + 2e, # Neon+3 ionisation
+        ne+5 + e -> ne+4,      # Neon+4 recombination
+        ne+5 + d -> ne+4 + d+, # Neon+4 charge exchange recombination
+
+        ne+5 + e -> ne+6 + 2e, # Neon+3 ionisation
+        ne+6 + e -> ne+5,      # Neon+4 recombination
+        ne+6 + d -> ne+5 + d+, # Neon+4 charge exchange recombination
+
+        ne+6 + e -> ne+7 + 2e, # Neon+3 ionisation
+        ne+7 + e -> ne+6,      # Neon+4 recombination
+        ne+7 + d -> ne+6 + d+, # Neon+4 charge exchange recombination
+
+        ne+7 + e -> ne+8 + 2e, # Neon+3 ionisation
+        ne+8 + e -> ne+7,      # Neon+4 recombination
+        ne+8 + d -> ne+7 + d+, # Neon+4 charge exchange recombination
+
+        ne+8 + e -> ne+9 + 2e, # Neon+3 ionisation
+        ne+9 + e -> ne+8,      # Neon+4 recombination
+        ne+9 + d -> ne+8 + d+, # Neon+4 charge exchange recombination
+
+        ne+9 + e -> ne+10 + 2e, # Neon+3 ionisation
+        ne+10 + e -> ne+9,      # Neon+4 recombination
+        ne+10 + d -> ne+9 + d+, # Neon+4 charge exchange recombination
+       )

--- a/examples/1D-neon-source/BOUT.inp
+++ b/examples/1D-neon-source/BOUT.inp
@@ -3,9 +3,9 @@
 #  - sheath boundary on upper Y
 #  - Evolving electron and ion species
 #  - heat conduction
-#  - Uniform source of heat and particles throughout domain
+#  - Source of heat and particles upstream of X-point
 #  - Non-uniform grid, packed towards the target
-#  - Recycling of ions as atoms
+#  - 100% recycling of ions as atoms, so particle source should go to zero
 #  - Ionisation of neutrals as ions
 #  - Charge exchange between neutrals and ions
 #  - Feedback control of upstream density
@@ -15,8 +15,8 @@
 #  Does not include recombination
 
 
-nout = 10
-timestep = 100
+nout = 100
+timestep = 1000
 
 MXG = 0  # No guard cells in X
 
@@ -40,13 +40,18 @@ y_xpt = pi * ( 2 - dymin - sqrt( (2-dymin)^2 - 4*(1-dymin)*source ) ) / (1 - dym
 ixseps1 = -1
 ixseps2 = -1
 
+[restart_files]
+init_missing = true # Initialise any missing variables to zero
+
 [hermes]
 # Notes:
-#  - electrons after other species, so the density can be set by quasineutrality
-#  - zero_current after thermal force, so the electric field includes the force on the electrons
+#  - electrons after other species, so the density can be set by quasineutrality,
+#    and their parallel flow using zero-current condition
+#  - electron_force_balance after thermal force and collisions, so the electric field
+#    includes the force on the electrons
 components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, ne+5, ne+6, ne+7, ne+8, ne+9, ne+10, e,
-              zero_current, sheath_boundary, collisions, recycling, reactions,
-              neutral_parallel_diffusion)
+              sheath_boundary, thermal_force, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -56,10 +61,10 @@ Bnorm = 1
 Tnorm = 100
 
 [solver]
-type = beuler
-diagnose = true
-
+type = beuler  # Backward Euler steady-state solver
 max_nonlinear_iterations = 10
+
+diagnose = true
 
 atol = 1e-7
 rtol = 1e-5
@@ -88,13 +93,13 @@ charge = 1
 AA = 2
 
 density_upstream = 8e18  # Upstream density [m^-3]
-density_source_positive = false # Force source to be >= 0
+density_source_positive = false  # Force source to be > 0?
 density_controller_i = 5e-4
 density_controller_p = 1e-2
 
 thermal_conduction = true  # in evolve_pressure
 
-diagnose = true
+diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
 recycle_multiplier = 1.0  # Recycling fraction
@@ -147,7 +152,7 @@ AA = 20
 [Nne]
 function = 1e-5
 
-#source = 1e19 * exp(-(y - 2*pi)^2) # source of neon near the target
+source = 1e19 * exp(-(y - 2*pi)^2) # source of neon near the target
 
 [Pne]
 function = 1e-7
@@ -369,7 +374,7 @@ function = 1e-7
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, zero_current, evolve_pressure, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -3,9 +3,9 @@
 #  - sheath boundary on upper Y
 #  - Evolving electron and ion species
 #  - heat conduction
-#  - Uniform source of heat and particles throughout domain
+#  - Source of heat and particles upstream of X-point
 #  - Non-uniform grid, packed towards the target
-#  - Recycling of ions as atoms
+#  - 100% recycling of ions as atoms, so particle source should go to zero
 #  - Ionisation of neutrals as ions
 #  - Charge exchange between neutrals and ions
 #  - Feedback control of upstream density
@@ -49,7 +49,7 @@ init_missing = true # Initialise any missing variables to zero
 #    and their parallel flow using zero-current condition
 #  - electron_force_balance after thermal force and collisions, so the electric field
 #    includes the force on the electrons
-components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, e,
+components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, ne+5, ne+6, ne+7, ne+8, ne+9, ne+10, e,
               sheath_boundary, thermal_force, collisions, recycling, reactions,
               electron_force_balance, neutral_parallel_diffusion)
 
@@ -61,13 +61,13 @@ Bnorm = 1
 Tnorm = 100
 
 [solver]
-type = beuler
+type = beuler  # Backward Euler steady-state solver
 max_nonlinear_iterations = 10
+
+diagnose = true
 
 atol = 1e-7
 rtol = 1e-5
-
-diagnose = true
 
 [sheath_boundary]
 
@@ -90,14 +90,17 @@ noflow_upper_y = false  # Sheath boundary at upper y
 charge = 1
 AA = 2
 
-density_upstream = 1e19  # Upstream density [m^-3]
+density_upstream = 8e18  # Upstream density [m^-3]
+density_source_positive = false  # Force source to be > 0?
+density_controller_i = 5e-4
+density_controller_p = 1e-2
 
 thermal_conduction = true  # in evolve_pressure
 
-diagnose = true
+diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 0.99  # Recycling fraction
+recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 
@@ -235,7 +238,7 @@ function = 1e-7
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, zero_current, noflow_boundary
+type = quasineutral, zero_current, evolve_pressure, noflow_boundary
 
 noflow_upper_y = false
 
@@ -254,7 +257,7 @@ source = `Pd+:source`  # Same as ion pressure source
 
 [recycling]
 
-species = d+, ne+, ne+2, ne+3, ne+4
+species = d+, ne+, ne+2, ne+3, ne+4, ne+5, ne+6, ne+7, ne+8, ne+9, ne+10
 
 [reactions]
 type = (

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -42,11 +42,13 @@ ixseps2 = -1
 
 [hermes]
 # Notes:
-#  - electrons after other species, so the density can be set by quasineutrality
-#  - zero_current after thermal force, so the electric field includes the force on the electrons
+#  - electrons after other species, so the density can be set by quasineutrality,
+#    and their parallel flow using zero-current condition
+#  - electron_force_balance after thermal force and collisions, so the electric field
+#    includes the force on the electrons
 components = (d+, d, ne, ne+, ne+2, ne+3, ne+4, e,
-              zero_current, sheath_boundary, thermal_force, collisions, recycling, reactions,
-              neutral_parallel_diffusion)
+              sheath_boundary, thermal_force, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -227,7 +229,7 @@ function = 1e-7
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, evolve_pressure, zero_current, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -16,7 +16,7 @@
 
 
 nout = 100
-timestep = 10
+timestep = 1000
 
 MXG = 0  # No guard cells in X
 
@@ -40,6 +40,9 @@ y_xpt = pi * ( 2 - dymin - sqrt( (2-dymin)^2 - 4*(1-dymin)*source ) ) / (1 - dym
 ixseps1 = -1
 ixseps2 = -1
 
+[restart_files]
+init_missing = true # Initialise any missing variables to zero
+
 [hermes]
 # Notes:
 #  - electrons after other species, so the density can be set by quasineutrality,
@@ -58,10 +61,13 @@ Bnorm = 1
 Tnorm = 100
 
 [solver]
-mxstep = 100000
+type = beuler
+max_nonlinear_iterations = 10
 
 atol = 1e-7
 rtol = 1e-5
+
+diagnose = true
 
 [sheath_boundary]
 

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -237,6 +237,138 @@ function = 1e-7
 
 ####################################
 
+[ne+5] # Neon ions (5+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 5
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 1  # Recycling fraction
+
+diagnose = true
+
+[Nne+5]
+function = 1e-5
+
+[Pne+5]
+function = 1e-7
+
+####################################
+
+[ne+6] # Neon ions (6+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 6
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 1  # Recycling fraction
+
+diagnose = true
+
+[Nne+6]
+function = 1e-5
+
+[Pne+6]
+function = 1e-7
+
+####################################
+
+[ne+7] # Neon ions (7+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 7
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 1  # Recycling fraction
+
+diagnose = true
+
+[Nne+7]
+function = 1e-5
+
+[Pne+7]
+function = 1e-7
+
+####################################
+
+[ne+8] # Neon ions (8+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 8
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 1  # Recycling fraction
+
+diagnose = true
+
+[Nne+8]
+function = 1e-5
+
+[Pne+8]
+function = 1e-7
+
+####################################
+
+[ne+9] # Neon ions (9+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 9
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 1  # Recycling fraction
+
+diagnose = true
+
+[Nne+9]
+function = 1e-5
+
+[Pne+9]
+function = 1e-7
+
+####################################
+
+[ne+10] # Neon ions (10+)
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+charge = 10
+AA = 20
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+recycle_as = ne
+recycle_multiplier = 0.99  # Recycling fraction
+
+diagnose = true
+
+[Nne+10]
+function = 1e-5
+
+[Pne+10]
+function = 1e-7
+
+####################################
+
 [e] # Electrons
 type = quasineutral, zero_current, evolve_pressure, noflow_boundary
 
@@ -279,4 +411,28 @@ type = (
         ne+3 + e -> ne+4 + 2e, # Neon+3 ionisation
         ne+4 + e -> ne+3,      # Neon+4 recombination
         ne+4 + d -> ne+3 + d+, # Neon+4 charge exchange recombination
+
+        ne+4 + e -> ne+5 + 2e, # Neon+3 ionisation
+        ne+5 + e -> ne+4,      # Neon+4 recombination
+        ne+5 + d -> ne+4 + d+, # Neon+4 charge exchange recombination
+
+        ne+5 + e -> ne+6 + 2e, # Neon+3 ionisation
+        ne+6 + e -> ne+5,      # Neon+4 recombination
+        ne+6 + d -> ne+5 + d+, # Neon+4 charge exchange recombination
+
+        ne+6 + e -> ne+7 + 2e, # Neon+3 ionisation
+        ne+7 + e -> ne+6,      # Neon+4 recombination
+        ne+7 + d -> ne+6 + d+, # Neon+4 charge exchange recombination
+
+        ne+7 + e -> ne+8 + 2e, # Neon+3 ionisation
+        ne+8 + e -> ne+7,      # Neon+4 recombination
+        ne+8 + d -> ne+7 + d+, # Neon+4 charge exchange recombination
+
+        ne+8 + e -> ne+9 + 2e, # Neon+3 ionisation
+        ne+9 + e -> ne+8,      # Neon+4 recombination
+        ne+9 + d -> ne+8 + d+, # Neon+4 charge exchange recombination
+
+        ne+9 + e -> ne+10 + 2e, # Neon+3 ionisation
+        ne+10 + e -> ne+9,      # Neon+4 recombination
+        ne+10 + d -> ne+9 + d+, # Neon+4 charge exchange recombination
        )

--- a/examples/1D-recycling/BOUT.inp
+++ b/examples/1D-recycling/BOUT.inp
@@ -40,10 +40,10 @@ ixseps2 = -1
 
 [hermes]
 # Evolve ion density, ion and electron pressure, then calculate force on ions due
-# to electron pressure by imposing zero current.
+# to electron pressure by using electron force balance.
 components = (d+, d, e,
-              zero_current, sheath_boundary, collisions, recycling, reactions,
-              neutral_parallel_diffusion)
+              sheath_boundary, collisions, recycling, reactions,
+              electron_parallel_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -125,7 +125,7 @@ function = 0.0001
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, evolve_pressure, zero_current, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-sheath-conduction/BOUT.inp
+++ b/examples/1D-sheath-conduction/BOUT.inp
@@ -27,8 +27,9 @@ ixseps2 = -1
 
 [hermes]
 # Evolve ion density, ion and electron pressure, then calculate force on ions due
-# to electron pressure by imposing zero current.
-components = i, e, sheath_boundary, zero_current, collisions
+# to electron pressure using electron force balance
+# Collisions are needed to calculate heat conduction
+components = i, e, sheath_boundary, collisions, electron_force_balance
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -81,7 +82,7 @@ function = 0
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, evolve_pressure, zero_current, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-sheath/BOUT.inp
+++ b/examples/1D-sheath/BOUT.inp
@@ -27,8 +27,8 @@ ixseps2 = -1
 
 [hermes]
 # Evolve ion density, ion and electron pressure, then calculate force on ions due
-# to electron pressure by imposing zero current.
-components = i, e, sheath_boundary, zero_current
+# to electron pressure using electron force balance
+components = i, e, sheath_boundary, electron_force_balance
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?
@@ -68,7 +68,7 @@ flux = 4e23  # Particles per m^2 per second input
 source = (flux/(mesh:length_xpt))*H(mesh:length_xpt - mesh:ypos)
 
 [Pi]
-function = 1 
+function = 1
 
 powerflux = 2e7  # Input power flux in W/m^2
 
@@ -81,7 +81,7 @@ function = 0
 ####################################
 
 [e] # Electrons
-type = quasineutral, evolve_pressure, noflow_boundary
+type = quasineutral, evolve_pressure, zero_current, noflow_boundary
 
 noflow_upper_y = false
 

--- a/examples/1D-te-ti/BOUT.inp
+++ b/examples/1D-te-ti/BOUT.inp
@@ -18,7 +18,7 @@ mxstep = 10000
 [hermes]
 # Evolve ion density, ion and electron pressure, then calculate force on ions due
 # to electron pressure by imposing zero current.
-components = i, e, zero_current
+components = i, e, electron_force_balance
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = false  # Normalise the input metric?
@@ -36,7 +36,7 @@ AA = 1.0
 thermal_conduction = false  # in evolve_pressure
 
 [e] # Electrons
-type = quasineutral, evolve_pressure
+type = quasineutral, zero_current, evolve_pressure
 
 charge = -1
 AA = 1/1836

--- a/examples/tokamak/diffusion-transport/BOUT.inp
+++ b/examples/tokamak/diffusion-transport/BOUT.inp
@@ -16,7 +16,7 @@ type = shifted
 mxstep = 10000
 
 [hermes]
-components = h+, e, collisions, sheath_boundary
+components = h+, e, collisions, sheath_boundary, electron_force_balance
 
 Nnorm = 2e18  # Reference density [m^-3]
 Bnorm = 1   # Reference magnetic field [T]

--- a/examples/tokamak/recycling-dthe/BOUT.inp
+++ b/examples/tokamak/recycling-dthe/BOUT.inp
@@ -16,7 +16,9 @@ type = shifted
 mxstep = 10000
 
 [hermes]
-components = d+, d, t+, t, he+, he, e, collisions, sheath_boundary, recycling, reactions
+components = (d+, d, t+, t, he+, he, e,
+              collisions, sheath_boundary, recycling,
+              reactions, electron_force_balance)
 
 Nnorm = 2e18  # Reference density [m^-3]
 Bnorm = 1   # Reference magnetic field [T]

--- a/examples/tokamak/recycling/BOUT.inp
+++ b/examples/tokamak/recycling/BOUT.inp
@@ -16,7 +16,9 @@ type = shifted
 mxstep = 10000
 
 [hermes]
-components = h+, h, e, collisions, sheath_boundary, recycling, reactions
+components = (h+, h, e,
+              collisions, sheath_boundary, recycling,
+              reactions, electron_force_balance)
 
 Nnorm = 2e18  # Reference density [m^-3]
 Bnorm = 1   # Reference magnetic field [T]

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -26,6 +26,7 @@
 #include <bout/constants.hxx>
 #include "include/ionisation.hxx"
 #include "include/neutral_mixed.hxx"
+#include "include/electron_force_balance.hxx"
 #include "include/evolve_density.hxx"
 #include "include/isothermal.hxx"
 #include "include/sheath_closure.hxx"

--- a/include/component.hxx
+++ b/include/component.hxx
@@ -129,6 +129,16 @@ T get(const Options& option, const std::string& location = "") {
   return getNonFinal<T>(option);
 }
 
+/// Check if an option can be fetched
+/// Sets the final flag so setting the value
+/// afterwards will lead to an error
+bool isSetFinal(const Options& option, const std::string& location = "");
+
+/// Check if an option can be fetched
+/// Sets the final flag so setting the value in the domain
+/// afterwards will lead to an error
+bool isSetFinalNoBoundary(const Options& option, const std::string& location = "");
+
 #define TOSTRING_(x) #x
 #define TOSTRING(x) TOSTRING_(x)
 

--- a/include/electron_force_balance.hxx
+++ b/include/electron_force_balance.hxx
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef ELECTRON_FORCE_BALANCE
+#define ELECTRON_FORCE_BALANCE
+
+#include "component.hxx"
+
+/// Balance the parallel electron pressure gradient against
+/// the electric field. Use this electric field to calculate
+/// a force on the other species
+///
+///   E = (-∇p_e + F) / n_e
+///
+/// where F is the momentum source for the electrons.
+///
+/// Then uses this electric field to calculate a force on all
+/// ion species.
+///
+/// Note: This needs to be put after collisions and other
+///       components which impose forces on electrons
+///
+struct ElectronForceBalance : public Component {
+  ElectronForceBalance(std::string, Options&, Solver*) {}
+
+  /// Required inputs
+  /// - species
+  ///   - e
+  ///     - pressure
+  ///     - density
+  ///     - momentum_source [optional]
+  ///     Asserts that charge = -1
+  ///
+  /// Sets in the input
+  /// - species
+  ///   - <all except e>   if both density and charge are set
+  ///     - momentum_source
+  /// 
+  void transform(Options &state) override;
+};
+
+namespace {
+RegisterComponent<ElectronForceBalance> registercomponentelectronforcebalance("electron_force_balance");
+}
+
+#endif // ELECTRON_FORCE_BALANCE

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -49,6 +49,7 @@ private:
   bool evolve_log; ///< Evolve logarithm of P?
   Field3D logP;    ///< Natural logarithm of P
 
+  BoutReal density_floor; ///< Minimum density for calculating T
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 
   Field3D source; ///< External pressure source

--- a/include/zero_current.hxx
+++ b/include/zero_current.hxx
@@ -4,31 +4,44 @@
 
 #include "component.hxx"
 
-/// Balance the parallel electron pressure gradient against
-/// the electric field. Use this electric field to calculate
-/// a force on the other species
+/// Set the velocity of a species so that
+/// there is no net current, by summing the current from
+/// other species.
 ///
-///   E = (-∇p_e + F) / n_e
-///
-/// where F is the momentum source for the electrons
-///
+/// This is most often used in the electron species, but
+/// does not need to be.
 struct ZeroCurrent : public Component {
-  ZeroCurrent(std::string, Options&, Solver*) {}
+  /// Inputs
+  /// ------
+  ///
+  /// @param name    Short name for species e.g. "e"
+  /// @param alloptions   Component configuration options
+  ///   - <name>
+  ///     - charge   (must not be zero)
+  ZeroCurrent(std::string name, Options& alloptions, Solver*);
   
   /// Required inputs
   /// - species
-  ///   - e
-  ///     - pressure
+  ///   - <name>
   ///     - density
-  ///     - momentum_source [optional]
-  ///     Asserts that charge = -1
+  ///     - charge
+  ///   - <one or more other species>
+  ///     - density
+  ///     - velocity
+  ///     - charge
   ///
-  /// Sets in the input
+  /// Sets in the state
   /// - species
-  ///   - <all except e>   if both density and charge are set
-  ///     - momentum_source
+  ///   - <name>
+  ///     - velocity
   /// 
   void transform(Options &state) override;
+
+private:
+  std::string name; ///< Name of this species
+  BoutReal charge;  ///< The charge of this species
+
+  Field3D velocity; ///< Species velocity (for writing to output)
 };
 
 namespace {

--- a/src/adas_reaction.cxx
+++ b/src/adas_reaction.cxx
@@ -195,7 +195,7 @@ void OpenADASChargeExchange::calculate_rates(Options& electron, Options& from_A,
 
   const Field3D reaction_rate = cellAverage(
       [&](BoutReal na, BoutReal nb, BoutReal ne, BoutReal te) {
-        return na * nb * rate_coef.evaluate(te * Tnorm, ne * Nnorm) * Nnorm / FreqNorm;
+        return floor(na, 1e-5) * floor(nb, 1e-5) * rate_coef.evaluate(te * Tnorm, ne * Nnorm) * Nnorm / FreqNorm;
       },
       Ne.getRegion("RGN_NOBNDRY"))(Na, Nb, Ne, Te);
 

--- a/src/component.cxx
+++ b/src/component.cxx
@@ -24,3 +24,20 @@ constexpr decltype(ComponentFactory::type_name) ComponentFactory::type_name;
 constexpr decltype(ComponentFactory::section_name) ComponentFactory::section_name;
 constexpr decltype(ComponentFactory::option_name) ComponentFactory::option_name;
 constexpr decltype(ComponentFactory::default_type) ComponentFactory::default_type;
+
+bool isSetFinal(const Options& option, const std::string& location) {
+#if CHECKLEVEL >= 1
+  // Mark option as final, both inside the domain and the boundary
+  const_cast<Options&>(option).attributes["final"] = location;
+  const_cast<Options&>(option).attributes["final-domain"] = location;
+#endif
+  return option.isSet();
+}
+
+bool isSetFinalNoBoundary(const Options& option, const std::string& location) {
+#if CHECKLEVEL >= 1
+  // Mark option as final inside the domain, but not in the boundary
+  const_cast<Options&>(option).attributes["final-domain"] = location;
+#endif
+  return option.isSet();
+}

--- a/src/electron_force_balance.cxx
+++ b/src/electron_force_balance.cxx
@@ -1,0 +1,48 @@
+
+#include <difops.hxx>
+
+#include "../include/electron_force_balance.hxx"
+
+void ElectronForceBalance::transform(Options &state) {
+  AUTO_TRACE();
+
+  // Get the electron pressure
+  // Note: The pressure boundary can be set in sheath boundary condition
+  //       which depends on the electron velocity being set here first.
+  Options& electrons = state["species"]["e"];
+  Field3D Pe = getNoBoundary<Field3D>(electrons["pressure"]);
+  Pe.applyBoundary("neumann");
+
+  Field3D Ne = getNoBoundary<Field3D>(electrons["density"]);
+
+  ASSERT1(get<BoutReal>(electrons["charge"]) == -1.0);
+
+  // Force balance, E = (-∇p + F) / n
+  Field3D force_density = - Grad_par(Pe);
+
+  if (isSetFinal(electrons["momentum_source"], "zero_current")) {
+    // Balance other forces from e.g. collisions
+    // Note: marked as final so can't be set later
+    force_density += get<Field3D>(electrons["momentum_source"]);
+  }
+  const Field3D Epar = force_density / Ne;
+
+  // Now calculate forces on other species
+  Options& allspecies = state["species"];
+  for (auto& kv : allspecies.getChildren()) {
+    if (kv.first == "e") {
+      continue; // Skip electrons
+    }
+    Options& species = allspecies[kv.first]; // Note: Need non-const
+
+    if (!(species.isSet("density") and species.isSet("charge"))) {
+      continue; // Needs both density and charge to experience a force
+    }
+
+    const Field3D N = getNoBoundary<Field3D>(species["density"]);
+    const BoutReal charge = get<BoutReal>(species["charge"]);
+
+    add(species["momentum_source"],
+        charge * N * Epar);
+  }
+}

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -91,8 +91,6 @@ void EvolveDensity::transform(Options &state) {
   mesh->communicate(N);
 
   auto& species = state["species"][name];
-  // Flooring N here results in unphysical sheath fluxes.
-  // Traced to flooring the density in the calculation of potential in sheath_boundary.cxx line 139
   set(species["density"], N);
   set(species["AA"], AA); // Atomic mass
   if (charge != 0.0) { // Don't set charge for neutral species
@@ -107,6 +105,9 @@ void EvolveDensity::finally(const Options &state) {
   auto coord = N.getCoordinates();
 
   auto& species = state["species"][name];
+
+  // Get updated density with boundary conditions
+  N = get<Field3D>(species["density"]);
 
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -91,7 +91,9 @@ void EvolveDensity::transform(Options &state) {
   mesh->communicate(N);
 
   auto& species = state["species"][name];
-  set(species["density"], floor(N, 0.0));
+  // Flooring N here results in unphysical sheath fluxes.
+  // Traced to flooring the density in the calculation of potential in sheath_boundary.cxx line 139
+  set(species["density"], N);
   set(species["AA"], AA); // Atomic mass
   if (charge != 0.0) { // Don't set charge for neutral species
     set(species["charge"], charge);

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -236,7 +236,7 @@ void EvolveMomentum::finally(const Options &state) {
   }
 
   // Get the species density
-  Field3D N = get<Field3D>(species["density"]);
+  Field3D N = floor(get<Field3D>(species["density"]), 1e-5);
   
   // Parallel flow
   V = get<Field3D>(species["velocity"]);

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -220,7 +220,10 @@ void EvolveMomentum::finally(const Options &state) {
   AUTO_TRACE();
 
   auto& species = state["species"][name];
-  
+
+  // Get updated momentum with boundary conditions
+  NV = get<Field3D>(species["momentum"]);
+
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -10,6 +10,12 @@
 using bout::globals::mesh;
 
 namespace {
+BoutReal floor(BoutReal value, BoutReal min) {
+  if (value < min)
+    return min;
+  return value;
+}
+
 Ind3D indexAt(const Field3D& f, int x, int y, int z) {
   int ny = f.getNy();
   int nz = f.getNz();
@@ -25,6 +31,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
 
   evolve_log = options["evolve_log"].doc("Evolve the logarithmof pressure?").withDefault<bool>(false);
 
+  density_floor = options["density_floor"].doc("Minimum density floor").withDefault(1e-5);
   if (evolve_log) {
     // Evolve logarithm of density
     solver->add(logP, std::string("logP") + name);
@@ -107,7 +114,7 @@ void EvolvePressure::transform(Options& state) {
   // Calculate temperature
   // Not using density boundary condition
   N = getNoBoundary<Field3D>(species["density"]);
-  T = P / floor(N, 1e-5);
+  T = P / floor(N, density_floor);
   T.applyBoundary("neumann");
 
   set(species["temperature"], T);

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -119,6 +119,10 @@ void EvolvePressure::finally(const Options& state) {
   /// Get the section containing this species
   const auto& species = state["species"][name];
 
+  // Get updated pressure and temperature with boundary conditions
+  P = get<Field3D>(species["pressure"]);
+  T = get<Field3D>(species["temperature"]);
+
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow
 

--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -27,8 +27,8 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   // Get rate coefficient, convert cm^3/s to m^3/s then normalise
   const Field3D sigmav = exp(ln_sigmav) * (1e-6 * Nnorm / FreqNorm);
 
-  const Field3D Natom = get<Field3D>(atom1["density"]);
-  const Field3D Nion = get<Field3D>(ion1["density"]);
+  const Field3D Natom = floor(get<Field3D>(atom1["density"]), 1e-5);
+  const Field3D Nion = floor(get<Field3D>(ion1["density"]), 1e-5);
 
   const Field3D R = Natom * Nion * sigmav; // Rate coefficient
 

--- a/src/makefile
+++ b/src/makefile
@@ -27,6 +27,7 @@ SOURCEC		= component.cxx component_scheduler.cxx ionisation.cxx radiation.cxx \
                   neutral_parallel_diffusion.cxx \
                   hydrogen_charge_exchange.cxx \
                   upstream_density_feedback.cxx \
-                  thermal_force.cxx
+                  thermal_force.cxx \
+                  electron_force_balance.cxx
 
 include $(BOUT_TOP)/make.config

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -92,7 +92,7 @@ void SheathBoundary::transform(Options &state) {
 
   // Need electron properties
   // Not const because boundary conditions will be set
-  Field3D Ne = getNoBoundary<Field3D>(electrons["density"]);
+  Field3D Ne = floor(getNoBoundary<Field3D>(electrons["density"]), 0.0);
   Field3D Te = getNoBoundary<Field3D>(electrons["temperature"]);
   Field3D Pe =
       electrons.isSet("pressure") ? getNoBoundary<Field3D>(electrons["pressure"]) : Te * Ne;
@@ -136,7 +136,7 @@ void SheathBoundary::transform(Options &state) {
         continue; // Skip electrons and non-charged ions
       }
       
-      const Field3D Ni = getNoBoundary<Field3D>(species["density"]);
+      const Field3D Ni = floor(getNoBoundary<Field3D>(species["density"]), 0.0);
       const Field3D Ti = getNoBoundary<Field3D>(species["temperature"]);
       const BoutReal Mi = getNoBoundary<BoutReal>(species["AA"]);
       const BoutReal Zi = getNoBoundary<BoutReal>(species["charge"]);
@@ -285,7 +285,7 @@ void SheathBoundary::transform(Options &state) {
 
         // Free boundary potential linearly extrapolated
         phi[im] = 2 * phi[i] - phi[ip];
-        
+
         const BoutReal nesheath = 0.5 * (Ne[im] + Ne[i]);
         const BoutReal tesheath = 0.5 * (Te[im] + Te[i]);  // electron temperature
         const BoutReal phisheath = floor(0.5 * (phi[im] + phi[i]), 0.0); // Electron saturation at phi = 0
@@ -412,7 +412,7 @@ void SheathBoundary::transform(Options &state) {
                                      : 5. / 3; // Ratio of specific heats (ideal gas)
 
     // Density and temperature boundary conditions will be imposed (free)
-    Field3D Ni = getNoBoundary<Field3D>(species["density"]);
+    Field3D Ni = floor(getNoBoundary<Field3D>(species["density"]), 0.0);
     Field3D Ti = getNoBoundary<Field3D>(species["temperature"]);
     Field3D Pi = species.isSet("pressure") ? getNoBoundary<Field3D>(species["pressure"]) : Ni * Ti;
 

--- a/src/zero_current.cxx
+++ b/src/zero_current.cxx
@@ -62,5 +62,6 @@ void ZeroCurrent::transform(Options &state) {
   Options& species = state["species"][name];
   Field3D N = getNoBoundary<Field3D>(species["density"]);
 
-  set(species["velocity"], current / (-charge * N));
+  velocity = current / (-charge * N);
+  set(species["velocity"], velocity);
 }

--- a/src/zero_current.cxx
+++ b/src/zero_current.cxx
@@ -3,67 +3,64 @@
 
 #include "../include/zero_current.hxx"
 
+ZeroCurrent::ZeroCurrent(std::string name, Options& alloptions, Solver*)
+    : name(name) {
+  AUTO_TRACE();
+  Options &options = alloptions[name];
+
+  charge = options["charge"].doc("Particle charge. electrons = -1");
+
+  // Save the velocity
+  bout::globals::dump.addRepeat(velocity, std::string("V") + name);
+  velocity = 0.0;
+
+  ASSERT0(charge != 0.0);
+}
+
 void ZeroCurrent::transform(Options &state) {
   AUTO_TRACE();
 
-  // Get the electron pressure
-  // Note: The pressure boundary can be set in sheath boundary condition
-  //       which depends on the electron velocity being set here first.
-  Options& electrons = state["species"]["e"];
-  Field3D Pe = getNoBoundary<Field3D>(electrons["pressure"]);
-  Pe.applyBoundary("neumann");
-
-  Field3D Ne = getNoBoundary<Field3D>(electrons["density"]);
-
-  ASSERT1(get<BoutReal>(electrons["charge"]) == -1.0);
-
-  // Force balance, E = (-∇p + F) / n
-  Field3D force_density = - Grad_par(Pe);
-
-  if (electrons.isSet("momentum_source")) {
-    // Balance other forces from e.g. collisions
-    force_density += get<Field3D>(electrons["momentum_source"]);
-  }
-  const Field3D Epar = force_density / Ne;
-
-  // Current due to ions
-  Field3D ion_current;
+  // Current due to other species
+  Field3D current;
   
   // Now calculate forces on other species
   Options& allspecies = state["species"];
   for (auto& kv : allspecies.getChildren()) {
-    if (kv.first == "e") {
-      continue; // Skip electrons
+    if (kv.first == name) {
+      continue; // Skip self
     }
     Options& species = allspecies[kv.first]; // Note: Need non-const
-    
+ 
     if (!(species.isSet("density") and species.isSet("charge"))) {
-      continue; // Needs both density and charge to experience a force
+      continue; // Needs both density and charge to contribute
     }
-    
-    const Field3D N = getNoBoundary<Field3D>(species["density"]);
-    const BoutReal charge = get<BoutReal>(species["charge"]);
 
-    add(species["momentum_source"],
-        charge * N * Epar);
+    if (isSetFinalNoBoundary(species["velocity"], "zero_current")) {
+      // If velocity is set, update the current
+      // Note: Mark final so can't be set later
 
-    if (species.isSet("velocity")) {
-      // If velocity is set, update the ion current
-      
+      const Field3D N = getNoBoundary<Field3D>(species["density"]);
+      const BoutReal charge = get<BoutReal>(species["charge"]);
       const Field3D V = getNoBoundary<Field3D>(species["velocity"]);
-      
-      if (!ion_current.isAllocated()) {
+
+      if (!current.isAllocated()) {
         // Not yet allocated -> Set to the value
         // This avoids having to set to zero initially and add the first time
-        ion_current = charge * N * V;
+        current = charge * N * V;
       } else {
-        ion_current += charge * N * V;
+        current += charge * N * V;
       }
     }
   }
 
-  if (ion_current.isAllocated()) {
-    // If ion current set, set the electron velocity
-    set(electrons["velocity"], ion_current / Ne);
+  if (!current.isAllocated()) {
+    // No currents, probably not what is intended
+    throw BoutException("No other species to set velocity from");
   }
+
+  // Get the species density
+  Options& species = state["species"][name];
+  Field3D N = getNoBoundary<Field3D>(species["density"]);
+
+  set(species["velocity"], current / (-charge * N));
 }

--- a/tests/unit/test_component.cxx
+++ b/tests/unit/test_component.cxx
@@ -108,3 +108,28 @@ TEST(ComponentTest, SetBoundaryAfterGetNoBoundary) {
 
   ASSERT_EQ(getNonFinal<int>(option), 3);
 }
+
+TEST(ComponentTest, IsSetFinalStaysFalse) {
+  Options option;
+
+  ASSERT_EQ(isSetFinal(option["test"]), false);
+  // Shouldn't change if called again
+  ASSERT_EQ(isSetFinal(option["test"]), false);
+}
+
+TEST(ComponentTest, GetAfterIsSetFinal) {
+  Options option;
+  option["test"] = 1;
+
+  ASSERT_EQ(isSetFinal(option["test"]), true);
+  // Can get the value
+  ASSERT_EQ(get<int>(option["test"]), 1);
+}
+
+TEST(ComponentTest, SetAfterIsSetFinal) {
+  Options option;
+
+  ASSERT_EQ(isSetFinal(option["test"]), false);
+  // Can't now set the value
+  ASSERT_THROW(set<int>(option["test"], 3), BoutException);
+}

--- a/tests/unit/test_electron_force_balance.cxx
+++ b/tests/unit/test_electron_force_balance.cxx
@@ -1,0 +1,108 @@
+
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+
+#include "../../include/electron_force_balance.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+#include <field_factory.hxx>  // For generating functions
+
+// Reuse the "standard" fixture for FakeMesh
+using ElectronForceBalanceTest = FakeMeshFixture;
+
+TEST_F(ElectronForceBalanceTest, CreateComponent) {
+  Options options;
+
+  ElectronForceBalance component("test", options, nullptr);
+}
+
+TEST_F(ElectronForceBalanceTest, MissingElectronPressure) {
+  Options options;
+
+  ElectronForceBalance component("test", options, nullptr);
+
+  ASSERT_THROW(component.transform(options), BoutException);
+}
+
+TEST_F(ElectronForceBalanceTest, ZeroPressureGradient) {
+  Options options;
+
+  ElectronForceBalance component("test", options, nullptr);
+
+  options["species"]["e"]["pressure"] = 1.0;
+  options["species"]["e"]["density"] = 1.0;
+  options["species"]["e"]["charge"] = -1.0;
+
+  options["species"]["h+"]["density"] = 1.0;
+  options["species"]["h+"]["charge"] = 1.0;
+
+  component.transform(options);
+
+  // Should have a momentum source, but zero because no pressure gradient
+  ASSERT_TRUE(options["species"]["h+"].isSet("momentum_source"));
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["species"]["h+"]["momentum_source"]), 0.0,
+                           "RGN_NOBNDRY"));
+}
+
+TEST_F(ElectronForceBalanceTest, WithPressureGradient) {
+  Options options;
+
+  ElectronForceBalance component("test", options, nullptr);
+
+  // Create a function which increases in y
+  options["species"]["e"]["pressure"] =
+      FieldFactory::get()->create3D("y", &options, mesh);
+  options["species"]["e"]["density"] = 1.0;
+  options["species"]["e"]["charge"] = -1.0;
+
+  options["species"]["h+"]["density"] = 1.0;
+  options["species"]["h+"]["charge"] = 1.0;
+
+  component.transform(options);
+
+  // Should have a momentum source
+  ASSERT_TRUE(options["species"]["h+"].isSet("momentum_source"));
+
+  // Force on ions should be in negative y direction
+  Field3D F = get<Field3D>(options["species"]["h+"]["momentum_source"]);
+
+  BOUT_FOR_SERIAL(i, F.getRegion("RGN_NOBNDRY")) {
+    ASSERT_LT(F[i], 0.0) << "Force on ions (h+) not negative at " << i;
+  }
+}
+
+
+TEST_F(ElectronForceBalanceTest, ForceBalance) {
+  Options options;
+  ElectronForceBalance component("test", options, nullptr);
+
+  options["species"]["e"]["pressure"] =1.0;
+  options["species"]["e"]["density"] = 2.0;
+  options["species"]["e"]["charge"] = -1.0;
+
+  options["species"]["e"]["momentum_source"] = 0.5;
+
+  // Should have E = momentum_source / density = 0.5 / 2.0
+
+  options["species"]["ion"]["density"] = 1.0;
+  options["species"]["ion"]["charge"] = 3.0;
+
+  component.transform(options);
+
+  // Should give ion momentum source charge * E = 3 * 0.5 / 2.0
+  Field3D F = get<Field3D>(options["species"]["ion"]["momentum_source"]);
+
+  BOUT_FOR_SERIAL(i, F.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(F[i], 3. * 0.5 / 2.0) << "Momentum source not correct at " << i;
+  }
+}

--- a/tests/unit/test_zero_current.cxx
+++ b/tests/unit/test_zero_current.cxx
@@ -22,74 +22,20 @@ using ZeroCurrentTest = FakeMeshFixture;
 
 TEST_F(ZeroCurrentTest, CreateComponent) {
   Options options;
-  
+
+  options["test"]["charge"] = 1.0; // Must be a charged species
   ZeroCurrent component("test", options, nullptr);
-}
-
-TEST_F(ZeroCurrentTest, MissingElectronPressure) {
-  Options options;
-  
-  ZeroCurrent component("test", options, nullptr);
-
-  ASSERT_THROW(component.transform(options), BoutException);
-}
-
-TEST_F(ZeroCurrentTest, ZeroPressureGradient) {
-  Options options;
-  
-  ZeroCurrent component("test", options, nullptr);
-
-  options["species"]["e"]["pressure"] = 1.0;
-  options["species"]["e"]["density"] = 1.0;
-  options["species"]["e"]["charge"] = -1.0;
-
-  options["species"]["h+"]["density"] = 1.0;
-  options["species"]["h+"]["charge"] = 1.0;
-
-  component.transform(options);
-  
-  // Should have a momentum source, but zero because no pressure gradient
-  ASSERT_TRUE(options["species"]["h+"].isSet("momentum_source"));
-  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["species"]["h+"]["momentum_source"]), 0.0,
-                           "RGN_NOBNDRY"));
-}
-
-TEST_F(ZeroCurrentTest, WithPressureGradient) {
-  Options options;
-  
-  ZeroCurrent component("test", options, nullptr);
-
-  // Create a function which increases in y
-  options["species"]["e"]["pressure"] =
-      FieldFactory::get()->create3D("y", &options, mesh);
-  options["species"]["e"]["density"] = 1.0;
-  options["species"]["e"]["charge"] = -1.0;
-
-  options["species"]["h+"]["density"] = 1.0;
-  options["species"]["h+"]["charge"] = 1.0;
-
-  component.transform(options);
-  
-  // Should have a momentum source
-  ASSERT_TRUE(options["species"]["h+"].isSet("momentum_source"));
-
-  // Force on ions should be in negative y direction
-  Field3D F = get<Field3D>(options["species"]["h+"]["momentum_source"]);
-
-  BOUT_FOR_SERIAL(i, F.getRegion("RGN_NOBNDRY")) {
-    ASSERT_LT(F[i], 0.0) << "Force on ions (h+) not negative at " << i;
-  }
 }
 
 TEST_F(ZeroCurrentTest, ElectronFlowVelocity) {
   Options options;
-  
-  ZeroCurrent component("test", options, nullptr);
 
-  options["species"]["e"]["pressure"] =
-      FieldFactory::get()->create3D("y", &options, mesh);
-  options["species"]["e"]["density"] = 2.0;
+  options["e"]["charge"] = -1.0;
+
+  ZeroCurrent component("e", options, nullptr);
+
   options["species"]["e"]["charge"] = -1.0;
+  options["species"]["e"]["density"] = 2.0;
 
   options["species"]["ion"]["density"] = 1.0;
   options["species"]["ion"]["charge"] = 2.0;
@@ -104,30 +50,5 @@ TEST_F(ZeroCurrentTest, ElectronFlowVelocity) {
   Field3D Ve = get<Field3D>(options["species"]["e"]["velocity"]);
   BOUT_FOR_SERIAL(i, Ve.getRegion("RGN_NOBNDRY")) {
     ASSERT_DOUBLE_EQ(Ve[i], Vi[i]) << "Electron velocity not equal to ion velocity at " << i;
-  }
-}
-
-TEST_F(ZeroCurrentTest, ElectronForceBalance) {
-  Options options;
-  ZeroCurrent component("test", options, nullptr);
-
-  options["species"]["e"]["pressure"] =1.0;
-  options["species"]["e"]["density"] = 2.0;
-  options["species"]["e"]["charge"] = -1.0;
-
-  options["species"]["e"]["momentum_source"] = 0.5;
-
-  // Should have E = momentum_source / density = 0.5 / 2.0
-
-  options["species"]["ion"]["density"] = 1.0;
-  options["species"]["ion"]["charge"] = 3.0;
-
-  component.transform(options);
-
-  // Should give ion momentum source charge * E = 3 * 0.5 / 2.0
-  Field3D F = get<Field3D>(options["species"]["ion"]["momentum_source"]);
-
-  BOUT_FOR_SERIAL(i, F.getRegion("RGN_NOBNDRY")) {
-    ASSERT_DOUBLE_EQ(F[i], 3. * 0.5 / 2.0) << "Momentum source not correct at " << i;
   }
 }


### PR DESCRIPTION
`zero_current` now only sets the velocity of a species based on the net current from other species (similar to `quasineutral` for the density).

Calculation of the parallel electric field has to move to a separate component, `electron_force_balance`.

This is needed because electron velocity is needed to calculate collisions, and forces on electrons due to collisions are needed to calculate the electric field.

Caught by adding more checks on values being set after being used.