### PR TITLE
Low density improvements

### DIFF
--- a/include/evolve_momentum.hxx
+++ b/include/evolve_momentum.hxx
@@ -35,6 +35,7 @@ private:
   std::string name;     ///< Short name of species e.g "e"
 
   Field3D NV;           ///< Species parallel momentum (normalised, evolving)
+  Field3D NV_solver;    ///< Momentum as input from solver
   Field3D V;            ///< Species parallel velocity
 
   Field3D momentum_source; ///< From other components. Stored for diagnostic output

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -25,7 +25,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
   if (evolve_log) {
     // Evolve logarithm of density
     solver->add(logP, std::string("logP") + name);
-    // Save the density to the restart file
+    // Save the pressure to the restart file
     // so the simulation can be restarted evolving density
     //get_restart_datafile()->addOnce(P, std::string("P") + name);
 
@@ -102,17 +102,18 @@ void EvolvePressure::transform(Options& state) {
 
   mesh->communicate(P);
 
-  Field3D Pfloor = floor(P, 0.0);
 
   auto& species = state["species"][name];
-
-  set(species["pressure"], Pfloor);
 
   // Calculate temperature
   // Not using density boundary condition
   N = getNoBoundary<Field3D>(species["density"]);
-  T = Pfloor / floor(N, density_floor);
 
+  Field3D Pfloor = floor(P, 0.0);
+  T = Pfloor / floor(N, density_floor);
+  Pfloor = N * T; // Ensure consistency
+
+  set(species["pressure"], Pfloor);
   set(species["temperature"], T);
 }
 
@@ -128,6 +129,7 @@ void EvolvePressure::finally(const Options& state) {
   Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
 
   T = get<Field3D>(species["temperature"]);
+  N = get<Field3D>(species["density"]);
 
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow
@@ -201,8 +203,6 @@ void EvolvePressure::finally(const Options& state) {
        * DOI 10.1002/ctpp.200610001
        */
 
-      Field3D N = get<Field3D>(species["density"]);
-
       // Spitzer-Harm heat flux
       Field3D q_SH = kappa_par * Grad_par(T);
       // Free-streaming flux
@@ -266,6 +266,10 @@ void EvolvePressure::finally(const Options& state) {
   if (evolve_log) {
     ddt(logP) = ddt(P) / P;
   }
+
+  // Term to force evolved P towards N * T
+  // This is active when P < 0 or when N < density_floor
+  ddt(P) += N * T - P;
 
 #if CHECKLEVEL >= 1
   for (auto& i : P.getRegion("RGN_NOBNDRY")) {


### PR DESCRIPTION
Changes to improve numerical stability, especially at low density
- Use stronger numerical dissipation in `evolve_momentum` : the fastest wave in the system rather than species sound speed
- Add a term to momentum and pressure equations, that damps the evolving quantity towards consistency with the derived floored quantities e.g. pressure should be consistent with N * T, with T calculated using floored density. In practice this has the effect of damping dynamics in regions where `N < density_floor`.
