### PR TITLE
Add diagnose option

### DIFF
--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -74,6 +74,9 @@ private:
   bool upper_y; // Boundary on upper y?
 
   bool always_set_phi; ///< Set phi field?
+
+  bool diagnose; // Save additional diagnostics?
+
 };
 
 namespace {

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -95,6 +95,11 @@ SheathBoundarySimple::SheathBoundarySimple(std::string name, Options& alloptions
       options["always_set_phi"]
           .doc("Always set phi field? Default is to only modify if already set")
           .withDefault<bool>(false);
+
+  diagnose = alloptions[name]["diagnose"]
+      .doc("Output additional diagnostics?")
+      .withDefault<bool>(false);
+      
 }
 
 void SheathBoundarySimple::transform(Options& state) {


### PR DESCRIPTION
If we are not expecting a perfect energy balance and don't save the sheath heat flux in the dump file, then there is no way for a user to validate their Python reconstruction of the sheath heat flux code.

This branch aims to save the heat flux for sheath_boundary, sheath_boundary_simple and neutral_boundary for all species involved.

Currently stuck on getting a segmentation fault after adding a diagnose option...