### PR TITLE
Fix energy source/sink setting in sheath  boundary conditions

### DIFF
--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -402,7 +402,8 @@ void SheathBoundary::transform(Options &state) {
   setBoundary(electrons["pressure"], fromFieldAligned(Pe));
 
   // Add energy source (negative in cell next to sheath)
-  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
+  // Note: already includes previously set sources
+  set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));
@@ -630,6 +631,7 @@ void SheathBoundary::transform(Options &state) {
     }
 
     // Additional loss of energy through sheath
-    add(species["energy_source"], fromFieldAligned(energy_source));
+    // Note: Already includes previously set sources
+    set(species["energy_source"], fromFieldAligned(energy_source));
   }
 }

--- a/src/sheath_boundary_insulating.cxx
+++ b/src/sheath_boundary_insulating.cxx
@@ -425,7 +425,8 @@ void SheathBoundaryInsulating::transform(Options &state) {
     }
 
     // Additional loss of energy through sheath
-    add(species["energy_source"], fromFieldAligned(energy_source));
+    // Note: Already includes any previously set sources
+    set(species["energy_source"], fromFieldAligned(energy_source));
   }
 
   //////////////////////////////////////////////////////////////////
@@ -509,7 +510,7 @@ void SheathBoundaryInsulating::transform(Options &state) {
   }
 
   // Set energy source (negative in cell next to sheath)
-  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
+  set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -377,7 +377,8 @@ void SheathBoundarySimple::transform(Options& state) {
   setBoundary(electrons["pressure"], fromFieldAligned(Pe));
 
   // Set energy source (negative in cell next to sheath)
-  add(electrons["energy_source"], fromFieldAligned(electron_energy_source));
+  // Note: electron_energy_source includes any sources previously set in other components
+  set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));
@@ -560,6 +561,7 @@ void SheathBoundarySimple::transform(Options& state) {
     }
 
     // Additional loss of energy through sheath
-    add(species["energy_source"], fromFieldAligned(energy_source));
+    // Note: energy_source already includes previously set values
+    set(species["energy_source"], fromFieldAligned(energy_source));
   }
 }


### PR DESCRIPTION
If the sheath boundary was set *after* other sources of energy, such as atomic reactions, then the previous code would accidentally double those sources/sinks.

This happened because the sheath boundary conditions would:
1. Get the energy_source
2. Add the sheath contribution to energy_source
3. Add the resulting field to the energy_source in the state

This commit fixes this by replacing step 3 with
3*. Set energy_source in the state to the resulting field