### PR TITLE
Fix bug in sheath_boundary_simple

### DIFF
--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -467,7 +467,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Set boundary conditions on flows
           Vi[im] = 2. * visheath - Vi[i];
-          NVi[im] = 2. * nisheath * visheath - NVi[i];
+          NVi[im] = 2. * Mi * nisheath * visheath - NVi[i];
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
@@ -524,7 +524,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Set boundary conditions on flows
           Vi[ip] = 2. * visheath - Vi[i];
-          NVi[ip] = 2. * nisheath * visheath - NVi[i];
+          NVi[ip] = 2. * Mi * nisheath * visheath - NVi[i];
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath


### PR DESCRIPTION
Thanks @mikekryjak!

This boundary condition was missing a factor of ion atomic mass number in the calculation of the momentum at the sheath. Other sheath boundary components already included this term.

Fixes issue #68 