### PR TITLE
Add option to skip submodule update in CMAKE build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,25 @@ project(hermes-3 LANGUAGES CXX)
 # Extra CMake scripts in cmake/ subdirectory
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
-# Update submodules
+option(HERMES_UPDATE_GIT_SUBMODULE "Check submodules are up-to-date during build" ON)
 # Adapted from https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
-find_package(Git QUIET)
-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
-  message(STATUS "Submodule update")
-  execute_process(COMMAND ${GIT_EXECUTABLE} -c submodule.recurse=false submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    RESULT_VARIABLE GIT_SUBMOD_RESULT)
-  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+# Update submodules as needed
+function(hermes_update_submodules)
+  if(NOT HERMES_UPDATE_GIT_SUBMODULE)
+    return()
   endif()
-endif()
+  find_package(Git QUIET)
+  if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+    message(STATUS "Submodule update")
+    execute_process(COMMAND ${GIT_EXECUTABLE} -c submodule.recurse=false submodule update --init --recursive
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+      message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+  endif()
+endfunction()
+hermes_update_submodules()
 
 # Get the Git revision
 include(GetGitRevisionDescription)


### PR DESCRIPTION
Adds an option `HERMES_UPDATE_GIT_SUBMODULE` which uses identical code to `BOUT_UPDATE_GIT_SUBMODULE`. This is so that you can choose to build `hermes` with a modified local version of BOUT++ in `hermes-3/external/BOUT-dev/`