### PR TITLE
Sheath wall potential

### DIFF
--- a/include/sheath_boundary.hxx
+++ b/include/sheath_boundary.hxx
@@ -20,10 +20,18 @@
 ///     using to/fromFieldAligned
 ///
 struct SheathBoundary : public Component {
+  /// # Input options
+  /// - <name>  e.g. "sheath_boundary"
+  ///   - lower_y                  Boundary on lower y?
+  ///   - upper_y                  Boundary on upper y?
+  ///   - wall_potential           Voltage of the wall [Volts]
+  ///   - secondary_electron_coef  Effective secondary electron emission coefficient
+  ///   - sin_alpha                Sine of the angle between magnetic field line and wall surface (0 to 1)
+  ///   - always_set_phi           Always set phi field? Default is to only modify if already set
   SheathBoundary(std::string name, Options &options, Solver *);
 
   ///
-  /// Inputs
+  /// # Inputs
   /// - species
   ///   - e
   ///     - density
@@ -44,7 +52,7 @@ struct SheathBoundary : public Component {
   /// - fields
   ///   - phi    Optional. If not set, calculated at boundary (see note below)
   ///
-  /// Outputs
+  /// # Outputs
   /// - species
   ///   - e
   ///     - density      Sets boundary
@@ -74,6 +82,8 @@ private:
   bool upper_y; // Boundary on upper y?
 
   bool always_set_phi; ///< Set phi field?
+
+  Field3D wall_potential; ///< Voltage at the wall. Normalised units.
 };
 
 namespace {

--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -16,10 +16,21 @@
 ///     this is here for comparison to that more complete model.
 ///
 struct SheathBoundarySimple : public Component {
+  /// # Input options
+  /// - <name>  e.g. "sheath_boundary_simple"
+  ///   - lower_y                  Boundary on lower y?
+  ///   - upper_y                  Boundary on upper y?
+  ///   - gamma_e                  Electron sheath heat transmission coefficient
+  ///   - gamma_i                  Ion sheath heat transmission coefficient
+  ///   - sheath_ion_polytropic    Ion polytropic coefficient in Bohm sound speed. Default 1.
+  ///   - wall_potential           Voltage of the wall [Volts]
+  ///   - secondary_electron_coef  Effective secondary electron emission coefficient
+  ///   - sin_alpha                Sine of the angle between magnetic field line and wall surface (0 to 1)
+  ///   - always_set_phi           Always set phi field? Default is to only modify if already set
   SheathBoundarySimple(std::string name, Options &options, Solver *);
 
   ///
-  /// Inputs
+  /// # Inputs
   /// - species
   ///   - e
   ///     - density
@@ -40,7 +51,7 @@ struct SheathBoundarySimple : public Component {
   /// - fields
   ///   - phi    Optional. If not set, calculated at boundary (see note below)
   ///
-  /// Outputs
+  /// # Outputs
   /// - species
   ///   - e
   ///     - density      Sets boundary
@@ -74,6 +85,8 @@ private:
   bool upper_y; // Boundary on upper y?
 
   bool always_set_phi; ///< Set phi field?
+
+  Field3D wall_potential; ///< Voltage of the wall. Normalised units.
 };
 
 namespace {

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -53,6 +53,25 @@ struct Vorticity : public Component {
   void finally(const Options &state) override;
 
   void outputVars(Options &state) override;
+
+  // Save and restore potential phi
+  void restartVars(Options& state) override {
+    AUTO_TRACE();
+
+    // NOTE: This is a hack because we know that the loaded restart file
+    //       is passed into restartVars in PhysicsModel::postInit
+    // The restart value should be used in init() rather than here
+    static bool first = true;
+    if (first and state.isSet("phi")) {
+      first = false;
+      phi = state["phi"].as<Field3D>();
+    }
+
+    // Save the potential
+    set_with_attrs(state["phi"], phi,
+                   {{"long_name", "plasma potential"},
+                    {"source", "vorticity"}});
+  }
 private:
   Field3D Vort; // Evolving vorticity
   

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -84,6 +84,15 @@ SheathBoundary::SheathBoundary(std::string name, Options &alloptions, Solver *) 
       options["always_set_phi"]
           .doc("Always set phi field? Default is to only modify if already set")
           .withDefault<bool>(false);
+
+  const Options& units = alloptions["units"];
+  const BoutReal Tnorm = units["eV"];
+
+  // Read wall voltage, convert to normalised units
+  wall_potential = options["wall_potential"]
+                       .doc("Voltage of the wall [Volts]")
+                       .withDefault(Field3D(0.0))
+                   / Tnorm;
 }
 
 void SheathBoundary::transform(Options &state) {
@@ -249,6 +258,9 @@ void SheathBoundary::transform(Options &state) {
             phi[i] = Te[i] * log(sqrt(Te[i] / (Me * TWOPI)) * (1. - Ge) / ion_sum[i]);
           }
 
+          const BoutReal phi_wall = 0.5 * (wall_potential[i] + wall_potential[i.ym()]);
+          phi[i] += phi_wall; // Add bias potential
+
           phi[i.yp()] = phi[i.ym()] = phi[i]; // Constant into sheath
         }
       }
@@ -264,6 +276,9 @@ void SheathBoundary::transform(Options &state) {
           } else {
             phi[i] = Te[i] * log(sqrt(Te[i] / (Me * TWOPI)) * (1. - Ge) / ion_sum[i]);
           }
+
+          const BoutReal phi_wall = 0.5 * (wall_potential[i] + wall_potential[i.yp()]);
+          phi[i] += phi_wall; // Add bias potential
 
           phi[i.yp()] = phi[i.ym()] = phi[i];
         }
@@ -299,15 +314,18 @@ void SheathBoundary::transform(Options &state) {
 
         const BoutReal nesheath = 0.5 * (Ne[im] + Ne[i]);
         const BoutReal tesheath = 0.5 * (Te[im] + Te[i]);  // electron temperature
-        const BoutReal phisheath = floor(0.5 * (phi[im] + phi[i]), 0.0); // Electron saturation at phi = 0
+        const BoutReal phi_wall = 0.5 * (wall_potential[im] + wall_potential[i]);
+
+        const BoutReal phisheath = floor(
+            0.5 * (phi[im] + phi[i]), phi_wall); // Electron saturation at phi = phi_wall
 
         // Electron sheath heat transmission
-        const BoutReal gamma_e = 2 / (1. - Ge) + phisheath / floor(tesheath, 1e-5);
+        const BoutReal gamma_e = 2 / (1. - Ge) + (phisheath - phi_wall) / floor(tesheath, 1e-5);
 
         // Electron velocity into sheath (< 0)
         const BoutReal vesheath = (tesheath < 1e-10) ?
           0.0 :
-          -sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
+          -sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-(phisheath - phi_wall) / tesheath);
 
         Ve[im] = 2 * vesheath - Ve[i];
         NVe[im] = 2. * Me * nesheath * vesheath - NVe[i];
@@ -359,15 +377,16 @@ void SheathBoundary::transform(Options &state) {
 
         const BoutReal nesheath = 0.5 * (Ne[ip] + Ne[i]);
         const BoutReal tesheath = 0.5 * (Te[ip] + Te[i]);  // electron temperature
-        const BoutReal phisheath = floor(0.5 * (phi[ip] + phi[i]), 0.0); // Electron saturation at phi = 0
+        const BoutReal phi_wall = 0.5 * (wall_potential[ip] + wall_potential[i]);
+        const BoutReal phisheath = floor(0.5 * (phi[ip] + phi[i]), phi_wall); // Electron saturation at phi = phi_wall
 
         // Electron sheath heat transmission
-        const BoutReal gamma_e = 2 / (1. - Ge) + phisheath / floor(tesheath, 1e-5);
+        const BoutReal gamma_e = 2 / (1. - Ge) + (phisheath - phi_wall) / floor(tesheath, 1e-5);
 
         // Electron velocity into sheath (> 0)
         const BoutReal vesheath = (tesheath < 1e-10) ?
           0.0 :
-          sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-phisheath / tesheath);
+          sqrt(tesheath / (TWOPI * Me)) * (1. - Ge) * exp(-(phisheath - phi_wall) / tesheath);
 
         Ve[ip] = 2 * vesheath - Ve[i];
         NVe[ip] = 2. * Me * nesheath * vesheath - NVe[i];

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -77,7 +77,6 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
   // Add phi to restart files so that the value in the boundaries
   // is restored on restart. This is done even when phi is not evolving,
   // so that phi can be saved and re-loaded
-  // get_restart_datafile()->addOnce(phi, "phi");
 
   // Set initial value. Will be overwritten if restarting
   phi = 0.0;

--- a/tests/unit/test_sheath_boundary.cxx
+++ b/tests/unit/test_sheath_boundary.cxx
@@ -23,13 +23,15 @@ using SheathBoundaryTest = FakeMeshFixture;
 
 TEST_F(SheathBoundaryTest, CreateComponent) {
   Options options;
-  
+  options["units"]["eV"] = 1.0; // Voltage normalisation 
+
   SheathBoundary component("test", options, nullptr);
 }
 
 TEST_F(SheathBoundaryTest, DontSetPotential) {
   Options options;
-  
+  options["units"]["eV"] = 1.0; // Voltage normalisation 
+ 
   SheathBoundary component("test", options, nullptr);
 
   Field3D N = FieldFactory::get()->create3D("1 + y", &options, mesh);
@@ -58,6 +60,7 @@ TEST_F(SheathBoundaryTest, DontSetPotential) {
 
 TEST_F(SheathBoundaryTest, CalculatePotential) {
   Options options{{"test", {{"always_set_phi", true}}}};
+  options["units"]["eV"] = 1.0; // Voltage normalisation 
 
   SheathBoundary component("test", options, nullptr);
 


### PR DESCRIPTION
Can set an input `wall_potential` to bias the `sheath_boundary` and `sheath_boundary_simple` boundary conditions.