### PR TITLE
Adding hydrogen CX diagnostics

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -691,6 +691,21 @@ twice.
 When reactions are added, all the species involved must be included, or an exception
 should be thrown.
 
+Notes:
+
+1. Charge exchange channel diagnostics: For two species `a` and `b`,
+   the channel `Fab_cx` is a source of momentum for species `a` due to
+   charge exchange with species `b`. There are corresponding sinks for
+   the products of the charge exchange reaction which are not saved.
+
+   For example,reaction `d + t+ -> d+ + t` will save the following
+   forces (momentum sources):
+   - `Fdt+_cx` is a source of momentum for deuterium atoms `d` and sink of momentum for deuterium ions `d+`.
+   - `Ft+d_cx` is a source of momentum for tritium ions `t+` and sink of momentum for tritium atoms `t`
+
+   The reason for this convention is the existence of the inverse reactions:
+   `t + d+ -> t+ + d` outputs diagnostics `Ftd+_cx` and `Fd+t_cx`.
+
 Hydrogen
 ~~~~~~~~
 

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -52,7 +52,15 @@ protected:
   ///   - momentum_source
   ///   - energy_source
   ///
-  void calculate_rates(Options& atom1, Options& ion1, Options& atom2, Options& ion2);
+  /// Diagnostic output
+  ///  R            Reaction rate, transfer of particles in case of different isotopes
+  ///  atom_mom     Momentum removed from atom1, added to ion2
+  ///  ion_mom      Momentum removed from ion1, added to atom2
+  ///  atom_energy  Energy removed from atom1, added to ion2
+  ///  ion_energy   Energy removed from ion1, added to atom2
+  ///
+  void calculate_rates(Options& atom1, Options& ion1, Options& atom2, Options& ion2,
+                       Field3D &R, Field3D &atom_mom, Field3D &ion_mom, Field3D &atom_energy, Field3D &ion_energy);
 };
 
 /// Hydrogen charge exchange
@@ -60,17 +68,93 @@ protected:
 ///
 /// @tparam Isotope1   The isotope ('h', 'd' or 't') of the initial atom
 /// @tparam Isotope2   The isotope ('h', 'd' or 't') of the initial ion
+///
+///   atom   +   ion     ->   ion      +    atom
+/// Isotope1 + Isotope2+ -> Isotope1+  +  Isotope2
+///
+/// Diagnostics
+/// -----------
+///
+/// If diagnose = true is set in the options, then the following diagnostics are saved:
+///   - F<Isotope1><Isotope2>+_cx  (e.g. Fhd+_cx) the momentum added to Isotope1 atoms due
+///                                due to charge exchange with Isotope2 ions.
+///                                There is a corresponding loss of momentum for the Isotope1 ions
+///                                d/dt(NVh)  = ... + Fhd+_cx   // Atom momentum source
+///                                d/dt(NVh+) = ... - Fhd+_cx   // Ion momentum sink
+///   - E<Isotope1><Isotope2>+_cx  Energy added to Isotope1 atoms due to charge exchange with
+///                                Isotope2 ions. This contributes to two pressure equations
+///                                d/dt(3/2 Ph)  = ... + Ehd+_cx
+///                                d/dt(3/2 Ph+) = ... - Ehd+_cx
+///
+/// If Isotope1 != Isotope2 then there is also the source of energy for Isotope2 atoms
+/// and a source of particles:
+///   - F<Isotope2>+<Isotope1>_cx  Source of momentum for Isotope2 ions, sink for Isotope2 atoms
+///   - E<Isotope2>+<Isotope1>_cx  Source of energy for Isotope2 ions, sink for Isotope2 atoms
+///   - S<Isotope1><Isotope2>+_cx  Source of Isotope1 atoms due to charge exchange with Isotope2 ions
+///                                Note: S<Isotope2><Isotope1>+_cx = -S<Isotope1><Isotope2>+_cx
+///                                For example Shd+_cx contributes to four density equations:
+///                                d/dt(Nh)  = ... + Shd+_cx
+///                                d/dt(Nh+) = ... - Shd+_cx
+///                                d/dt(Nd)  = ... - Shd+_cx
+///                                d/dt(Nd+) = ... + Shd+_cx
+///
 template <char Isotope1, char Isotope2>
 struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
   HydrogenChargeExchangeIsotope(std::string name, Options& alloptions, Solver* solver)
-      : HydrogenChargeExchange(name, alloptions, solver) {}
+      : HydrogenChargeExchange(name, alloptions, solver) {
+
+    diagnose = alloptions[name]["diagnose"]
+      .doc("Output additional diagnostics?")
+      .withDefault<bool>(false);
+    if (diagnose) {
+      // Save particle, momentum and energy channels
+
+      bout::globals::dump.addRepeat(F, {'F', Isotope1, Isotope2, '+', '_', 'c', 'x'}); // e.g Fhd+_cx
+      bout::globals::dump.addRepeat(E, {'E', Isotope1, Isotope2, '+', '_', 'c', 'x'}); // e.g Edt+_cx
+      if (Isotope1 != Isotope2) {
+        // Different isotope => particle source, second momentum & energy channel
+        bout::globals::dump.addRepeat(F2, {'F', Isotope2, '+', Isotope1, '_', 'c', 'x'}); // e.g Fdh+_cx
+        bout::globals::dump.addRepeat(E2, {'E', Isotope2, '+', Isotope1, '_', 'c', 'x'}); // e.g Etd+_cx
+
+        // Source of isotope1 atoms
+        bout::globals::dump.addRepeat(S, {'S', Isotope1, Isotope2, '+', '_', 'c', 'x'}); // e.g Shd+_cx
+      }
+    }
+  }
 
   void transform(Options& state) override {
+    Field3D R, atom_mom, ion_mom, atom_energy, ion_energy;
+
     calculate_rates(state["species"][{Isotope1}],       // e.g. "h"
                     state["species"][{Isotope2, '+'}],  // e.g. "d+"
                     state["species"][{Isotope2}],       // e.g. "d"
-                    state["species"][{Isotope1, '+'}]); // e.g. "h+"
+                    state["species"][{Isotope1, '+'}],  // e.g. "h+"
+                    R, atom_mom, ion_mom, atom_energy, ion_energy); // Transfer channels
+
+    if (diagnose) {
+      // Calculate diagnostics to be written to dump file
+      if (Isotope1 == Isotope2) {
+        // Simpler case of same isotopes
+        //  - No net particle source/sink
+        //  - atoms lose atom_mom, gain ion_mom 
+        //
+        F = ion_mom - atom_mom; // Momentum transferred to atoms due to CX with ions
+        E = ion_energy - atom_energy; // Energy transferred to atoms
+      } else {
+        // Different isotopes 
+        S = -R; // Source of Isotope1 atoms
+        F = -atom_mom; // Source of momentum for Isotope1 atoms
+        F2 = -ion_mom;  // Source of momentum for Isotope2 ions
+        E = -atom_energy; // Source of energy for Isotope1 atoms
+        E2 = -ion_energy; // Source of energy for Isotope2 ions
+      }
+    }
   }
+private:
+  bool diagnose; ///< Outputting diagnostics?
+  Field3D S; ///< Particle exchange, used if Isotope1 != Isotope2
+  Field3D F, F2; ///< Momentum exchange
+  Field3D E, E2; ///< Energy exchange
 };
 
 namespace {

--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -1,7 +1,10 @@
 #include "../include/hydrogen_charge_exchange.hxx"
 
 void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
-                                             Options& atom2, Options& ion2) {
+                                             Options& atom2, Options& ion2,
+                                             Field3D &R,
+                                             Field3D &atom_mom, Field3D &ion_mom,
+                                             Field3D &atom_energy, Field3D &ion_energy) {
 
   // Temperatures and masses of initial atom and ion
   const Field3D Tatom = get<Field3D>(atom1["temperature"]);
@@ -33,7 +36,7 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   const Field3D Natom = floor(get<Field3D>(atom1["density"]), 1e-5);
   const Field3D Nion = floor(get<Field3D>(ion1["density"]), 1e-5);
 
-  const Field3D R = Natom * Nion * sigmav; // Rate coefficient
+  R = Natom * Nion * sigmav; // Rate coefficient. This is an output parameter.
 
   if ((&atom1 != &atom2) or (&ion1 != &ion2)) {
     // Transfer particles atom1 -> ion2, ion1 -> atom2
@@ -44,20 +47,20 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   } // Skip the case where the same isotope swaps places
 
   // Transfer momentum
-  const Field3D atom_mom = R * get<Field3D>(atom1["velocity"]);
+  atom_mom = R * get<Field3D>(atom1["velocity"]);
   subtract(atom1["momentum_source"], atom_mom);
   add(ion2["momentum_source"], atom_mom);
 
-  const Field3D ion_mom = R * get<Field3D>(ion1["velocity"]);
+  ion_mom = R * get<Field3D>(ion1["velocity"]);
   subtract(ion1["momentum_source"], ion_mom);
   add(atom2["momentum_source"], ion_mom);
 
   // Transfer energy
-  const Field3D atom_energy = (3. / 2) * R * Tatom;
+  atom_energy = (3. / 2) * R * Tatom;
   subtract(atom1["energy_source"], atom_energy);
   add(ion2["energy_source"], atom_energy);
 
-  const Field3D ion_energy = (3. / 2) * R * Tion;
+  ion_energy = (3. / 2) * R * Tion;
   subtract(ion1["energy_source"], ion_energy);
   add(atom2["energy_source"], ion_energy);
 }


### PR DESCRIPTION
Need to be a bit careful with naming of sources/sinks when there are multiple isotopes.

For two species `a` and `b`, the channel `Fab_cx` is a source of momentum for species `a` due to charge exchange with species `b`. There are corresponding sinks for the products of the charge exchange reaction which are not saved. 

For example: 
Reaction `d + t+ -> d+ + t` will save the following forces (momentum sources):
- `Fdt+_cx` is a source of momentum for deuterium atoms `d` and sink of momentum for deuterium ions `d+`.
- `Ft+d_cx` is a source of momentum for tritium ions `t+` and sink of momentum for tritium atoms `t`

The reason for this convention is the existence of the inverse reactions:
`t + d+ -> t+ + d` outputs diagnostics `Ftd+_cx` and `Fd+t_cx`.