### PR TITLE
Atomic diagnostics

### DIFF
--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -12,11 +12,13 @@ struct AmjuelHeIonisation01 : public AmjuelReaction {
   AmjuelHeIonisation01(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& state, Field3D &reaction_rate);
+  void calculate_rates(Options& state, 
+                        Field3D &reaction_rate, Field3D &momentum_exchange,
+                        Field3D &energy_exchange, Field3D &energy_loss);
 
   void transform(Options& state) override{
-    Field3D reaction_rate;
-    calculate_rates(state, reaction_rate);
+    Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
   };
 };
 
@@ -29,11 +31,13 @@ struct AmjuelHeRecombination10 : public AmjuelReaction {
   AmjuelHeRecombination10(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& state, Field3D &reaction_rate);
+  void calculate_rates(Options& state, 
+                      Field3D &reaction_rate, Field3D &momentum_exchange,
+                      Field3D &energy_exchange, Field3D &energy_loss);
 
   void transform(Options& state) override{
-    Field3D reaction_rate;
-    calculate_rates(state, reaction_rate);
+    Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
   };
 };
 

--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -4,6 +4,7 @@
 
 #include "amjuel_reaction.hxx"
 
+
 /// e + he -> he+ + 2e
 /// Amjuel reaction 2.3.9a, page 161
 /// Not resolving metastables, only transporting ground state
@@ -11,8 +12,11 @@ struct AmjuelHeIonisation01 : public AmjuelReaction {
   AmjuelHeIonisation01(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
+  void calculate_rates(Options& state, Field3D &reaction_rate);
+
   void transform(Options& state) override{
     Field3D reaction_rate;
+    calculate_rates(state, reaction_rate);
   };
 };
 
@@ -25,8 +29,11 @@ struct AmjuelHeRecombination10 : public AmjuelReaction {
   AmjuelHeRecombination10(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
+  void calculate_rates(Options& state, Field3D &reaction_rate);
+
   void transform(Options& state) override{
     Field3D reaction_rate;
+    calculate_rates(state, reaction_rate);
   };
 };
 

--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -11,7 +11,9 @@ struct AmjuelHeIonisation01 : public AmjuelReaction {
   AmjuelHeIonisation01(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void transform(Options& state) override;
+  void transform(Options& state) override{
+    Field3D reaction_rate;
+  };
 };
 
 
@@ -23,7 +25,9 @@ struct AmjuelHeRecombination10 : public AmjuelReaction {
   AmjuelHeRecombination10(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void transform(Options& state) override;
+  void transform(Options& state) override{
+    Field3D reaction_rate;
+  };
 };
 
 

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -17,7 +17,20 @@ struct AmjuelHydIonisation : public AmjuelReaction {
 template <char Isotope>
 struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
   AmjuelHydIonisationIsotope(std::string name, Options& alloptions, Solver* solver)
-      : AmjuelHydIonisation(name, alloptions, solver) {}
+      : AmjuelHydIonisation(name, alloptions, solver) {
+
+    diagnose = alloptions[name]["diagnose"]
+      .doc("Output additional diagnostics?")
+      .withDefault<bool>(false);
+
+    if (diagnose) {
+      // Save particle, momentum and energy channels
+
+      bout::globals::dump.addRepeat(S, {"Sd+_iz"}); // Particle source
+    }
+
+
+  }
 
   void transform(Options& state) override {
     Options& electron = state["species"]["e"];

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -28,10 +28,10 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     if (diagnose) {
       // Save particle, momentum and energy channels
 
-      bout::globals::dump.addRepeat(S, {"Sd+_iz"}); // Particle source
-      bout::globals::dump.addRepeat(F, {"Fd+_iz"}); // Momentum exchange
-      bout::globals::dump.addRepeat(E, {"Ed+_iz"}); // Energy exchange
-      bout::globals::dump.addRepeat(R, {"Rd+_ex"}); // Radiation loss
+      bout::globals::dump.addRepeat(S, {'S', Isotope, '+', '_', 'i', 'z'}); // Particle source
+      bout::globals::dump.addRepeat(F, {'F', Isotope, '+', '_', 'i', 'z'}); // Momentum exchange
+      bout::globals::dump.addRepeat(E, {'E', Isotope, '+', '_', 'i', 'z'}); // Energy exchange
+      bout::globals::dump.addRepeat(R, {'R', Isotope, '+', '_', 'e', 'x'}); // Radiation loss
     }
 
 

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -9,7 +9,7 @@ struct AmjuelHydIonisation : public AmjuelReaction {
   AmjuelHydIonisation(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& electron, Options& atom, Options& ion);
+  void calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate);
 };
 
 /// Hydrogen ionisation
@@ -23,9 +23,20 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     Options& electron = state["species"]["e"];
     Options& atom = state["species"][{Isotope}];     // e.g. "h"
     Options& ion = state["species"][{Isotope, '+'}]; // e.g. "h+"
+    Field3D reaction_rate;
 
-    calculate_rates(electron, atom, ion);
+    calculate_rates(electron, atom, ion, reaction_rate);
+
+    if (diagnose) {
+      S = reaction_rate;
+    }
   }
+private:
+  bool diagnose; ///< Outputting diagnostics?
+  Field3D S; ///< Particle exchange
+  Field3D F; ///< Momentum exchange
+  Field3D E; ///< Energy exchange
+  Field3D R; ///< Radiation loss
 };
 
 namespace {

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -49,7 +49,7 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
       S = reaction_rate;
       F = momentum_exchange;
       E = energy_exchange;
-      R = energy_loss;
+      R = -energy_loss;
     }
   }
 private:

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -29,6 +29,9 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
       // Save particle, momentum and energy channels
 
       bout::globals::dump.addRepeat(S, {"Sd+_iz"}); // Particle source
+      bout::globals::dump.addRepeat(F, {"Fd+_iz"}); // Momentum exchange
+      bout::globals::dump.addRepeat(E, {"Ed+_iz"}); // Energy exchange
+      bout::globals::dump.addRepeat(R, {"Rd+_ex"}); // Radiation loss
     }
 
 
@@ -44,6 +47,9 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
 
     if (diagnose) {
       S = reaction_rate;
+      F = momentum_exchange;
+      E = energy_exchange;
+      R = energy_loss;
     }
   }
 private:

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -9,7 +9,9 @@ struct AmjuelHydIonisation : public AmjuelReaction {
   AmjuelHydIonisation(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate);
+  void calculate_rates(Options& electron, Options& atom, Options& ion, 
+                        Field3D &reaction_rate, Field3D &momentum_exchange,
+                        Field3D &energy_exchange, Field3D &energy_loss);
 };
 
 /// Hydrogen ionisation
@@ -36,9 +38,9 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     Options& electron = state["species"]["e"];
     Options& atom = state["species"][{Isotope}];     // e.g. "h"
     Options& ion = state["species"][{Isotope, '+'}]; // e.g. "h+"
-    Field3D reaction_rate;
+    Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
-    calculate_rates(electron, atom, ion, reaction_rate);
+    calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
 
     if (diagnose) {
       S = reaction_rate;

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -30,10 +30,10 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     if (diagnose) {
       // Save particle, momentum and energy channels
 
-      bout::globals::dump.addRepeat(S, {"Sd+_rec"}); // Particle source
-      bout::globals::dump.addRepeat(F, {"Fd+_rec"}); // Momentum exchange
-      bout::globals::dump.addRepeat(E, {"Ed+_rec"}); // Energy exchange
-      bout::globals::dump.addRepeat(R, {"Rd+_rec"}); // Radiation loss
+      bout::globals::dump.addRepeat(S, {'S', Isotope, '+', '_', 'r', 'e', 'c'}); // Particle source
+      bout::globals::dump.addRepeat(F, {'F', Isotope, '+', '_', 'r', 'e', 'c'}); // Momentum exchange
+      bout::globals::dump.addRepeat(E, {'E', Isotope, '+', '_', 'r', 'e', 'c'}); // Energy exchange
+      bout::globals::dump.addRepeat(R, {'R', Isotope, '+', '_', 'r', 'e', 'c'}); // Radiation loss
       }
     
     

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -48,10 +48,10 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
 
     if (diagnose) {
-      S = reaction_rate;
-      F = momentum_exchange;
-      E = energy_exchange;
-      R = energy_loss;
+      S = -reaction_rate;
+      F = -momentum_exchange;
+      E = -energy_exchange;
+      R = -energy_loss;
     }
   }
 private:

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -11,7 +11,7 @@ struct AmjuelHydRecombination : public AmjuelReaction {
   AmjuelHydRecombination(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& electron, Options& atom, Options& ion);
+  void calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate);
 };
 
 /// Hydrogen recombination
@@ -25,8 +25,9 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     Options& electron = state["species"]["e"];
     Options& atom = state["species"][{Isotope}];     // e.g. "h"
     Options& ion = state["species"][{Isotope, '+'}]; // e.g. "h+"
+    Field3D reaction_rate;
 
-    calculate_rates(electron, atom, ion);
+    calculate_rates(electron, atom, ion, reaction_rate);
   }
 };
 

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -11,7 +11,9 @@ struct AmjuelHydRecombination : public AmjuelReaction {
   AmjuelHydRecombination(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {}
 
-  void calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate);
+  void calculate_rates(Options& electron, Options& atom, Options& ion,
+                        Field3D &reaction_rate, Field3D &momentum_exchange,
+                        Field3D &energy_exchange, Field3D &energy_loss);
 };
 
 /// Hydrogen recombination
@@ -20,14 +22,14 @@ template <char Isotope>
 struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
   AmjuelHydRecombinationIsotope(std::string name, Options& alloptions, Solver* solver)
       : AmjuelHydRecombination(name, alloptions, solver) {}
-
+  
   void transform(Options& state) override {
     Options& electron = state["species"]["e"];
     Options& atom = state["species"][{Isotope}];     // e.g. "h"
     Options& ion = state["species"][{Isotope, '+'}]; // e.g. "h+"
-    Field3D reaction_rate;
+    Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
-    calculate_rates(electron, atom, ion, reaction_rate);
+    calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
   }
 };
 

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -96,6 +96,7 @@ protected:
         Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te);
 
     // Particles
+    // For ionisation, "from_ion" is the neutral and "to_ion" is the ion
     subtract(from_ion["density_source"], reaction_rate);
     add(to_ion["density_source"], reaction_rate);
 

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -68,7 +68,8 @@ protected:
   void electron_reaction(Options& electron, Options& from_ion, Options& to_ion,
                          const BoutReal (&rate_coefs)[rows][cols],
                          const BoutReal (&radiation_coefs)[rows][cols],
-                         BoutReal electron_heating) {
+                         BoutReal electron_heating,
+                         Field3D &reaction_rate) {
     Field3D Ne = get<Field3D>(electron["density"]);
     Field3D Te = get<Field3D>(electron["temperature"]);
 
@@ -84,7 +85,7 @@ protected:
     const BoutReal to_charge =
         to_ion.isSet("charge") ? get<BoutReal>(to_ion["charge"]) : 0.0;
 
-    Field3D reaction_rate = cellAverage(
+    reaction_rate = cellAverage(
         [&](BoutReal ne, BoutReal n1, BoutReal te) {
           return ne * n1 * evaluate(rate_coefs, te * Tnorm, ne * Nnorm) * Nnorm
                  / FreqNorm;

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -69,7 +69,10 @@ protected:
                          const BoutReal (&rate_coefs)[rows][cols],
                          const BoutReal (&radiation_coefs)[rows][cols],
                          BoutReal electron_heating,
-                         Field3D &reaction_rate) {
+                         Field3D &reaction_rate,
+                         Field3D &momentum_exchange,
+                         Field3D &energy_exchange,
+                         Field3D &energy_loss) {
     Field3D Ne = get<Field3D>(electron["density"]);
     Field3D Te = get<Field3D>(electron["temperature"]);
 
@@ -102,18 +105,18 @@ protected:
     }
 
     // Momentum
-    Field3D momentum_exchange = reaction_rate * AA * V1;
+    momentum_exchange = reaction_rate * AA * V1;
 
     subtract(from_ion["momentum_source"], momentum_exchange);
     add(to_ion["momentum_source"], momentum_exchange);
 
     // Ion energy
-    Field3D energy_exchange = reaction_rate * (3. / 2) * T1;
+    energy_exchange = reaction_rate * (3. / 2) * T1;
     subtract(from_ion["energy_source"], energy_exchange);
     add(to_ion["energy_source"], energy_exchange);
 
     // Electron energy loss (radiation, ionisation potential)
-    Field3D energy_loss = cellAverage(
+    energy_loss = cellAverage(
         [&](BoutReal ne, BoutReal n1, BoutReal te) {
           return ne * n1 * evaluate(radiation_coefs, te * Tnorm, ne * Nnorm) * Nnorm
                  / (Tnorm * FreqNorm);

--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -66,13 +66,15 @@ static constexpr const BoutReal he01_radiation_coefs[9][9] = {
      2.60719149454e-09, -2.870919514967e-10, 8.059675146168e-12, 3.704316808942e-13,
      -1.713225271579e-14}};
 
-void AmjuelHeIonisation01::calculate_rates(Options& state, Field3D &reaction_rate) {
+void AmjuelHeIonisation01::calculate_rates(Options& state, 
+                                          Field3D &reaction_rate, Field3D &momentum_exchange,
+                                          Field3D &energy_exchange, Field3D &energy_loss) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he"],  // From helium atoms
                     state["species"]["he+"], // To helium ions
                     he01_rate_coefs, he01_radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs,
-                    reaction_rate
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
 
   );
 }
@@ -143,12 +145,14 @@ static constexpr const BoutReal he10_radiation_coefs[9][9] = {
      -5.086412415216e-09, 3.674153797642e-10, -1.621809988343e-11, 6.737654534264e-13,
      -1.678705755876e-14}};
 
-void AmjuelHeRecombination10::calculate_rates(Options& state, Field3D &reaction_rate) {
+void AmjuelHeRecombination10::calculate_rates(Options& state, 
+                                              Field3D &reaction_rate, Field3D &momentum_exchange,
+                                              Field3D &energy_exchange, Field3D &energy_loss) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms
                     he10_rate_coefs, he10_radiation_coefs,
                     24.586, // Ionisation potential heating of electrons
-                    reaction_rate
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
   );
 }

--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -66,12 +66,14 @@ static constexpr const BoutReal he01_radiation_coefs[9][9] = {
      2.60719149454e-09, -2.870919514967e-10, 8.059675146168e-12, 3.704316808942e-13,
      -1.713225271579e-14}};
 
-void AmjuelHeIonisation01::transform(Options& state) {
+void AmjuelHeIonisation01::transform(Options& state, Field3D &reaction_rate) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he"],  // From helium atoms
                     state["species"]["he+"], // To helium ions
                     he01_rate_coefs, he01_radiation_coefs,
-                    0.0 // Note: Ionisation potential included in radiation_coefs
+                    0.0, // Note: Ionisation potential included in radiation_coefs,
+                    reaction_rate
+
   );
 }
 
@@ -141,11 +143,12 @@ static constexpr const BoutReal he10_radiation_coefs[9][9] = {
      -5.086412415216e-09, 3.674153797642e-10, -1.621809988343e-11, 6.737654534264e-13,
      -1.678705755876e-14}};
 
-void AmjuelHeRecombination10::transform(Options& state) {
+void AmjuelHeRecombination10::transform(Options& state, Field3D &reaction_rate) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms
                     he10_rate_coefs, he10_radiation_coefs,
-                    24.586 // Ionisation potential heating of electrons
+                    24.586, // Ionisation potential heating of electrons
+                    reaction_rate
   );
 }

--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -66,7 +66,7 @@ static constexpr const BoutReal he01_radiation_coefs[9][9] = {
      2.60719149454e-09, -2.870919514967e-10, 8.059675146168e-12, 3.704316808942e-13,
      -1.713225271579e-14}};
 
-void AmjuelHeIonisation01::transform(Options& state, Field3D &reaction_rate) {
+void AmjuelHeIonisation01::calculate_rates(Options& state, Field3D &reaction_rate) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he"],  // From helium atoms
                     state["species"]["he+"], // To helium ions
@@ -143,7 +143,7 @@ static constexpr const BoutReal he10_radiation_coefs[9][9] = {
      -5.086412415216e-09, 3.674153797642e-10, -1.621809988343e-11, 6.737654534264e-13,
      -1.678705755876e-14}};
 
-void AmjuelHeRecombination10::transform(Options& state, Field3D &reaction_rate) {
+void AmjuelHeRecombination10::calculate_rates(Options& state, Field3D &reaction_rate) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms

--- a/src/amjuel_hyd_ionisation.cxx
+++ b/src/amjuel_hyd_ionisation.cxx
@@ -65,9 +65,11 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
      1.734769090475e-15}};
 
 void AmjuelHydIonisation::calculate_rates(
-  Options& electron, Options& atom, Options& ion, Field3D &reaction_rate) {
+  Options& electron, Options& atom, Options& ion, 
+  Field3D &reaction_rate, Field3D &momentum_exchange,
+  Field3D &energy_exchange, Field3D &energy_loss) {
   electron_reaction(electron, atom, ion, rate_coefs, radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs
-                    reaction_rate
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
   );
 }

--- a/src/amjuel_hyd_ionisation.cxx
+++ b/src/amjuel_hyd_ionisation.cxx
@@ -64,8 +64,10 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
      -1.512777532459e-09, 8.733801272834e-11, 7.196798841269e-13, -1.441033650378e-13,
      1.734769090475e-15}};
 
-void AmjuelHydIonisation::calculate_rates(Options& electron, Options& atom, Options& ion) {
+void AmjuelHydIonisation::calculate_rates(
+  Options& electron, Options& atom, Options& ion, Field3D &reaction_rate) {
   electron_reaction(electron, atom, ion, rate_coefs, radiation_coefs,
-                    0.0 // Note: Ionisation potential included in radiation_coefs
+                    0.0, // Note: Ionisation potential included in radiation_coefs
+                    reaction_rate
   );
 }

--- a/src/amjuel_hyd_recombination.cxx
+++ b/src/amjuel_hyd_recombination.cxx
@@ -64,8 +64,9 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
      -1.146485227699e-08, 6.772338917155e-10, -1.776496344763e-11, 7.199195061382e-14,
      3.929300283002e-15}};
 
-void AmjuelHydRecombination::calculate_rates(Options& electron, Options& atom, Options& ion) {
+void AmjuelHydRecombination::calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate) {
   electron_reaction(electron, ion, atom, rate_coefs, radiation_coefs,
-                    13.6 // Potential energy loss [eV] heats electrons
+                    13.6, // Potential energy loss [eV] heats electrons
+                    reaction_rate
   );
 }

--- a/src/amjuel_hyd_recombination.cxx
+++ b/src/amjuel_hyd_recombination.cxx
@@ -64,9 +64,12 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
      -1.146485227699e-08, 6.772338917155e-10, -1.776496344763e-11, 7.199195061382e-14,
      3.929300283002e-15}};
 
-void AmjuelHydRecombination::calculate_rates(Options& electron, Options& atom, Options& ion, Field3D &reaction_rate) {
+void AmjuelHydRecombination::calculate_rates(
+  Options& electron, Options& atom, Options& ion, 
+  Field3D &reaction_rate, Field3D &momentum_exchange,
+  Field3D &energy_exchange, Field3D &energy_loss) {
   electron_reaction(electron, ion, atom, rate_coefs, radiation_coefs,
                     13.6, // Potential energy loss [eV] heats electrons
-                    reaction_rate
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
   );
 }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -70,6 +70,7 @@ EvolveDensity::EvolveDensity(std::string name, Options &alloptions, Solver *solv
           .withDefault<bool>(false)) {
     bout::globals::dump.addRepeat(ddt(N), std::string("ddt(N") + name + std::string(")"));
     bout::globals::dump.addRepeat(Sn, std::string("SN") + name);
+    bout::globals::dump.addRepeat(source, std::string("S") + name + std::string("_src"));
     Sn = 0.0;
   }
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -75,7 +75,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
       bout::globals::dump.addRepeat(kappa_par, std::string("kappa_par_") + name);
     }
     bout::globals::dump.addRepeat(T, std::string("T") + name);
-
+    bout::globals::dump.addRepeat(source, std::string("E") + name + std::string("_src"));
     bout::globals::dump.addRepeat(ddt(P), std::string("ddt(P") + name + std::string(")"));
     bout::globals::dump.addRepeat(Sp, std::string("SP") + name);
     Sp = 0.0;

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -75,7 +75,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
       bout::globals::dump.addRepeat(kappa_par, std::string("kappa_par_") + name);
     }
     bout::globals::dump.addRepeat(T, std::string("T") + name);
-    bout::globals::dump.addRepeat(source, std::string("E") + name + std::string("_src"));
+    bout::globals::dump.addRepeat(source, std::string("P") + name + std::string("_src"));
     bout::globals::dump.addRepeat(ddt(P), std::string("ddt(P") + name + std::string(")"));
     bout::globals::dump.addRepeat(Sp, std::string("SP") + name);
     Sp = 0.0;


### PR DESCRIPTION
Add new diagnose variables S, E, F and R covering particle source, energy transfer, momentum transfer and radiation loss for hydrogenic ionisation and recombination. This does not cover the He reactions but can be easily extended to do so (I think).

Variable names are in the pattern "Sd+_iz", "Fd+_rec" and so on. There is one variable which is an odd one out - "Rd+_ex". The "ex" is there to maintain consistency with Hermes-2 and SD1D, where Riz is specifically the 13.6eV ionisation cost and Rex the remaining radiative losses. Welcome comments on whether this is good or whether it adds more confusion...

The modifications compile and the variables are saved and look plausible at first glance. I will test each of them to make sure it makes sense before upgrading this to a pull request.

