### PR TITLE
BOUT++ updates and bug fix

### DIFF
--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -145,7 +145,7 @@ void AmjuelHeRecombination10::transform(Options& state) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms
-                    he01_rate_coefs, he01_radiation_coefs,
+                    he10_rate_coefs, he10_radiation_coefs,
                     24.586 // Ionisation potential heating of electrons
   );
 }

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -59,7 +59,7 @@ void AnomalousDiffusion::transform(Options &state) {
     // Particle diffusion. Gradients of density drive flows of particles,
     // momentum and energy
     add(species["density_source"],
-        FV::Div_a_Laplace_perp(anomalous_D, N2D));
+        Div_a_Laplace_perp_upwind(anomalous_D, N2D));
 
     // Note: Upwind operators used, or unphysical increases
     // in temperature and flow can be produced


### PR DESCRIPTION
- Update BOUT++ version to get newer `beuler` solver
- Fix bug in Helium recombination rates
- Change anomalous diffusion method to upwind for all channels
