### PR TITLE
Improve debugging in neutral_parallel_diffusion

### DIFF
--- a/include/neutral_parallel_diffusion.hxx
+++ b/include/neutral_parallel_diffusion.hxx
@@ -26,7 +26,7 @@ struct NeutralParallelDiffusion : public Component {
   ///      - collision_frequency
   ///      - density
   ///      - temperature
-  ///      - pressure
+  ///      - pressure     [optional, or density * temperature]
   ///      - velocity     [optional]
   ///      - momentum     [if velocity set]
   ///

--- a/src/neutral_parallel_diffusion.cxx
+++ b/src/neutral_parallel_diffusion.cxx
@@ -5,7 +5,7 @@
 using bout::globals::mesh;
 
 void NeutralParallelDiffusion::transform(Options& state) {
-
+  AUTO_TRACE();
   Options& allspecies = state["species"];
   for (auto& kv : allspecies.getChildren()) {
     // Get non-const reference
@@ -18,9 +18,10 @@ void NeutralParallelDiffusion::transform(Options& state) {
 
     auto nu = get<Field3D>(species["collision_frequency"]);
     const BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
-    Field3D Nn = get<Field3D>(species["density"]);
-    Field3D Tn = get<Field3D>(species["temperature"]);
-    Field3D Pn = get<Field3D>(species["pressure"]);
+    const Field3D Nn = GET_VALUE(Field3D, species["density"]);
+    const Field3D Tn = GET_VALUE(Field3D, species["temperature"]);
+    const Field3D Pn = IS_SET(species["pressure"]) ?
+      GET_VALUE(Field3D, species["pressure"]) : Nn * Tn;
 
     // Diffusion coefficient
     Field3D Dn = dneut * Tn / (AA * nu);


### PR DESCRIPTION
1. Make pressure an optional input, calculate from density and
   temperature if not available. Using IS_SET so that an error
   will be thrown if pressure is set afterwards.

2. Add backtrace and use GET_VALUE to record information for
   debugging.