### PR TITLE
Adding SNB electron heat conduction component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(HERMES_SOURCES
     src/sheath_closure.cxx
     src/sheath_boundary.cxx
     src/sheath_boundary_simple.cxx
+    src/snb_conduction.cxx
     src/fixed_fraction_ions.cxx
     src/sound_speed.cxx
     src/zero_current.cxx
@@ -110,6 +111,7 @@ set(HERMES_SOURCES
     include/loadmetric.hxx
     include/neutral_mixed.hxx
     include/neutral_parallel_diffusion.hxx
+    include/snb_conduction.hxx
     include/solkit_neutral_parallel_diffusion.hxx
     include/noflow_boundary.hxx
     include/quasineutral.hxx

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -179,6 +179,17 @@ The implementation is in `EvolvePressure`:
    :members:
 
 
+SNB nonlocal heat flux
+~~~~~~~~~~~~~~~~~~~~~~
+
+Calculates the divergence of the electron heat flux using the
+Shurtz-Nicolai-Busquet (SNB) model. Uses the BOUT++ implementation which is
+`documented here <https://bout-dev.readthedocs.io/en/latest/user_docs/nonlocal.html?#snb-model>`_.
+
+.. doxygenstruct:: SNBConduction
+   :members:
+
+
 Species parallel dynamics
 -------------------------
 

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -61,6 +61,7 @@
 #include "include/fixed_temperature.hxx"
 #include "include/transform.hxx"
 #include "include/fixed_fraction_radiation.hxx"
+#include "include/snb_conduction.hxx"
 
 #include "include/loadmetric.hxx"
 

--- a/include/snb_conduction.hxx
+++ b/include/snb_conduction.hxx
@@ -1,0 +1,83 @@
+#pragma once
+#ifndef SNB_CONDUCTION_H
+#define SNB_CONDUCTION_H
+
+#include "component.hxx"
+
+#include <bout/snb.hxx>
+
+/// Calculate electron heat flux using the Shurtz-Nicolai-Busquet (SNB) model
+///
+/// This component will only calculate divergence of heat flux for the
+/// electron (`e`) species.
+///
+/// # Usage
+///
+/// Add as a top-level component after both electron temperature and
+/// collision times have been calculated.
+///
+/// Important: If evolving electron pressure, disable thermal
+/// conduction or that will continue to add Spitzer heat conduction.
+///
+/// ```
+/// [hermes]
+/// components = e, ..., collisions, snb_conduction
+///
+/// [e]
+/// type = evolve_pressure, ...
+/// thermal_conduction = false # For evolve_pressure
+///
+/// [snb_conduction]
+/// diagnose = true # Saves heat flux diagnostics
+/// ```
+///
+/// # Useful references:
+///
+///  *  Braginskii equations by R.Fitzpatrick:
+///     http://farside.ph.utexas.edu/teaching/plasma/Plasmahtml/node35.html
+///
+///  *  J.P.Brodrick et al 2017: https://doi.org/10.1063/1.5001079 and
+///     https://arxiv.org/abs/1704.08963
+///
+///  *  Shurtz, Nicolai and Busquet 2000: https://doi.org/10.1063/1.1289512
+///
+struct SNBConduction : public Component {
+
+  /// Inputs
+  ///  - <name>
+  ///    - diagnose   Saves Div_Q_SH and Div_Q_SNB
+  SNBConduction(std::string name, Options& alloptions, Solver*) {
+    AUTO_TRACE();
+    auto& options = alloptions[name];
+
+    if (options["diagnose"]
+        .doc("Save additional output diagnostics")
+          .withDefault<bool>(false)) {
+      SAVE_REPEAT(Div_Q_SH, Div_Q_SNB);
+    }
+  }
+
+  /// Inputs
+  /// - species
+  ///   - e
+  ///     - density
+  ///     - collision_frequency
+  ///
+  /// Sets
+  /// - species
+  ///   - e
+  ///     - energy_source
+  void transform(Options& state) override;
+
+private:
+  bout::HeatFluxSNB snb;
+
+  Field3D Div_Q_SH, Div_Q_SNB; ///< Divergence of heat fluxes
+};
+
+namespace {
+RegisterComponent<SNBConduction> registercomponentsnbconduction("snb_conduction");
+}
+
+#endif // SNB_CONDUCTION_H
+

--- a/src/snb_conduction.cxx
+++ b/src/snb_conduction.cxx
@@ -1,0 +1,37 @@
+#include "../include/snb_conduction.hxx"
+
+#include <bout.hxx>
+using bout::globals::mesh;
+
+void SNBConduction::transform(Options& state) {
+  auto units = state["units"];
+  const auto rho_s0 = get<BoutReal>(units["meters"]);
+  const auto Tnorm = get<BoutReal>(units["eV"]);
+  const auto Nnorm = get<BoutReal>(units["inv_meters_cubed"]);
+  const auto Omega_ci = 1. / get<BoutReal>(units["seconds"]);
+
+  Options& electrons = state["species"]["e"];
+  // Note: Needs boundary conditions on temperature
+  const Field3D Te = GET_VALUE(Field3D, electrons["temperature"]) * Tnorm; // eV
+  const Field3D Ne = GET_VALUE(Field3D, electrons["density"]) * Nnorm;     // In m^-3
+
+  // SNB non-local heat flux. Also returns the Spitzer-Harm value for comparison
+  // Note: Te in eV, Ne in Nnorm
+  Field2D dy_orig = mesh->getCoordinates()->dy;
+  mesh->getCoordinates()->dy *= rho_s0; // Convert distances to m
+
+  // Inputs in eV and m^-3
+  Div_Q_SNB = snb.divHeatFlux(Te, Ne, &Div_Q_SH);
+
+  // Restore the metric tensor
+  mesh->getCoordinates()->dy = dy_orig;
+
+  // Normalise from eV/m^3/s
+  Div_Q_SNB /= Tnorm * Nnorm * Omega_ci;
+  Div_Q_SH /= Tnorm * Nnorm * Omega_ci;
+
+  // Divergence of heat flux appears with a minus sign in energy source:
+  //
+  // ddt(3/2 P) = .. - Div(q)
+  subtract(electrons["energy_source"], Div_Q_SNB);
+}


### PR DESCRIPTION
Wrapper around BOUT++ SNB heat flux code. Only calculates for electrons, as validity for other species is probably dubious.

Includes documentation, but no tests yet. Should add some tests before merging.
