### PR TITLE
Some important fixes

### DIFF
--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -246,7 +246,7 @@ void EvolvePressure::finally(const Options& state) {
 
   if (species.isSet("density_source") and species.isSet("velocity")) {
     // Change in balance between kinetic & thermal energy due to particle source
-    auto Sn = get<Field3D>(species["energy_source"]);
+    auto Sn = get<Field3D>(species["density_source"]);
     auto V = get<Field3D>(species["velocity"]);
     auto AA = get<BoutReal>(species["AA"]);
     ddt(P) += Sn * 0.5 * AA * N * SQ(V);

--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -60,4 +60,8 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   const Field3D ion_energy = (3. / 2) * R * Tion;
   subtract(ion1["energy_source"], ion_energy);
   add(atom2["energy_source"], ion_energy);
+
+  // Update collision frequency for the two colliding species
+  add(atom1["collision_frequency"], Nion * sigmav);
+  add(ion1["collision_frequency"], Natom * sigmav);
 }


### PR DESCRIPTION
1. Add charge exchange to collision frequency. This is important for neutral diffusion.
2. Correct copy/paste error in pressure correction for particle sources and flow velocity: `energy_source` was used rather than `density_source`.
