### PR TITLE
Vorticity get sound_speed if dissipation enabled

### DIFF
--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -567,17 +567,16 @@ void Vorticity::finally(const Options &state) {
     ddt(Vort) += Div_par((Z / A) * NV);
   }
 
-  if (state.isSet("sound_speed")) {
+  if (vort_dissipation) {
+    // Adds dissipation term like in other equations
     Field3D sound_speed = get<Field3D>(state["sound_speed"]);
-    if (vort_dissipation) {
-      // Adds dissipation term like in other equations
-      ddt(Vort) -= FV::Div_par(Vort, 0.0, sound_speed);
-    }
+    ddt(Vort) -= FV::Div_par(Vort, 0.0, sound_speed);
+  }
 
-    if (phi_dissipation) {
-      // Adds dissipation term like in other equations, but depending on gradient of potential
-      ddt(Vort) -= FV::Div_par(-phi, 0.0, sound_speed);
-    }
+  if (phi_dissipation) {
+    // Adds dissipation term like in other equations, but depending on gradient of potential
+    Field3D sound_speed = get<Field3D>(state["sound_speed"]);
+    ddt(Vort) -= FV::Div_par(-phi, 0.0, sound_speed);
   }
 
   if (hyper_z > 0) {

--- a/tests/integrated/vorticity/data/BOUT.inp
+++ b/tests/integrated/vorticity/data/BOUT.inp
@@ -29,6 +29,7 @@ average_atomic_mass = 2 # Weighted average atomic mass, for polarisaion current
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false # Split phi into n=0 and n!=0 components
+phi_dissipation = false # Add parallel dissipation (default is true)
 
 [Vort]
 function = exp(-((x-0.5)^2 + (mesh:zn - 0.5)^2)/(0.2^2))


### PR DESCRIPTION
Previously these terms would be silently disabled if sound_speed was not available. Now if `phi_dissipation` or `vort_dissipation` is enabled and `sound_speed` is not available then an error should occur.