### PR TITLE
Sheath fixes

### DIFF
--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -401,8 +401,8 @@ void SheathBoundary::transform(Options &state) {
   setBoundary(electrons["temperature"], fromFieldAligned(Te));
   setBoundary(electrons["pressure"], fromFieldAligned(Pe));
 
-  // Set energy source (negative in cell next to sheath)
-  set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
+  // Add energy source (negative in cell next to sheath)
+  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));
@@ -630,6 +630,6 @@ void SheathBoundary::transform(Options &state) {
     }
 
     // Additional loss of energy through sheath
-    set(species["energy_source"], fromFieldAligned(energy_source));
+    add(species["energy_source"], fromFieldAligned(energy_source));
   }
 }

--- a/src/sheath_boundary_insulating.cxx
+++ b/src/sheath_boundary_insulating.cxx
@@ -425,7 +425,7 @@ void SheathBoundaryInsulating::transform(Options &state) {
     }
 
     // Additional loss of energy through sheath
-    set(species["energy_source"], fromFieldAligned(energy_source));
+    add(species["energy_source"], fromFieldAligned(energy_source));
   }
 
   //////////////////////////////////////////////////////////////////
@@ -509,7 +509,7 @@ void SheathBoundaryInsulating::transform(Options &state) {
   }
 
   // Set energy source (negative in cell next to sheath)
-  set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
+  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -105,18 +105,21 @@ void SheathBoundarySimple::transform(Options& state) {
 
   // Need electron properties
   // Not const because boundary conditions will be set
-  Field3D Ne = getNoBoundary<Field3D>(electrons["density"]);
-  Field3D Te = getNoBoundary<Field3D>(electrons["temperature"]);
-  Field3D Pe = electrons.isSet("pressure") ? getNoBoundary<Field3D>(electrons["pressure"])
-                                           : Te * Ne;
+  Field3D Ne = toFieldAligned(floor(GET_NOBOUNDARY(Field3D, electrons["density"]), 0.0));
+  Field3D Te = toFieldAligned(GET_NOBOUNDARY(Field3D, electrons["temperature"]));
+  Field3D Pe = IS_SET_NOBOUNDARY(electrons["pressure"])
+    ? toFieldAligned(getNoBoundary<Field3D>(electrons["pressure"]))
+    : Te * Ne;
 
   // Mass, normalised to proton mass
   const BoutReal Me =
-      electrons.isSet("AA") ? get<BoutReal>(electrons["AA"]) : SI::Me / SI::Mp;
+      IS_SET(electrons["AA"]) ? get<BoutReal>(electrons["AA"]) : SI::Me / SI::Mp;
 
   // This is for applying boundary conditions
-  Field3D Ve =
-      electrons.isSet("velocity") ? getNoBoundary<Field3D>(electrons["velocity"]) : 0.0;
+  Field3D Ve = IS_SET_NOBOUNDARY(electrons["velocity"])
+    ? toFieldAligned(getNoBoundary<Field3D>(electrons["velocity"]))
+    : zeroFrom(Ne);
+
   Field3D NVe = IS_SET_NOBOUNDARY(electrons["momentum"])
     ? toFieldAligned(getNoBoundary<Field3D>(electrons["momentum"]))
     : zeroFrom(Ne);
@@ -264,8 +267,8 @@ void SheathBoundarySimple::transform(Options& state) {
   // Electrons
 
   Field3D electron_energy_source = electrons.isSet("energy_source")
-                                       ? getNonFinal<Field3D>(electrons["energy_source"])
-                                       : 0.0;
+    ? toFieldAligned(getNonFinal<Field3D>(electrons["energy_source"]))
+    : zeroFrom(Ne);
 
   if (lower_y) {
     for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
@@ -369,15 +372,15 @@ void SheathBoundarySimple::transform(Options& state) {
   }
 
   // Set electron density and temperature, now with boundary conditions
-  setBoundary(electrons["density"], Ne);
-  setBoundary(electrons["temperature"], Te);
-  setBoundary(electrons["pressure"], Pe);
+  setBoundary(electrons["density"], fromFieldAligned(Ne));
+  setBoundary(electrons["temperature"], fromFieldAligned(Te));
+  setBoundary(electrons["pressure"], fromFieldAligned(Pe));
 
   // Set energy source (negative in cell next to sheath)
   add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
-  if (electrons.isSet("velocity")) {
-    setBoundary(electrons["velocity"], Ve);
+  if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
+    setBoundary(electrons["velocity"], fromFieldAligned(Ve));
   }
   if (IS_SET_NOBOUNDARY(electrons["momentum"])) {
     setBoundary(electrons["momentum"], fromFieldAligned(NVe));
@@ -385,7 +388,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
   if (always_set_phi or (state.isSection("fields") and state["fields"].isSet("phi"))) {
     // Set the potential, including boundary conditions
-    setBoundary(state["fields"]["phi"], phi);
+    setBoundary(state["fields"]["phi"], fromFieldAligned(phi));
   }
 
   //////////////////////////////////////////////////////////////////
@@ -408,23 +411,26 @@ void SheathBoundarySimple::transform(Options& state) {
     const BoutReal Mi = get<BoutReal>(species["AA"]);
 
     // Density and temperature boundary conditions will be imposed (free)
-    Field3D Ni = getNoBoundary<Field3D>(species["density"]);
-    Field3D Ti = getNoBoundary<Field3D>(species["temperature"]);
-    Field3D Pi =
-        species.isSet("pressure") ? getNoBoundary<Field3D>(species["pressure"]) : Ni * Ti;
+    Field3D Ni = toFieldAligned(floor(getNoBoundary<Field3D>(species["density"]), 0.0));
+    Field3D Ti = toFieldAligned(getNoBoundary<Field3D>(species["temperature"]));
+    Field3D Pi = species.isSet("pressure")
+      ? toFieldAligned(getNoBoundary<Field3D>(species["pressure"]))
+      : Ni * Ti;
 
     // Get the velocity and momentum
     // These will be modified at the boundaries
     // and then put back into the state
-    Field3D Vi =
-        species.isSet("velocity") ? getNoBoundary<Field3D>(species["velocity"]) : 0.0;
-    Field3D NVi = species.isSet("momentum") ? getNoBoundary<Field3D>(species["momentum"])
-                                            : Mi * Ni * Vi;
+    Field3D Vi = species.isSet("velocity")
+      ? toFieldAligned(getNoBoundary<Field3D>(species["velocity"]))
+      : zeroFrom(Ni);
+    Field3D NVi = species.isSet("momentum")
+      ? toFieldAligned(getNoBoundary<Field3D>(species["momentum"]))
+      : Mi * Ni * Vi;
 
     // Energy source will be modified in the domain
     Field3D energy_source = species.isSet("energy_source")
-                                ? getNonFinal<Field3D>(species["energy_source"])
-                                : 0.0;
+      ? toFieldAligned(getNonFinal<Field3D>(species["energy_source"]))
+      : zeroFrom(Ni);
 
     if (lower_y) {
       for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
@@ -533,16 +539,16 @@ void SheathBoundarySimple::transform(Options& state) {
 
     // Finished boundary conditions for this species
     // Put the modified fields back into the state.
-    setBoundary(species["density"], Ni);
-    setBoundary(species["temperature"], Ti);
-    setBoundary(species["pressure"], Pi);
+    setBoundary(species["density"], fromFieldAligned(Ni));
+    setBoundary(species["temperature"], fromFieldAligned(Ti));
+    setBoundary(species["pressure"], fromFieldAligned(Pi));
 
     if (species.isSet("velocity")) {
-      setBoundary(species["velocity"], Vi);
+      setBoundary(species["velocity"], fromFieldAligned(Vi));
     }
 
     if (species.isSet("momentum")) {
-      setBoundary(species["momentum"], NVi);
+      setBoundary(species["momentum"], fromFieldAligned(NVi));
     }
 
     // Additional loss of energy through sheath

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -369,7 +369,7 @@ void SheathBoundarySimple::transform(Options& state) {
   setBoundary(electrons["pressure"], Pe);
 
   // Set energy source (negative in cell next to sheath)
-  set(electrons["energy_source"], electron_energy_source);
+  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (electrons.isSet("velocity")) {
     setBoundary(electrons["velocity"], Ve);
@@ -538,6 +538,6 @@ void SheathBoundarySimple::transform(Options& state) {
     }
 
     // Additional loss of energy through sheath
-    set(species["energy_source"], energy_source);
+    add(species["energy_source"], fromFieldAligned(energy_source));
   }
 }


### PR DESCRIPTION
- `sheath_boundary_simple` was ok for 1D simulations without electric fields, but needed fixes to work correctly in 3D (to/fromFieldAligned) and with electric fields & currents (setting electron momentum)
- Sheath energy losses should be added to other terms if already set, rather than replacing. 

Should probably make `set` throw an exception if the value has already been set, and add an `overwrite` function.