### PR TITLE
Experimental: Local timestepping for each cell

### DIFF
--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -53,6 +53,7 @@
 #include "include/quasineutral.hxx"
 #include "include/recycling.hxx"
 #include "include/relax_potential.hxx"
+#include "include/scale_timederivs.hxx"
 #include "include/set_temperature.hxx"
 #include "include/sheath_boundary.hxx"
 #include "include/sheath_boundary_insulating.hxx"

--- a/include/scale_timederivs.hxx
+++ b/include/scale_timederivs.hxx
@@ -30,7 +30,7 @@ struct ScaleTimeDerivs : public Component {
     auto Te = get<Field3D>(state["species"]["e"]["temperature"]);
     Field3D dt = dl2 / pow(Te, 5./2);
 
-    state["solver"]["scale_timederivs"] = dt / max(dt, true);
+    state["scale_timederivs"] = dt / max(dt, true);
   }
 
 private:

--- a/include/scale_timederivs.hxx
+++ b/include/scale_timederivs.hxx
@@ -11,29 +11,23 @@
 /// where the aim is to reach ddt -> 0
 ///
 struct ScaleTimeDerivs : public Component {
-  ScaleTimeDerivs(std::string name, Options &alloptions, Solver*) {
-    Options &options = alloptions[name];
-
-  }
+  ScaleTimeDerivs(std::string, Options&, Solver*) {}
 
   /// Sets in the state
   ///
-  /// - solver
-  ///   - scale_timederivs
+  /// - scale_timederivs
   ///
   void transform(Options &state) override {
-    
+
     auto* coord = bout::globals::mesh->getCoordinates();
     Field2D dl2 = coord->g_22 * SQ(coord->dy);
-    
+
     // Scale by parallel heat conduction CFL timescale
     auto Te = get<Field3D>(state["species"]["e"]["temperature"]);
-    Field3D dt = dl2 / pow(Te, 5./2);
+    Field3D dt = dl2 / pow(floor(Te, 1e-5), 5./2);
 
     state["scale_timederivs"] = dt / max(dt, true);
   }
-
-private:
 };
 
 namespace {

--- a/include/scale_timederivs.hxx
+++ b/include/scale_timederivs.hxx
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef SCALE_TIMEDERIVS_H
+#define SCALE_TIMEDERIVS_H
+
+#include "component.hxx"
+#include <globals.hxx>
+
+/// Scale time derivatives of the system
+///
+/// This is intended for steady-state calculations
+/// where the aim is to reach ddt -> 0
+///
+struct ScaleTimeDerivs : public Component {
+  ScaleTimeDerivs(std::string name, Options &alloptions, Solver*) {
+    Options &options = alloptions[name];
+
+  }
+
+  /// Sets in the state
+  ///
+  /// - solver
+  ///   - scale_timederivs
+  ///
+  void transform(Options &state) override {
+    
+    auto* coord = bout::globals::mesh->getCoordinates();
+    Field2D dl2 = coord->g_22 * SQ(coord->dy);
+    
+    // Scale by parallel heat conduction CFL timescale
+    auto Te = get<Field3D>(state["species"]["e"]["temperature"]);
+    Field3D dt = dl2 / pow(Te, 5./2);
+
+    state["solver"]["scale_timederivs"] = dt / max(dt, true);
+  }
+
+private:
+};
+
+namespace {
+RegisterComponent<ScaleTimeDerivs> registercomponentscaletimederivs("scale_timederivs");
+}
+
+#endif // SCALE_TIMEDERIVS_H
+

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -175,6 +175,11 @@ void EvolveDensity::finally(const Options& state) {
   }
   ddt(N) += Sn;
 
+  // Scale time derivatives
+  if (state["solver"]["scale_timederivs"].isSet()) {
+    ddt(N) *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  }
+
   if (evolve_log) {
     ddt(logN) = ddt(N) / N;
   }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -176,8 +176,8 @@ void EvolveDensity::finally(const Options& state) {
   ddt(N) += Sn;
 
   // Scale time derivatives
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    ddt(N) *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    ddt(N) *= get<Field3D>(state["scale_timederivs"]);
   }
 
   if (evolve_log) {

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -145,8 +145,8 @@ void EvolveMomentum::finally(const Options &state) {
   ddt(NV) += NV - NV_solver;
 
   // Scale time derivatives
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    ddt(NV) *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    ddt(NV) *= get<Field3D>(state["scale_timederivs"]);
   }
 
 #if CHECKLEVEL >= 1

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -144,6 +144,11 @@ void EvolveMomentum::finally(const Options &state) {
   // -> Add term to force NV_solver towards NV
   ddt(NV) += NV - NV_solver;
 
+  // Scale time derivatives
+  if (state["solver"]["scale_timederivs"].isSet()) {
+    ddt(NV) *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  }
+
 #if CHECKLEVEL >= 1
   for (auto& i : NV.getRegion("RGN_NOBNDRY")) {
     if (!std::isfinite(ddt(NV)[i])) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -272,8 +272,8 @@ void EvolvePressure::finally(const Options& state) {
   ddt(P) += N * T - P;
 
   // Scale time derivatives
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    ddt(P) *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    ddt(P) *= get<Field3D>(state["scale_timederivs"]);
   }
 
 #if CHECKLEVEL >= 1

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -371,8 +371,8 @@ void EvolvePressure::precon(const Options &state, BoutReal gamma) {
   // Set the coefficient in Div_par( B * Grad_par )
   Field3D coef = -(2. / 3) * gamma * kappa_par / floor(N, density_floor);
 
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    coef *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    coef *= get<Field3D>(state["scale_timederivs"]);
   }
 
   inv->setCoefB(coef);

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -355,8 +355,8 @@ void NeutralMixed::finally(const Options& state) {
   }
 
   // Scale time derivatives
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    Field3D scale_timederivs = get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    Field3D scale_timederivs = get<Field3D>(state["scale_timederivs"]);
     ddt(Nn) *= scale_timederivs;
     ddt(Pn) *= scale_timederivs;
     ddt(NVn) *= scale_timederivs;

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -353,6 +353,14 @@ void NeutralMixed::finally(const Options& state) {
       ddt(Nn)[i] = 0.0;
     }
   }
+
+  // Scale time derivatives
+  if (state["solver"]["scale_timederivs"].isSet()) {
+    Field3D scale_timederivs = get<Field3D>(state["solver"]["scale_timederivs"]);
+    ddt(Nn) *= scale_timederivs;
+    ddt(Pn) *= scale_timederivs;
+    ddt(NVn) *= scale_timederivs;
+  }
 }
 
 void NeutralMixed::outputVars(Options& state) {
@@ -463,7 +471,7 @@ void NeutralMixed::outputVars(Options& state) {
   }
 }
 
-void NeutralMixed::precon(const Options&, BoutReal gamma) {
+void NeutralMixed::precon(const Options& state, BoutReal gamma) {
   if (!precondition) {
     return;
   }
@@ -471,7 +479,13 @@ void NeutralMixed::precon(const Options&, BoutReal gamma) {
   // Neutral gas diffusion
   // Solve (1 - gamma*Dnn*Delp2)^{-1}
 
-  inv->setCoefD(-gamma * Dnn);
+  Field3D coef = -gamma * Dnn;
+
+  if (state["solver"]["scale_timederivs"].isSet()) {
+    coef *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  }
+
+  inv->setCoefD(coef);
 
   ddt(Nn) = inv->solve(ddt(Nn));
   ddt(NVn) = inv->solve(ddt(NVn));

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -481,8 +481,8 @@ void NeutralMixed::precon(const Options& state, BoutReal gamma) {
 
   Field3D coef = -gamma * Dnn;
 
-  if (state["solver"]["scale_timederivs"].isSet()) {
-    coef *= get<Field3D>(state["solver"]["scale_timederivs"]);
+  if (state.isSet("scale_timederivs")) {
+    coef *= get<Field3D>(state["scale_timederivs"]);
   }
 
   inv->setCoefD(coef);


### PR DESCRIPTION
Modify the time derivatives in each cell, scaling to something like the local CFL limit set by electron heat conduction. Intended to help control oscillations in tiny cells near core boundary. May help convergence to steady state for transport problems.

Enable by adding the `scale_timederivs` component once at the top level;

    [hermes]
    components = e, d+, ..., scale_timederivs

The component will calculate a timestep scaling factor for each cell, based on the electron temperature and the parallel cell size.  That scaling factor is then applied in the `evolve_density`, `evolve_momentum`, `evolve_pressure` and `neutral_mixed` components.

Note that with this the simulation time is not physical meaningful. 