### PR TITLE
Ensure that metrics are written to output file

### DIFF
--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -190,6 +190,9 @@ void Hermes::outputVars(Options& options) {
   // Save the Hermes version in the output dump files
   options["HERMES_REVISION"].force(hermes::version::revision);
 
+  // Ensure that metrics are updated
+  mesh->getCoordinates()->outputVars(options);
+
   // Save normalisation quantities. These may be used by components
   // to calculate conversion factors to SI units
 


### PR DESCRIPTION
Since BOUT++ v5 update the metric tensor components were not written to output after being recalculated and normalised. This adds them to the output file each timestep.

Should fix issue #113
