### PR TITLE
Fix blob2d* examples

### DIFF
--- a/examples/blob2d-te-ti/BOUT.inp
+++ b/examples/blob2d-te-ti/BOUT.inp
@@ -85,6 +85,8 @@ bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
 
+phi_dissipation = false # No parallel dynamics
+
 [sheath_closure]
 connection_length = 10 # meters
 potential_offset = -1.0  # Potential at which sheath current is zero

--- a/examples/blob2d-te/BOUT.inp
+++ b/examples/blob2d-te/BOUT.inp
@@ -64,5 +64,7 @@ bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
 
+phi_dissipation = false # No parallel dynamics
+
 [sheath_closure]
 connection_length = 10 # meters

--- a/examples/blob2d/BOUT.inp
+++ b/examples/blob2d/BOUT.inp
@@ -61,5 +61,7 @@ bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
 
+phi_dissipation = false # No parallel dynamics
+
 [sheath_closure]
 connection_length = 10 # meters


### PR DESCRIPTION
The vorticity component has `phi_dissipation` enabled by default, that requires `sound_speed` to be set. Turning off `phi_dissipation`.