### PR TITLE
Ensure CX momentum has AA factor

### DIFF
--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -44,11 +44,11 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   } // Skip the case where the same isotope swaps places
 
   // Transfer momentum
-  const Field3D atom_mom = R * get<Field3D>(atom1["velocity"]);
+  const Field3D atom_mom = R * Aatom * get<Field3D>(atom1["velocity"]);
   subtract(atom1["momentum_source"], atom_mom);
   add(ion2["momentum_source"], atom_mom);
 
-  const Field3D ion_mom = R * get<Field3D>(ion1["velocity"]);
+  const Field3D ion_mom = R * Aion * get<Field3D>(ion1["velocity"]);
   subtract(ion1["momentum_source"], ion_mom);
   add(atom2["momentum_source"], ion_mom);
 


### PR DESCRIPTION
In SD1D (and potentially Hermes-2) the atomic mass AA is hard-coded in the velocity normalisation Omega_ci. This makes it difficult if we want the code to support different species (or isotopes of a species). This means in Hermes-3 AA is taken out of Omega_ci and must be accounted for explicitly. 

This was done correctly for the amjuel_reaction.hxx modules which cover ionisation, recombination and excitation:
https://github.com/bendudson/hermes-3/blob/e5d86cdc9dde3559ea38a5d63dbbb8b03f2acdd0/include/amjuel_reaction.hxx#L104

However the AA factor was missing in the momentum exchange term for the charge exchange. This pull request fixes this.