### PR TITLE
Coefficients and sources in mesh file

### DIFF
--- a/include/anomalous_diffusion.hxx
+++ b/include/anomalous_diffusion.hxx
@@ -6,7 +6,22 @@
 
 /// Add anomalous diffusion of density, momentum and energy
 ///
+/// # Mesh inputs
+///
+/// D_<name>, chi_<name>, nu_<name>
+/// e.g `D_e`, `chi_e`, `nu_e`
+///
+/// in units of m^2/s
+///
 struct AnomalousDiffusion : public Component {
+  /// # Inputs
+  ///
+  /// - <name>
+  ///   - anomalous_D    This overrides D_<name> mesh input
+  ///   - anomalous_chi  This overrides chi_<name>
+  ///   - anomalous_nu   Overrides nu_<name>
+  ///   - anomalous_sheath_flux  Allow anomalous flux into sheath?
+  //                             Default false.
   AnomalousDiffusion(std::string name, Options &alloptions, Solver *);
 
   /// Inputs

--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -5,8 +5,29 @@
 #include "component.hxx"
 
 /// Evolve species density in time
-/// 
+///
+/// # Mesh inputs
+///
+/// N<name>_src  A source of particles, per cubic meter per second.
+///              This can be over-ridden by the `source` option setting.
 struct EvolveDensity : public Component {
+  /// # Inputs
+  ///
+  /// - <name>
+  ///   - charge         Particle charge e.g. hydrogen = 1
+  ///   - AA             Atomic mass number e.g. hydrogen = 1
+  ///   - bndry_flux     Allow flow through radial boundaries? Default is true.
+  ///   - poloidal_flows Include poloidal ExB flows? Default is true.
+  ///   - density_floor  Minimum density floor. Default is 1e-5 normalised units
+  ///   - low_n_diffuse  Enhance parallel diffusion at low density? Default false
+  ///   - hyper_z        Hyper-diffusion in Z. Default off.
+  ///   - evolve_log     Evolve logarithm of density? Default false.
+  ///   - diagnose       Output additional diagnostics?
+  ///
+  /// - N<name>   e.g. "Ne", "Nd+"
+  ///   - source    Source of particles [/m^3/s]
+  ///               NOTE: This overrides mesh input N<name>_src
+  ///
   EvolveDensity(std::string name, Options &options, Solver *solver);
 
   /// This sets in the state

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -6,7 +6,32 @@
 
 #include "component.hxx"
 
+/// Evolves species pressure in time
+///
+/// # Mesh inputs
+///
+/// P<name>_src   A source of pressure, in Pascals per second
+///               This can be over-ridden by the `source` option setting.
+///
 struct EvolvePressure : public Component {
+  ///
+  /// # Inputs
+  ///
+  /// - <name>
+  ///   - evolve_log           Evolve logarithm of pressure? Default is false
+  ///   - density_floor        Minimum density floor. Default 1e-5 normalised units.
+  ///   - bndry_flux           Allow flows through radial boundaries? Default is true
+  ///   - poloidal_flows       Include poloidal ExB flows? Default is true
+  ///   - thermal_conduction   Include parallel heat conduction? Default is true
+  ///   - kappa_coefficient    Heat conduction constant. Default is 3.16 for electrons, 3.9 otherwise
+  ///   - kappa_limit_alpha    Flux limiter, off by default.
+  ///   - p_div_v   Use p * Div(v) form? Default is v * Grad(p) form
+  ///   - hyper_z   Hyper-diffusion in Z
+  ///
+  /// - P<name>  e.g. "Pe", "Pd+"
+  ///   - source     Source of pressure [Pa / s].
+  ///                NOTE: This overrides mesh input P<name>_src
+  ///
   EvolvePressure(std::string name, Options& options, Solver* solver);
 
   /// Inputs

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -78,9 +78,14 @@ EvolveDensity::EvolveDensity(std::string name, Options &alloptions, Solver *solv
   const BoutReal Nnorm = units["inv_meters_cubed"];
   const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
 
+  // Try to read the density source from the mesh
+  // Units of particles per cubic meter per second
+  source = 0.0;
+  mesh->get(source, std::string("N") + name + "_src");
+  // Allow the user to override the source
   source = alloptions[std::string("N") + name]["source"]
                .doc("Source term in ddt(N" + name + std::string("). Units [m^-3/s]"))
-               .withDefault(Field3D(0.0))
+               .withDefault(source)
            / (Nnorm * Omega_ci);
 }
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -86,10 +86,15 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
   const BoutReal Tnorm = units["eV"];
   const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
 
+  // Try to read the pressure source from the mesh
+  // Units of Pascals per second
+  source = 0.0;
+  mesh->get(source, std::string("P") + name + "_src");
+  // Allow the user to override the source
   source = alloptions[std::string("P") + name]["source"]
                .doc(std::string("Source term in ddt(P") + name
                     + std::string("). Units [N/m^2/s]"))
-               .withDefault(Field3D(0.0))
+               .withDefault(source)
            / (SI::qe * Nnorm * Tnorm * Omega_ci);
 }
 


### PR DESCRIPTION
Reads sources and diffusion coefficients from the mesh, allowing them to be overridden by previous options:

`evolve_density` component
- `N<name>_src` mesh input (e.g. `Ne_src`). Overridden by `source` in `[N<name>]` section. Both have units of particles per cubic meter per second.

`evolve_pressure` component
- `P<name>_src` mesh input (e.g. `Pe_src`). Overridden by `source` in `[P<name>]` section. Both have units of Pascals per second.

`anomalous_diffusion` coefficient
- `D_<name>` mesh input (e.g. `D_e`). Overridden by `anomalous_D`. Both have units of m^2/s. Particle diffusion coefficient.
- `chi_<name>` mesh input (e.g. `chi_e`). Overridden by `anomalous_chi`. Both have units of m^2/s. Heat diffusion coefficient.
- `nu_<name>` mesh input (e.g. `nu_e`). Overridden by `anomalous_nu`. Both have units of m^2/s. Parallel momentum coefficient.
