### PR TITLE
Neutral transport flux limits

### DIFF
--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -50,6 +50,7 @@ private:
   BoutReal nn_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
 
   BoutReal flux_limit; ///< Diffusive flux limit
+  BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
 
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -48,7 +48,9 @@ private:
   BoutReal neutral_gamma; ///< Heat transmission for neutrals
   
   BoutReal nn_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
-  
+
+  BoutReal flux_limit; ///< Diffusive flux limit
+
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -71,7 +71,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
     .doc("Save additional output diagnostics")
     .withDefault<bool>(false);
 
-  enable_precon = options["precon"]
+  enable_precon = options["precondition"]
     .doc("Enable preconditioner? (Note: solver may not use it)")
     .withDefault<bool>(true);
 

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -44,6 +44,10 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                      .doc("Enable preconditioning in neutral model?")
                      .withDefault<bool>(true);
 
+  flux_limit = options["flux_limit"]
+    .doc("Limit diffusive fluxes to fraction of thermal speed. <0 means off.")
+    .withDefault(0.2);
+
   if (precondition) {
     inv = std::unique_ptr<Laplacian>(Laplacian::create(&options["precon_laplace"]));
 
@@ -171,6 +175,17 @@ void NeutralMixed::finally(const Options& state) {
   AUTO_TRACE();
   auto& localstate = state["species"][name];
 
+  // Logarithms used to calculate perpendicular velocity
+  // V_perp = -Dnn * ( Grad_perp(Nn)/Nn + Grad_perp(Tn)/Tn )
+  //
+  // Grad(Pn) / Pn = Grad(Tn)/Tn + Grad(Nn)/Nn
+  //               = Grad(logTn + logNn)
+  // Field3D logNn = log(Nn);
+  // Field3D logTn = log(Tn);
+
+  Field3D logPnlim = log(Pnlim);
+  logPnlim.applyBoundary("neumann");
+
   ///////////////////////////////////////////////////////
   // Calculate cross-field diffusion from collision frequency
   //
@@ -185,6 +200,15 @@ void NeutralMixed::finally(const Options& state) {
     Dnn = (Tn / AA) / (get<Field3D>(localstate["collision_frequency"]) + Rnn);
   } else {
     Dnn = (Tn / AA) / Rnn;
+  }
+
+  // Flux limit diffusion
+  if (flux_limit > 0.0) {
+    Field3D Dmax = flux_limit * sqrt(Tn / AA) /
+      (abs(Grad(logPnlim)) + 1. / neutral_lmax);
+    BOUT_FOR(i, Dmax.getRegion("RGN_NOBNDRY")) {
+      Dnn[i] = BOUTMIN(Dnn[i], Dmax[i]);
+    }
   }
 
   mesh->communicate(Dnn);
@@ -222,17 +246,6 @@ void NeutralMixed::finally(const Options& state) {
       }
     }
   }
-
-  // Logarithms used to calculate perpendicular velocity
-  // V_perp = -Dnn * ( Grad_perp(Nn)/Nn + Grad_perp(Tn)/Tn )
-  //
-  // Grad(Pn) / Pn = Grad(Tn)/Tn + Grad(Nn)/Nn
-  //               = Grad(logTn + logNn)
-  // Field3D logNn = log(Nn);
-  // Field3D logTn = log(Tn);
-
-  Field3D logPnlim = log(Pnlim);
-  logPnlim.applyBoundary("neumann");
 
   // Sound speed appearing in Lax flux for advection terms
   Field3D sound_speed = sqrt(Tn * (5. / 3) / AA);
@@ -356,6 +369,13 @@ void NeutralMixed::outputVars(Options& state) {
                     {"conversion", Tnorm},
                     {"standard_name", "temperature"},
                     {"long_name", name + " temperature"},
+                    {"source", "neutral_mixed"}});
+    set_with_attrs(state[std::string("Dnn") + name], Dnn,
+                   {{"time_dimension", "t"},
+                    {"units", "m^2/s"},
+                    {"conversion", Cs0 * Cs0 / Omega_ci},
+                    {"standard_name", "diffusion coefficient"},
+                    {"long_name", name + " diffusion coefficient"},
                     {"source", "neutral_mixed"}});
     set_with_attrs(state[std::string("SN") + name], Sn,
                    {{"time_dimension", "t"},


### PR DESCRIPTION
Adds `flux_limit` and `diffusion_limit` options to the `neutral_mixed` component. Finding diffusion coefficients of up to 3000 m^2/s, that cause time integration to be very slow. Applying limits for the first part of a simulation while profiles settle speeds things up considerably.