### PR TITLE
Tidy outputVars, reduce printing to logs

### DIFF
--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -48,11 +48,11 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
   void outputVars(Options& state) override {
     AUTO_TRACE();
     // Normalisations
-    auto Nnorm = state["Nnorm"].as<BoutReal>();
-    auto Tnorm = state["Tnorm"].as<BoutReal>();
+    auto Nnorm = get<BoutReal>(state["Nnorm"]);
+    auto Tnorm = get<BoutReal>(state["Tnorm"]);
     BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
-    auto Omega_ci = state["Omega_ci"].as<BoutReal>();
-    auto Cs0 = state["Cs0"].as<BoutReal>();
+    auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+    auto Cs0 = get<BoutReal>(state["Cs0"]);
 
     if (diagnose) {
       // Save particle, momentum and energy channels

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -50,11 +50,11 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
   void outputVars(Options& state) override {
     AUTO_TRACE();
     // Normalisations
-    auto Nnorm = state["Nnorm"].as<BoutReal>();
-    auto Tnorm = state["Tnorm"].as<BoutReal>();
+    auto Nnorm = get<BoutReal>(state["Nnorm"]);
+    auto Tnorm = get<BoutReal>(state["Tnorm"]);
     BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
-    auto Omega_ci = state["Omega_ci"].as<BoutReal>();
-    auto Cs0 = state["Cs0"].as<BoutReal>();
+    auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+    auto Cs0 = get<BoutReal>(state["Cs0"]);
 
     if (diagnose) {
       // Save particle, momentum and energy channels

--- a/include/fixed_density.hxx
+++ b/include/fixed_density.hxx
@@ -48,7 +48,7 @@ struct FixedDensity : public Component {
 
   void outputVars(Options& state) override {
     AUTO_TRACE();
-    auto Nnorm = state["Nnorm"].as<BoutReal>();
+    auto Nnorm = get<BoutReal>(state["Nnorm"]);
 
     // Save the density, not time dependent
     set_with_attrs(state[std::string("N") + name], N,

--- a/include/fixed_temperature.hxx
+++ b/include/fixed_temperature.hxx
@@ -58,7 +58,7 @@ struct FixedTemperature : public Component {
 
   void outputVars(Options& state) override {
     AUTO_TRACE();
-    auto Tnorm = state["Tnorm"].as<BoutReal>();
+    auto Tnorm = get<BoutReal>(state["Tnorm"]);
 
     // Save temperature to output files
     set_with_attrs(state[std::string("T") + name], T,
@@ -70,7 +70,7 @@ struct FixedTemperature : public Component {
                     {"source", "fixed_temperature"}});
 
     if (diagnose) {
-      auto Nnorm = state["Nnorm"].as<BoutReal>();
+      auto Nnorm = get<BoutReal>(state["Nnorm"]);
       BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
 
       // Save pressure as time-varying field

--- a/include/fixed_velocity.hxx
+++ b/include/fixed_velocity.hxx
@@ -43,7 +43,7 @@ struct FixedVelocity : public Component {
 
   void outputVars(Options& state) override {
     AUTO_TRACE();
-    auto Cs0 = state["Cs0"].as<BoutReal>();
+    auto Cs0 = get<BoutReal>(state["Cs0"]);
 
     // Save the density, not time dependent
     set_with_attrs(state[std::string("V") + name], V,

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -154,11 +154,11 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
   void outputVars(Options& state) override {
     AUTO_TRACE();
     // Normalisations
-    auto Nnorm = state["Nnorm"].as<BoutReal>();
-    auto Tnorm = state["Tnorm"].as<BoutReal>();
+    auto Nnorm = get<BoutReal>(state["Nnorm"]);
+    auto Tnorm = get<BoutReal>(state["Tnorm"]);
     BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
-    auto Omega_ci = state["Omega_ci"].as<BoutReal>();
-    auto Cs0 = state["Cs0"].as<BoutReal>();
+    auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+    auto Cs0 = get<BoutReal>(state["Cs0"]);
 
     if (diagnose) {
       // Save particle, momentum and energy channels

--- a/include/set_temperature.hxx
+++ b/include/set_temperature.hxx
@@ -70,7 +70,7 @@ struct SetTemperature : public Component {
     AUTO_TRACE();
 
     if (diagnose) {
-      auto Tnorm = state["Tnorm"].as<BoutReal>();
+      auto Tnorm = get<BoutReal>(state["Tnorm"]);
 
       // Save temperature to output files
       set_with_attrs(state[std::string("T") + name], T,

--- a/include/upstream_density_feedback.hxx
+++ b/include/upstream_density_feedback.hxx
@@ -61,8 +61,8 @@ struct UpstreamDensityFeedback : public Component {
     AUTO_TRACE();
     if (diagnose) {
       // Normalisations
-      auto Nnorm = state["Nnorm"].as<BoutReal>();
-      auto Omega_ci = state["Omega_ci"].as<BoutReal>();
+      auto Nnorm = get<BoutReal>(state["Nnorm"]);
+      auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
 
       // Shape is not time-dependent
       set_with_attrs(


### PR DESCRIPTION
Use get<>() rather than .as<>() when getting normalisation constants, so value isn't printed to log every time the output is written.