### PR TITLE
Add custom neutral sources to neutral_mixed

### DIFF
--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -55,7 +55,7 @@ private:
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 
-  Field3D density_source, energy_source; ///< External input source
+  Field3D density_source, pressure_source; ///< External input source
   Field3D Sn, Sp, Snv; ///< Particle, pressure and momentum source
 
   bool output_ddt; ///< Save time derivatives?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -55,6 +55,7 @@ private:
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 
+  Field3D source; ///< External input source
   Field3D Sn, Sp, Snv; ///< Particle, pressure and momentum source
 
   bool output_ddt; ///< Save time derivatives?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -55,7 +55,7 @@ private:
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 
-  Field3D source; ///< External input source
+  Field3D density_source, energy_source; ///< External input source
   Field3D Sn, Sp, Snv; ///< Particle, pressure and momentum source
 
   bool output_ddt; ///< Save time derivatives?

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -303,8 +303,8 @@ void NeutralMixed::finally(const Options& state) {
   Sn = density_source; // Save for possible output
   if (localstate.isSet("density_source")) {
     Sn += get<Field3D>(localstate["density_source"]);
-    ddt(Nn) += Sn;
   }
+  ddt(Nn) += Sn; // Always add density_source
 
   /////////////////////////////////////////////////////
   // Neutral momentum
@@ -342,8 +342,8 @@ void NeutralMixed::finally(const Options& state) {
   Sp = energy_source;
   if (localstate.isSet("energy_source")) {
     Sp += (2. / 3) * get<Field3D>(localstate["energy_source"]);
-    ddt(Pn) += Sp;
   }
+  ddt(Pn) += Sp;
 
   BOUT_FOR(i, Pn.getRegion("RGN_ALL")) {
     if ((Pn[i] < 1e-9) && (ddt(Pn)[i] < 0.0)) {
@@ -450,7 +450,7 @@ void NeutralMixed::outputVars(Options& state) {
                     {"standard_name", "density source"},
                     {"long_name", name + " number density source"},
                     {"species", name},
-                    {"source", "evolve_density"}});
+                    {"source", "neutral_mixed"}});
     set_with_attrs(state[std::string("P") + name + std::string("_src")], energy_source,
                    {{"time_dimension", "t"},
                     {"units", "Pa s^-1"},
@@ -458,7 +458,7 @@ void NeutralMixed::outputVars(Options& state) {
                     {"standard_name", "pressure source"},
                     {"long_name", name + " pressure source"},
                     {"species", name},
-                    {"source", "evolve_pressure"}});
+                    {"source", "neutral_mixed"}});
 
   }
 }

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -91,13 +91,13 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
 
   // Try to read the pressure source from the mesh
   // Units of Pascals per second
-  energy_source = 0.0;
-  mesh->get(energy_source, std::string("P") + name + "_src");
+  pressure_source = 0.0;
+  mesh->get(pressure_source, std::string("P") + name + "_src");
   // Allow the user to override the source
-  energy_source = alloptions[std::string("P") + name]["source"]
+  pressure_source = alloptions[std::string("P") + name]["source"]
                .doc(std::string("Source term in ddt(P") + name
                     + std::string("). Units [N/m^2/s]"))
-               .withDefault(energy_source)
+               .withDefault(pressure_source)
            / (SI::qe * Nnorm * Tnorm * Omega_ci);
 
 }
@@ -339,7 +339,7 @@ void NeutralMixed::finally(const Options& state) {
             + FV::Div_par_K_Grad_par(DnnNn, Tn)    // Parallel conduction
       ;
 
-  Sp = energy_source;
+  Sp = pressure_source;
   if (localstate.isSet("energy_source")) {
     Sp += (2. / 3) * get<Field3D>(localstate["energy_source"]);
   }
@@ -451,7 +451,7 @@ void NeutralMixed::outputVars(Options& state) {
                     {"long_name", name + " number density source"},
                     {"species", name},
                     {"source", "neutral_mixed"}});
-    set_with_attrs(state[std::string("P") + name + std::string("_src")], energy_source,
+    set_with_attrs(state[std::string("P") + name + std::string("_src")], pressure_source,
                    {{"time_dimension", "t"},
                     {"units", "Pa s^-1"},
                     {"conversion", Pnorm * Omega_ci},


### PR DESCRIPTION
Extending the custom mesh source changes from https://github.com/bendudson/hermes-3/pull/86 to the neutral_mixed component, allowing custom neutral density and energy sources being specified in the grid and post-processed.

- [x] Add neutral density source
- [x] Add neutral energy source