### PR TITLE
Extra diagnostics and settings for anomalous diffusion

### DIFF
--- a/include/anomalous_diffusion.hxx
+++ b/include/anomalous_diffusion.hxx
@@ -22,7 +22,11 @@ struct AnomalousDiffusion : public Component {
   ///   - anomalous_nu   Overrides nu_<name>
   ///   - anomalous_sheath_flux  Allow anomalous flux into sheath?
   //                             Default false.
-  AnomalousDiffusion(std::string name, Options &alloptions, Solver *);
+  AnomalousDiffusion(std::string name, Options &alloptions, Solver *) {
+    diagnose = alloptions[name]["diagnose"]
+                   .doc("Output additional diagnostics?")
+                   .withDefault<bool>(false);
+  };
 
   /// Inputs
   /// - species
@@ -41,9 +45,30 @@ struct AnomalousDiffusion : public Component {
   ///
   void transform(Options &state) override;
 
+  void outputVars(Options& state) override {
+    AUTO_TRACE();
+    // Normalisations
+    auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+    auto rho_s0 = get<BoutReal>(state["rho_s0"]);
+
+    if (diagnose) {
+      // Save particle, momentum and energy channels
+
+      set_with_attrs(state[{std::string("anomalous_D_") + name}], anomalous_D,
+                      {{"time_dimension", "t"},
+                      {"units", "m^2 s^-1"},
+                      {"conversion", rho_s0 * rho_s0 * Omega_ci},
+                      {"standard_name", "anomalous density diffusion"},
+                      {"long_name", std::string("Anomalous density diffusion of ") + name},
+                      {"source", "anomalous_diffusion"}});
+
+    }
+  }
+
 private:
   std::string name; ///< Species name
 
+  bool diagnose; ///< Outputting diagnostics?
   bool include_D, include_chi, include_nu; ///< Which terms should be included?
   Field2D anomalous_D; ///< Anomalous density diffusion coefficient
   Field2D anomalous_chi; ///< Anomalous thermal diffusion coefficient
@@ -51,6 +76,8 @@ private:
 
   bool anomalous_sheath_flux; ///< Allow anomalous diffusion into sheath?
 };
+
+
 
 namespace {
 RegisterComponent<AnomalousDiffusion> registercomponentanomalousdiffusion("anomalous_diffusion");

--- a/include/anomalous_diffusion.hxx
+++ b/include/anomalous_diffusion.hxx
@@ -22,11 +22,7 @@ struct AnomalousDiffusion : public Component {
   ///   - anomalous_nu   Overrides nu_<name>
   ///   - anomalous_sheath_flux  Allow anomalous flux into sheath?
   //                             Default false.
-  AnomalousDiffusion(std::string name, Options &alloptions, Solver *) {
-    diagnose = alloptions[name]["diagnose"]
-                   .doc("Output additional diagnostics?")
-                   .withDefault<bool>(false);
-  };
+  AnomalousDiffusion(std::string name, Options &alloptions, Solver *);
 
   /// Inputs
   /// - species
@@ -44,26 +40,6 @@ struct AnomalousDiffusion : public Component {
   ///     - energy_source
   ///
   void transform(Options &state) override;
-
-  void outputVars(Options& state) override {
-    AUTO_TRACE();
-    // Normalisations
-    auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
-    auto rho_s0 = get<BoutReal>(state["rho_s0"]);
-
-    if (diagnose) {
-      // Save particle, momentum and energy channels
-
-      set_with_attrs(state[{std::string("anomalous_D_") + name}], anomalous_D,
-                      {{"time_dimension", "t"},
-                      {"units", "m^2 s^-1"},
-                      {"conversion", rho_s0 * rho_s0 * Omega_ci},
-                      {"standard_name", "anomalous density diffusion"},
-                      {"long_name", std::string("Anomalous density diffusion of ") + name},
-                      {"source", "anomalous_diffusion"}});
-
-    }
-  }
 
 private:
   std::string name; ///< Species name

--- a/include/anomalous_diffusion.hxx
+++ b/include/anomalous_diffusion.hxx
@@ -40,6 +40,7 @@ struct AnomalousDiffusion : public Component {
   ///     - energy_source
   ///
   void transform(Options &state) override;
+  void outputVars(Options &state) override;
 
 private:
   std::string name; ///< Species name

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -110,6 +110,14 @@ void AnomalousDiffusion::transform(Options& state) {
     add(species["momentum_source"], Div_a_Grad_perp_upwind(anomalous_nu * N2D, V2D));
   }
 
+}
+
+void AnomalousDiffusion::outputVars(Options& state) {
+  AUTO_TRACE();
+  // Normalisations
+  auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+  auto rho_s0 = get<BoutReal>(state["rho_s0"]);
+
   if (diagnose) {
 
     // void outputVars(Options& state) override {
@@ -130,3 +138,4 @@ void AnomalousDiffusion::transform(Options& state) {
     // }
   }
 }
+

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -120,12 +120,7 @@ void AnomalousDiffusion::outputVars(Options& state) {
 
   if (diagnose) {
 
-    // void outputVars(Options& state) override {
       AUTO_TRACE();
-      // Normalisations
-      // auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
-      // auto rho_s0 = get<BoutReal>(state["rho_s0"]);
-      
       // Save particle, momentum and energy channels
 
       set_with_attrs(state[{std::string("anomalous_D_") + name}], anomalous_D,
@@ -135,6 +130,23 @@ void AnomalousDiffusion::outputVars(Options& state) {
                       {"standard_name", "anomalous density diffusion"},
                       {"long_name", std::string("Anomalous density diffusion of ") + name},
                       {"source", "anomalous_diffusion"}});
+
+      set_with_attrs(state[{std::string("anomalous_Chi_") + name}], anomalous_chi,
+                      {{"time_dimension", "t"},
+                      {"units", "m^2 s^-1"},
+                      {"conversion", rho_s0 * rho_s0 * Omega_ci},
+                      {"standard_name", "anomalous thermal diffusion"},
+                      {"long_name", std::string("Anomalous thermal diffusion of ") + name},
+                      {"source", "anomalous_diffusion"}});
+
+      set_with_attrs(state[{std::string("anomalous_nu_") + name}], anomalous_nu,
+                      {{"time_dimension", "t"},
+                      {"units", "m^2 s^-1"},
+                      {"conversion", rho_s0 * rho_s0 * Omega_ci},
+                      {"standard_name", "anomalous momentum diffusion"},
+                      {"long_name", std::string("Anomalous momentum diffusion of ") + name},
+                      {"source", "anomalous_diffusion"}});
+      
     // }
   }
 }


### PR DESCRIPTION
It is common to run with a profile of anomalous diffusion coefficients (e.g. with a lower value in the core to represent the transport barrier). It is also useful to change the coefficients while running the model, for example by only imposing a transport barrier after steady state has been achieved with uniform coefficients.

Unfortunately due to input file limitations restricting Y to be continuous around the core, it is not possible to differentiate the PFR from the core in the input file using Heaviside functions. This means that a coefficient profile must be imported from the mesh file (see [PR](https://github.com/bendudson/hermes-3/pull/86)). This poses two problems:

- It is not possible to check that the code is reading the coefficients correctly due to lack of diagnostics
- It is not possible to modify the coefficients in the input file, they must be changed in the mesh file.

In an ideal world:

- The mesh would contain only the final coefficients and one could scale them from the input file
- The output file would contain the coefficient settings, allowing one to track their changes over time and verify the mesh file is correct

This PR aims to do the following:

- [x] Add diagnostics for the anomalous coefficient settings
~- [ ] Add new input settings to the input which scale the coefficients~

**Update 20/01/2023:**
- Anomalous D, Chi and Nu now saved as new diagnostic variables
- Abandoned idea of scaling the sources from file. This is because in setting up a transport barrier, one would want to gradually reduce the coefficients in the core specifically. Can't really think of many uses for scaling the entire profile now, and one can already scale it up and down using the input file if one wants the coefficients to be uniform.
