### PR TITLE
Electromagnetic effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(HERMES_SOURCES
     src/loadmetric.cxx
     src/neutral_mixed.cxx
     src/full_velocity.cxx
+    src/electromagnetic.cxx
     src/electron_force_balance.cxx
     src/evolve_density.cxx
     src/vorticity.cxx
@@ -94,6 +95,7 @@ set(HERMES_SOURCES
     include/component_scheduler.hxx
     include/diamagnetic_drift.hxx
     include/div_ops.hxx
+    include/electromagnetic.hxx
     include/electron_force_balance.hxx
     include/evolve_density.hxx
     include/evolve_momentum.hxx

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -955,3 +955,57 @@ the potential in time as a diffusion equation.
 
 .. doxygenstruct:: RelaxPotential
    :members:
+
+electromagnetic
+~~~~~~~~~~~~~~~
+
+This component modifies the definition of momentum of all species, to
+include the contribution from the electromagnetic potential
+:math:`A_{||}`.
+
+Assumes that "momentum" :math:`p_s` calculated for all species
+:math:`s` is
+
+.. math::
+
+   p_s = m_s n_s v_{||s} + Z_s e n_s A_{||}
+
+which arises once the electromagnetic contribution to the force on
+each species is included in the momentum equation. This is normalised
+so that in dimensionless quantities
+
+.. math::
+
+   p_s = A n v_{||} + Z n A_{||}
+
+where :math:`A` and :math:`Z` are the atomic number and charge of the
+species.
+
+The current density :math:`j_{||}` in SI units is
+
+.. math::
+
+   j_{||} = -\frac{1}{\mu_0}\nabla_\perp^2 A_{||}
+
+which when normalised in Bohm units becomes
+
+.. math::
+
+   j_{||} = - \frac{1}{\beta_{em}}\nabla_\perp^2 A_{||}
+
+where :math:`\beta_{em}` is a normalisation parameter which is half
+the plasma electron beta as normally defined:
+
+.. math::
+
+   \beta_{em} = \frac{\mu_0 e \overline{n} \overline{T}}{\overline{B}^2}
+
+To convert the species momenta into a current, we take the sum of
+:math:`p_s Z_s e / m_s`. In terms of normalised quantities this gives:
+
+.. math::
+
+   - \frac{1}{\beta_{em}} \nabla_\perp^2 A_{||} + \sum_s \frac{Z^2 n_s}{A}A_{||} = \sum_s \frac{Z}{A} p_s
+
+.. doxygenstruct:: Electromagnetic
+   :members:

--- a/examples/linear/annulus-isothermal-he-emag/BOUT.inp
+++ b/examples/linear/annulus-isothermal-he-emag/BOUT.inp
@@ -1,0 +1,117 @@
+# Isothermal turbulence simulation
+#
+# Some values taken from
+#   https://doi.org/10.1063/1.4759010
+#   https://aip.scitation.org/doi/10.1063/1.3527987
+#
+
+nout = 500
+timestep = 1000
+
+[mesh]
+
+nx = 64   # Radial resolution including 4 guard cells
+ny = 16   # Parallel direction
+nz = 64   # number of points in azimuthal direction
+
+length = 17  # length of machine in meters
+Rmin = 0.1    # minimum radius in meters
+Rmax = 0.4  # maximum radius in meters
+
+Bxy = 0.1   # Magnetic field strength [T]
+
+# The following choices make a Clebsch coordinate system where
+# x is a radial flux coordinate
+# y is a parallel angle coordinate (0 -> 2π)
+# z is azimuthal angle (0 -> 2π)
+#
+# Note: In input expressions,
+#       x is normalised from 0->1, y and z from 0->2π,
+
+Bpxy = Bxy
+Btxy = 0
+hthe = length / (2π)
+Rxy = Rmin + (Rmax - Rmin) * x   # Radius from axis. Note: Here x is from 0->1
+sinty = 0  # Integrated shear
+
+dr = (Rmax - Rmin) / (nx - 4)
+dx = Bpxy * Rxy * dr    # Radial flux coordinate
+dy = 2π / ny     # Angle 0 -> 2π
+dz = 2π / nz     # Azimuthal angle
+
+ixseps1 = -1  # This line and the one below will add y boundaries
+ixseps2 = -1  #
+
+extrapolate_y = false  # Can result in negative Jacobians in guard cells
+
+[mesh:paralleltransform]
+type = identity
+
+[solver]
+
+mxstep = 10000
+
+[hermes]
+# Note: electromagnetic modifies the parallel momentum so comes after species and before boundary conditions
+components = (e, he+, electromagnetic, sound_speed, vorticity,
+              sheath_boundary, collisions
+              )
+
+Nnorm = 1e18  # Reference density [m^-3]
+Bnorm = 1   # Reference magnetic field [T]
+Tnorm = 1   # Reference temperature [eV]
+
+loadmetric = true  # Recalculate metric tensor? (false -> use grid values)
+
+[vorticity]
+
+diamagnetic = false   # Include diamagnetic current?
+diamagnetic_polarisation = false # Include diamagnetic drift in polarisation current?
+average_atomic_mass = `he+`:AA   # Weighted average atomic mass, for polarisaion current
+poloidal_flows = false  # Include poloidal ExB flow
+split_n0 = false  # Split phi into n=0 and n!=0 components
+
+vort_dissipation = false
+phi_dissipation = true
+
+phi_boundary_relax = true
+phi_boundary_timescale = 1e-6
+
+[vorticity:laplacian]
+inner_boundary_flags = 16  # INVERT_SET, setting inner boundary
+outer_boundary_flags = 16  # INVERT_SET, setting outer boundary
+
+################################################################
+# Electrons
+
+[e]
+# Evolve the electron density, parallel momentum, and fix Te
+type = evolve_density, evolve_momentum, isothermal
+
+AA = 60 / 1836
+charge = -1
+
+temperature = 5  # Electron temperature in eV
+
+poloidal_flows = false
+
+[Ne]
+bndry_all = neumann
+
+function = 1e-1 * exp(-x^2) + 1e-5*(mixmode(z) + mixmode(4*z - x)) # Starting density profile [x10^18 m^-3]
+
+source = 5e21*exp(-(x/0.3)^2)   # Particle source in m^-3s^-1
+
+################################################################
+# Helium ions
+[he+]
+# Set ion density from quasineutrality, evolve parallel flow
+type = quasineutral, evolve_momentum, isothermal
+
+AA = 4       # Atomic mass
+charge = 1
+
+temperature = 0.1   # Ion temperature in eV
+
+poloidal_flows = false
+

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -62,6 +62,7 @@
 #include "include/fixed_temperature.hxx"
 #include "include/transform.hxx"
 #include "include/fixed_fraction_radiation.hxx"
+#include "include/electromagnetic.hxx"
 
 #include "include/loadmetric.hxx"
 

--- a/include/electromagnetic.hxx
+++ b/include/electromagnetic.hxx
@@ -1,0 +1,69 @@
+#pragma once
+#ifndef ELECTROMAGNETIC_H
+#define ELECTROMAGNETIC_H
+
+#include "component.hxx"
+
+class Laplacian;
+
+/// Electromagnetic potential A||
+///
+/// Reinterprets all species' parallel momentum as a combination
+/// of a parallel flow and a magnetic contribution, i.e. canonical momentum.
+///
+///     m n v_{||} + Z e n A_{||}
+///
+/// Changes the "momentum" of each species so that after this component
+/// the momentuum of each species is just
+///
+///     m n v_{||}
+///
+/// This component should be run after all species have set their
+/// momentum, but before the momentum is used e.g to set boundary
+/// conditions.
+///
+/// Calculates the electromagnetic potential A_{||} using
+///
+/// Laplace(Apar) - alpha_em * Apar = -Ajpar
+///
+/// By default outputs Apar every timestep. When `diagnose = true` in
+/// also saves alpha_em and Ajpar.
+///
+struct Electromagnetic : public Component {
+  /// Options
+  /// - units
+  /// - <name>
+  ///   - diagnose   Saves Ajpar and alpha_em time-dependent values
+  ///
+  Electromagnetic(std::string name, Options &options, Solver *solver);
+
+  /// Inputs
+  /// - species
+  ///   - <..>      All species with charge and parallel momentum
+  ///     - charge
+  ///     - momentum
+  ///     - density
+  ///     - AA
+  ///
+  /// Sets
+  /// - species
+  ///   - <..>      All species with charge and parallel momentum
+  ///     - momentum  (modifies) to m n v||
+  /// - fields
+  ///   - Apar      Electromagnetic potential
+  ///
+  void transform(Options &state) override;
+private:
+  Field3D Apar; // Electromagnetic potential A_||
+  Field3D Ajpar; // Total parallel current density
+  Field3D alpha_em; // Coefficient
+  BoutReal beta_em; // Normalisation coefficient mu_0 e T n / B^2
+
+  std::unique_ptr<Laplacian> aparSolver; // Laplacian solver in X-Z
+};
+
+namespace {
+RegisterComponent<Electromagnetic> registercomponentelectromagnetic("electromagnetic");
+}
+
+#endif // ELECTROMAGNETIC_H

--- a/include/electromagnetic.hxx
+++ b/include/electromagnetic.hxx
@@ -49,6 +49,7 @@ struct Electromagnetic : public Component {
   /// - species
   ///   - <..>      All species with charge and parallel momentum
   ///     - momentum  (modifies) to m n v||
+  ///     - velocity  (modifies) to v||
   /// - fields
   ///   - Apar      Electromagnetic potential
   ///

--- a/src/electromagnetic.cxx
+++ b/src/electromagnetic.cxx
@@ -86,8 +86,11 @@ void Electromagnetic::transform(Options &state) {
     if (fabs(Z) < 1e-5) {
       continue; // Not charged
     }
+    const BoutReal A = get<BoutReal>(species["AA"]);
     const Field3D N = GET_NOBOUNDARY(Field3D, species["density"]);
 
     subtract(species["momentum"], Z * N * Apar);
+    // Note: velocity is momentum / (A * N)
+    subtract(species["velocity"], (Z / A) * Apar);
   }
 }

--- a/src/electromagnetic.cxx
+++ b/src/electromagnetic.cxx
@@ -1,0 +1,93 @@
+#include "../include/electromagnetic.hxx"
+
+#include <bout/constants.hxx>
+#include <invert_laplace.hxx>
+
+Electromagnetic::Electromagnetic(std::string name, Options &alloptions, Solver*) {
+  AUTO_TRACE();
+
+  Options& units = alloptions["units"];
+  BoutReal Bnorm = units["Tesla"];
+  BoutReal Tnorm = units["eV"];
+  BoutReal Nnorm = units["inv_meters_cubed"];
+
+  // Note: This is NOT plasma beta as usually defined, but
+  // is a factor of 2 too small (if Ti=0) or 4 (if Ti = Te)
+  // This is the normalisation parameter in the Helmholtz equation
+  beta_em = SI::mu0 * SI::qe * Tnorm * Nnorm / SQ(Bnorm);
+  output_info.write("Electromagnetic: beta_em = {}", beta_em);
+  SAVE_ONCE(beta_em);
+
+  auto& options = alloptions[name];
+
+  aparSolver = Laplacian::create(&options["laplacian"]);
+  // Set zero-gradient (neumann) boundary conditions
+  aparSolver->setInnerBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+  aparSolver->setOuterBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+
+  SAVE_REPEAT(Apar); // Always save Apar
+
+  if (options["diagnose"]
+      .doc("Output additional diagnostics?")
+      .withDefault<bool>(false)) {
+    SAVE_REPEAT(Ajpar, alpha_em);
+  }
+}
+
+void Electromagnetic::transform(Options &state) {
+  AUTO_TRACE();
+
+  Options& allspecies = state["species"];
+
+  // Sum coefficients over species
+  //
+  // Laplace(A||) - alpha_em * beta_em A|| = - beta_em * Ajpar
+  alpha_em = 0.0;
+  Ajpar = 0.0;
+  for (auto& kv : allspecies.getChildren()) {
+    const Options& species = kv.second;
+
+    if (!IS_SET(species["charge"]) or !species.isSet("momentum")) {
+      continue; // Not charged, or no parallel flow
+    }
+    const BoutReal Z = get<BoutReal>(species["charge"]);
+    if (fabs(Z) < 1e-5) {
+      continue; // Not charged
+    }
+
+    // Cannot rely on boundary conditions being set
+    const Field3D N = GET_NOBOUNDARY(Field3D, species["density"]);
+    // Non-final because we're going to change momentum
+    const Field3D mom = getNonFinal<Field3D>(species["momentum"]);
+    const BoutReal A = get<BoutReal>(species["AA"]);
+
+    // Coefficient in front of A_||
+    alpha_em += N * (SQ(Z) / A);
+
+    // Right hand side
+    Ajpar += mom * (Z / A);
+  }
+
+  // Invert Helmholtz equation for Apar
+  aparSolver->setCoefA((-beta_em) * alpha_em);
+  Apar = aparSolver->solve((-beta_em) * Ajpar);
+
+  // Save in the state
+  set(state["fields"]["Apar"], Apar);
+
+  // Update momentum
+  for (auto& kv : allspecies.getChildren()) {
+    Options& species = allspecies[kv.first]; // Note: need non-const
+
+    if (!species.isSet("charge") or !species.isSet("momentum")) {
+      continue; // Not charged, or no parallel flow
+    }
+    const BoutReal Z = get<BoutReal>(species["charge"]);
+    if (fabs(Z) < 1e-5) {
+      continue; // Not charged
+    }
+    const Field3D N = GET_NOBOUNDARY(Field3D, species["density"]);
+
+    subtract(species["momentum"], Z * N * Apar);
+  }
+}


### PR DESCRIPTION
Adds a component `electromagnetic` to include parallel electromagnetic electric field in all species' momentum equations. Re-interprets fluid momentum as a canonical momentum, calculates Apar by inverting a Helmholtz-like equation.