### PR TITLE
Fix tokamak examples

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -41,7 +41,20 @@ evolve_density
 ~~~~~~~~~~~~~~
 
 This component evolves the species density in time, using the BOUT++
-time integration solver.
+time integration solver. The species charge and atomic mass must be set,
+and the initial density should be specified in its own section:
+
+.. code-block:: ini
+
+   [d]
+   type = evolve_density, ...
+
+   AA = 2 # Atomic mass
+   charge = 0
+
+   [Nd]
+   function = 1 - 0.5x # Initial condition, normalised to Nnorm
+
 
 The implementation is in the `EvolveDensity` class:
 

--- a/examples/1D-hydrogen-equalT/BOUT.inp
+++ b/examples/1D-hydrogen-equalT/BOUT.inp
@@ -58,9 +58,10 @@ Tnorm = 100
 
 [solver]
 type = beuler  # Backward Euler steady-state solver
+snes_type = newtonls
 max_nonlinear_iterations = 10
 
-diagnose = true
+diagnose = false # Print diagnostic information?
 
 atol = 1e-7
 rtol = 1e-5

--- a/examples/1D-hydrogen/BOUT.inp
+++ b/examples/1D-hydrogen/BOUT.inp
@@ -57,9 +57,12 @@ Tnorm = 100
 
 [solver]
 type = beuler  # Backward Euler steady-state solver
+
+snes_type = newtonls
+
 max_nonlinear_iterations = 10
 
-diagnose = true
+diagnose = false # Print diagnostic information?
 
 atol = 1e-7
 rtol = 1e-5

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -63,9 +63,10 @@ Tnorm = 100
 
 [solver]
 type = beuler  # Backward Euler steady-state solver
+snes_type = newtonls  # PETSc nonlinear solver type
 max_nonlinear_iterations = 10
 
-diagnose = true
+diagnose = false  # Output additional diagnostics?
 
 atol = 1e-7
 rtol = 1e-5

--- a/examples/1D-periodic/plotstuff.py
+++ b/examples/1D-periodic/plotstuff.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 radial and toroidal directions
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ni", "NVi", "Pi"],
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/1D-recycling/BOUT.inp
+++ b/examples/1D-recycling/BOUT.inp
@@ -43,7 +43,7 @@ ixseps2 = -1
 # to electron pressure by using electron force balance.
 components = (d+, d, e,
               sheath_boundary, collisions, recycling, reactions,
-              electron_parallel_balance, neutral_parallel_diffusion)
+              electron_force_balance, neutral_parallel_diffusion)
 
 loadmetric = false        # Use Rxy, Bpxy etc?
 normalise_metric = true  # Normalise the input metric?

--- a/examples/1D-recycling/plotstuff.py
+++ b/examples/1D-recycling/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 radial and toroidal directions
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    [["Ne", "Nd+", "Nd"], "Ve", ["NVd+", "NVd"], ["Pe", "Pd+", "Pd"]],
+    logscale=[True, False, False, True],
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/1D-sheath-conduction/plotstuff.py
+++ b/examples/1D-sheath-conduction/plotstuff.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 radial and toroidal directions
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    [["Ne", "Ni"], ["Ve", "Vi"], ["Pe", "Pi"]],
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/1D-sheath/plotstuff.py
+++ b/examples/1D-sheath/plotstuff.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 radial and toroidal directions
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    [["Ne", "Ni"], ["Ve", "Vi"], ["Pe", "Pi"]],
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/1D-te-ti/plotstuff.py
+++ b/examples/1D-te-ti/plotstuff.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 radial and toroidal directions
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    [["Ne", "Ni"], "Ve", "NVi", ["Pe", "Pi"]],
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/2D-drift-plane-turbulence-te-ti/BOUT.inp
+++ b/examples/2D-drift-plane-turbulence-te-ti/BOUT.inp
@@ -91,6 +91,7 @@ average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion curr
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
 
 [sheath_closure]
 connection_length = 50 # meters

--- a/examples/2D-drift-plane-turbulence-te-ti/plotstuff.py
+++ b/examples/2D-drift-plane-turbulence-te-ti/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 parallel direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Pe", "Ph+", "Vort", "phi"],
+    ncols=5,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/blob2d-te-ti/BOUT.inp
+++ b/examples/blob2d-te-ti/BOUT.inp
@@ -84,6 +84,7 @@ average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion curr
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
 
 [sheath_closure]
 connection_length = 10 # meters

--- a/examples/blob2d-te-ti/plotstuff.py
+++ b/examples/blob2d-te-ti/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 parallel direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Pe", "Ph+", "Vort", "phi"],
+    ncols=5,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/blob2d-te/BOUT.inp
+++ b/examples/blob2d-te/BOUT.inp
@@ -63,6 +63,7 @@ average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion curr
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
 
 [sheath_closure]
 connection_length = 10 # meters

--- a/examples/blob2d-te/plotstuff.py
+++ b/examples/blob2d-te/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 parallel direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Pe", "Vort", "phi"],
+    ncols=5,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/blob2d-vpol/BOUT.inp
+++ b/examples/blob2d-vpol/BOUT.inp
@@ -63,6 +63,7 @@ average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion curr
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
 
 [sheath_closure]
 connection_length = 10 # meters

--- a/examples/blob2d/BOUT.inp
+++ b/examples/blob2d/BOUT.inp
@@ -60,6 +60,7 @@ average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion curr
 bndry_flux = false # Allow flows through radial boundaries
 poloidal_flows = false  # Include poloidal ExB flow
 split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
 
 [sheath_closure]
 connection_length = 10 # meters

--- a/examples/blob2d/plotstuff.py
+++ b/examples/blob2d/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".")
+print(ds)
+
+# Get rid of size-1 parallel direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Vort", "phi"],
+    ncols=5,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/solkit-comparison/single-temperature/BOUT.inp
+++ b/examples/solkit-comparison/single-temperature/BOUT.inp
@@ -57,6 +57,7 @@ Tnorm = 100
 
 [solver]
 type = beuler  # Backward Euler steady-state solver
+snes_type = newtonls  # PETSc nonlinear solver
 max_nonlinear_iterations = 10
 
 diagnose = false

--- a/examples/solkit-comparison/two-temperatures/BOUT.inp
+++ b/examples/solkit-comparison/two-temperatures/BOUT.inp
@@ -57,6 +57,7 @@ Tnorm = 100
 
 [solver]
 type = beuler  # Backward Euler steady-state solver
+snes_type = newtonls  # PETSc nonlinear solver
 max_nonlinear_iterations = 10
 
 diagnose = true

--- a/examples/tokamak/diffusion-conduction/BOUT.inp
+++ b/examples/tokamak/diffusion-conduction/BOUT.inp
@@ -51,10 +51,6 @@ function = 1
 bndry_core = dirichlet(1.0)  # Core boundary high density 
 bndry_all = dirichlet(0.01)   # All other boundaries low density
 
-[Th+]
-bndry_core = dirichlet(1.0)  # Core boundary high density 
-bndry_all = dirichlet(0.1)   # All other boundaries low density
-
 ################################################################
 # Electrons
 
@@ -75,7 +71,3 @@ diagnose = true
 function = 1
 bndry_core = dirichlet(1.0)  # Core boundary high density 
 bndry_all = dirichlet(0.01)   # All other boundaries low density
-
-[Te]
-bndry_core = dirichlet(1.0)  # Core boundary high density 
-bndry_all = dirichlet(0.1)   # All other boundaries low density

--- a/examples/tokamak/diffusion-conduction/plotstuff.py
+++ b/examples/tokamak/diffusion-conduction/plotstuff.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Pe", "Nh+", "Ph+"],
+    poloidal_plot=True,
+    ncols=4,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/tokamak/diffusion-flow-evolveT/plotstuff.py
+++ b/examples/tokamak/diffusion-flow-evolveT/plotstuff.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Nh", "NVh", "Ph"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/tokamak/diffusion-transport/BOUT.inp
+++ b/examples/tokamak/diffusion-transport/BOUT.inp
@@ -47,10 +47,6 @@ function = 1
 bndry_core = dirichlet(1.0)  # Core boundary high density 
 bndry_all = dirichlet(0.01)   # All other boundaries low density
 
-[Th+]
-bndry_core = dirichlet(1.0)  # Core boundary high density 
-bndry_all = dirichlet(0.1)   # All other boundaries low density
-
 ################################################################
 # Electrons
 
@@ -73,7 +69,4 @@ function = 1
 bndry_core = dirichlet(1.0)  # Core boundary high density 
 bndry_all = dirichlet(0.01)   # All other boundaries low density
 
-[Te]
-bndry_core = dirichlet(1.0)  # Core boundary high density 
-bndry_all = dirichlet(0.1)   # All other boundaries low density
 

--- a/examples/tokamak/diffusion-transport/plotstuff.py
+++ b/examples/tokamak/diffusion-transport/plotstuff.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Ve", "Pe", "Nh+", "NVh+", "Ph+"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/tokamak/diffusion/BOUT.inp
+++ b/examples/tokamak/diffusion/BOUT.inp
@@ -25,6 +25,9 @@ Tnorm = 5   # Reference temperature [eV]
 [h]
 type = evolve_density, anomalous_diffusion
 
+AA = 1
+charge = 1
+
 anomalous_D = 2    # Density diffusion [m^2/s]
 
 [Nh]

--- a/examples/tokamak/diffusion/plotstuff.py
+++ b/examples/tokamak/diffusion/plotstuff.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Nh"],
+    poloidal_plot=True,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/examples/tokamak/recycling-dthe-drifts/plotstuff.py
+++ b/examples/tokamak/recycling-dthe-drifts/plotstuff.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make some animations
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "NVe", "Pe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="electrons",
+)
+ds.bout.animate_list(
+    ["Nd+", "NVd+", "Pd+", "Nd", "NVd", "Pd"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="deuterium",
+)
+ds.bout.animate_list(
+    ["Nt+", "NVt+", "Pt+", "Nt", "NVt", "Pt"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="tritium",
+)
+ds.bout.animate_list(
+    ["Nhe+", "NVhe+", "Phe+", "Nhe", "NVhe", "Phe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="helium",
+)

--- a/examples/tokamak/recycling-dthe/plotstuff.py
+++ b/examples/tokamak/recycling-dthe/plotstuff.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make some animations
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Ve", "Pe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="electrons",
+)
+ds.bout.animate_list(
+    ["Nd+", "NVd+", "Pd+", "Nd", "NVd", "Pd"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="deuterium",
+)
+ds.bout.animate_list(
+    ["Nt+", "NVt+", "Pt+", "Nt", "NVt", "Pt"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="tritium",
+)
+ds.bout.animate_list(
+    ["Nhe+", "NVhe+", "Phe+", "Nhe", "NVhe", "Phe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="helium",
+)

--- a/examples/tokamak/recycling-dthene/plotstuff.py
+++ b/examples/tokamak/recycling-dthene/plotstuff.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make some animations
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Ve", "Pe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="electrons",
+)
+ds.bout.animate_list(
+    ["Nd+", "NVd+", "Pd+", "Nd", "NVd", "Pd"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="deuterium",
+)
+ds.bout.animate_list(
+    ["Nt+", "NVt+", "Pt+", "Nt", "NVt", "Pt"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="tritium",
+)
+ds.bout.animate_list(
+    ["Nhe+", "NVhe+", "Phe+", "Nhe", "NVhe", "Phe"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="helium",
+)
+ds.bout.animate_list(
+    ["Nne+", "NVne+", "Pne+", "Nne", "NVne", "Pne"],
+    poloidal_plot=True,
+    ncols=3,
+    show=True,
+    save_as="neon",
+)

--- a/examples/tokamak/recycling/plotstuff.py
+++ b/examples/tokamak/recycling/plotstuff.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import xhermes
+
+# Following two lines needed so all variables are shown when printing the Dataset
+import xarray as xr
+xr.set_options(display_max_rows=1000)
+
+# Set better figure size
+from matplotlib import pyplot as plt
+plt.rcParams["figure.figsize"] = (16,8)
+
+ds = xhermes.open(".", geometry="toroidal", gridfilepath="tokamak.nc")
+print(ds)
+
+# Get rid of size-1 toroidal direction
+ds = ds.squeeze()
+
+# Make an animation
+# Note: saving a gif can be slow. Comment out `save_as` argument to disable.
+ds.bout.animate_list(
+    ["Ne", "Ve", "Pe", "Nh+", "NVh+", "Ph+", "Nh", "NVh", "Ph"],
+    poloidal_plot=True,
+    ncols=5,
+    show=True,
+    save_as="hermes_animation",
+)

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -50,6 +50,7 @@ const Field3D D4DX4_FV_Index(const Field3D &f, bool bndry_flux=false);
 // Div ( k * Grad(f) )
 const Field2D Laplace_FV(const Field2D &k, const Field2D &f);
 
-const Field3D Div_a_Laplace_perp_upwind(const Field3D& a, const Field3D& f);
+/// Perpendicular diffusion including X and Y directions
+const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
 
 #endif //  __DIV_OPS_H__

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -4,6 +4,9 @@
 #include <bout/fv_ops.hxx>
 #include "../include/div_ops.hxx"
 
+using bout::globals::mesh;
+
+
 AnomalousDiffusion::AnomalousDiffusion(std::string name, Options &alloptions, Solver *) : name(name) {
   // Normalisations
   const Options& units = alloptions["units"];
@@ -45,42 +48,61 @@ void AnomalousDiffusion::transform(Options &state) {
   Options& species = state["species"][name];
 
   // Diffusion operates on 2D (axisymmetric) profiles
+  // Note: Includes diffusion in Y, so set boundary fluxes
+  // to zero by imposing neumann boundary conditions.
   const Field3D N = GET_NOBOUNDARY(Field3D, species["density"]);
-  const Field2D N2D = DC(N);
+  Field2D N2D = DC(N);
 
   const Field3D T = species.isSet("temperature")
                         ? GET_NOBOUNDARY(Field3D, species["temperature"])
                         : 0.0;
-  const Field2D T2D = DC(T);
+  Field2D T2D = DC(T);
 
   const Field3D V =
       species.isSet("velocity") ? GET_NOBOUNDARY(Field3D, species["velocity"]) : 0.0;
-  const Field2D V2D = DC(V);
-  
+  Field2D V2D = DC(V);
+
+  // Apply Neumann Y boundary condition, so no additional flux into boundary
+  // Note: Not setting radial (X) boundaries since those set radial fluxes
+  for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
+      N2D(r.ind, mesh->ystart - 1, jz) = N2D(r.ind, mesh->ystart, jz);
+      T2D(r.ind, mesh->ystart - 1, jz) = T2D(r.ind, mesh->ystart, jz);
+      V2D(r.ind, mesh->ystart - 1, jz) = V2D(r.ind, mesh->ystart, jz);
+    }
+  }
+  for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+    for (int jz = 0; jz < mesh->LocalNz; jz++) {
+      N2D(r.ind, mesh->yend + 1, jz) = N2D(r.ind, mesh->yend, jz);
+      T2D(r.ind, mesh->yend + 1, jz) = T2D(r.ind, mesh->yend, jz);
+      V2D(r.ind, mesh->yend + 1, jz) = V2D(r.ind, mesh->yend, jz);
+    }
+  }
+
   if (include_D) {
     // Particle diffusion. Gradients of density drive flows of particles,
     // momentum and energy
     add(species["density_source"],
-        Div_a_Laplace_perp_upwind(anomalous_D, N2D));
+        Div_a_Grad_perp_upwind(anomalous_D, N2D));
 
     // Note: Upwind operators used, or unphysical increases
     // in temperature and flow can be produced
     add(species["momentum_source"],
-        Div_a_Laplace_perp_upwind(V2D * anomalous_D, N2D));
+        Div_a_Grad_perp_upwind(V2D * anomalous_D, N2D));
 
     add(species["energy_source"],
-        Div_a_Laplace_perp_upwind((3./2)*T2D * anomalous_D, N2D));
+        Div_a_Grad_perp_upwind((3./2)*T2D * anomalous_D, N2D));
   }
 
   if (include_chi) {
     // Gradients in temperature which drive energy flows
     add(species["energy_source"],
-        Div_a_Laplace_perp_upwind(anomalous_chi * N2D, T2D));
+        Div_a_Grad_perp_upwind(anomalous_chi * N2D, T2D));
   }
 
   if (include_nu) {
     // Gradients in slow speed which drive momentum flows
     add(species["momentum_source"],
-        Div_a_Laplace_perp_upwind(anomalous_nu * N2D, V2D));
+        Div_a_Grad_perp_upwind(anomalous_nu * N2D, V2D));
   }
 }

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -756,8 +756,8 @@ const Field2D Laplace_FV(const Field2D &k, const Field2D &f) {
   return result;
 }
 
-// Div ( a Laplace_perp(f) )  -- diffusion
-const Field3D Div_a_Laplace_perp_upwind(const Field3D& a, const Field3D& f) {
+// Div ( a Grad_perp(f) )  -- diffusion
+const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
   ASSERT2(a.getLocation() == f.getLocation());
 
   Mesh* mesh = a.getMesh();

--- a/src/electron_force_balance.cxx
+++ b/src/electron_force_balance.cxx
@@ -39,7 +39,7 @@ void ElectronForceBalance::transform(Options &state) {
   // Force balance, E = (-∇p + F) / n
   Field3D force_density = - Grad_par(Pe);
 
-  if (isSetFinal(electrons["momentum_source"], "zero_current")) {
+  if (IS_SET(electrons["momentum_source"])) {
     // Balance other forces from e.g. collisions
     // Note: marked as final so can't be set later
     force_density += get<Field3D>(electrons["momentum_source"]);

--- a/src/relax_potential.cxx
+++ b/src/relax_potential.cxx
@@ -200,7 +200,7 @@ void RelaxPotential::finally(const Options& state) {
 
   if (boussinesq) {
     ddt(phi1) =
-        lambda_1 * (FV::Div_a_Laplace_perp(average_atomic_mass / Bsq, phi) - Vort);
+        lambda_1 * (FV::Div_a_Grad_perp(average_atomic_mass / Bsq, phi) - Vort);
 
     if (diamagnetic_polarisation) {
       for (auto& kv : allspecies.getChildren()) {
@@ -219,7 +219,7 @@ void RelaxPotential::finally(const Options& state) {
         }
         const BoutReal A = get<BoutReal>(species["AA"]);
         const Field3D P = get<Field3D>(species["pressure"]);
-        ddt(phi1) += lambda_1 * FV::Div_a_Laplace_perp(A / Bsq, P);
+        ddt(phi1) += lambda_1 * FV::Div_a_Grad_perp(A / Bsq, P);
       }
     }
   } else {
@@ -241,12 +241,12 @@ void RelaxPotential::finally(const Options& state) {
       const BoutReal Ai = get<BoutReal>(species["AA"]);
       const Field3D Ni = get<Field3D>(species["density"]);
 
-      phi_vort += FV::Div_a_Laplace_perp((Ai / Bsq) * Ni, phi);
+      phi_vort += FV::Div_a_Grad_perp((Ai / Bsq) * Ni, phi);
 
       if (diamagnetic_polarisation and species.isSet("pressure")) {
         // Calculate the diamagnetic flow contribution
         const Field3D Pi = get<Field3D>(species["pressure"]);
-        phi_vort += FV::Div_a_Laplace_perp(Ai / Bsq, Pi);
+        phi_vort += FV::Div_a_Grad_perp(Ai / Bsq, Pi);
       }
     }
 

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -467,7 +467,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Set boundary conditions on flows
           Vi[im] = 2. * visheath - Vi[i];
-          NVi[im] = 2. * nisheath * visheath - NVi[i];
+          NVi[im] = 2. * Mi * nisheath * visheath - NVi[i];
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
@@ -524,7 +524,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Set boundary conditions on flows
           Vi[ip] = 2. * visheath - Vi[i];
-          NVi[ip] = 2. * nisheath * visheath - NVi[i];
+          NVi[ip] = 2. * Mi * nisheath * visheath - NVi[i];
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath


### PR DESCRIPTION
It's been a while since these examples were tested
- Input file fixes, removing unused inputs
- evolve_density now requires charge and atomic mass to be set
- `anomalous_diffusion` was not setting Y boundaries, leading to NaN results. Not sure why these worked previously, but perhaps just not checked. 