### PR TITLE
Option for density and energy sinks for all species with sheath closure

### DIFF
--- a/examples/2D-drift-plane-turbulence-te-ti/BOUT.inp
+++ b/examples/2D-drift-plane-turbulence-te-ti/BOUT.inp
@@ -1,0 +1,98 @@
+nout = 200
+timestep = 1e2
+
+MYG = 0  # No guard cells in Y, 2D simulation
+
+[mesh]
+nx = 260
+ny = 1
+nz = 256
+
+Lrad = 0.3  # Radial width of domain [m]
+Lpol = 0.3  # Poloidal size of domain [m]
+
+Bpxy = 1.0  # Poloidal magnetic field [T]
+Rxy = 1.5   # Major radius [meters]
+
+dx = Lrad * Rxy * Bpxy / (nx - 4)  # Poloidal flux
+dz = Lpol / Rxy / nz   # Angle
+
+hthe = 1
+sinty = 0
+Bxy = Bpxy
+Btxy = 0
+bxcvz = 1./Rxy^2  # Curvature
+
+[mesh:paralleltransform]
+type = identity
+
+[solver]
+mxstep = 10000
+
+[hermes]
+# Two species, electrons and ions
+components = e, h+, vorticity, sheath_closure
+
+Nnorm = 1e19
+Bnorm = mesh:Bxy
+Tnorm = 50.0
+
+[e]
+type = evolve_density, evolve_pressure
+
+charge = -1
+AA = 1/1836
+
+poloidal_flows = false  # Y flows due to ExB
+thermal_conduction = false  # Parallel heat conduction
+
+[Ne]
+function = 1.0 + 1e-3*mixmode(x)*mixmode(z)
+
+x0 = 0.2
+width = 0.02
+source = 1e23 * exp(-((x-x0)/width)^2) # Units Nnorm/s
+
+bndry_all = neumann
+
+[Pe]
+function = Ne:function
+
+source = Ne:source * hermes:Tnorm * 1.602176634e-19
+
+bndry_all = neumann
+
+[h+]
+# Set the density so that the plasma is quasineutral
+type = quasineutral, evolve_pressure
+
+charge = 1
+AA = 1
+
+bndry_flux = true
+poloidal_flows = false
+thermal_conduction = false
+
+[Nh+]
+function = Ne:function
+
+[Ph+]
+function = `Nh+:function`
+
+source = Ne:source * hermes:Tnorm * 1.602176634e-19
+
+bndry_all = neumann
+
+[vorticity]
+
+diamagnetic = true   # Include diamagnetic current?
+diamagnetic_polarisation = true # Include diamagnetic drift in polarisation current?
+average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion current
+bndry_flux = false # Allow flows through radial boundaries
+poloidal_flows = false  # Include poloidal ExB flow
+split_n0 = false  # Split phi into n=0 and n!=0 components
+
+[sheath_closure]
+connection_length = 50 # meters
+potential_offset = 0.0  # Potential at which sheath current is zero
+sinks = true

--- a/include/sheath_closure.hxx
+++ b/include/sheath_closure.hxx
@@ -23,13 +23,14 @@ struct SheathClosure : public Component {
   ///
   /// Optional inputs
   /// - species
-  ///   - e
-  ///     - density
+  ///   - density
+  ///   - pressure
   ///
   /// Modifies
   /// - species
   ///   - e
   ///     - density_source   (If density present)
+  ///   - density_source and energy_source (If sinks=true)
   /// - fields
   ///   - DivJdia     Divergence of current
   ///
@@ -39,7 +40,11 @@ private:
 
   BoutReal sheath_gamma; // Sheath heat transmission coefficient
 
+  BoutReal sheath_gamma_ions; // Sheath heat transmission coefficient for ions
+
   BoutReal offset; // Potential at which the sheath current is zero
+
+  bool sinks; // Include sinks of density and energy?
 };
 
 namespace {


### PR DESCRIPTION
Allows source-driven 2d turbulence simulations.

If `sheath_closure:sinks = true` is set:
* Sheath particle flux is at a common sound speed of sqrt(P_total/(total mass density)), for all species. Electron particle sink is still modified by DivJsh.
* Ions have an energy sink like `gamma_i*Ti*sheath_flux`, where `gamma_i = 2.0` (by default) is taken from Stangeby's book.

NB These forms have not been chosen carefully - they were just the first that came to my mind!