### PR TITLE
Advection operator improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(HERMES_SOURCES
     src/electromagnetic.cxx
     src/electron_force_balance.cxx
     src/evolve_density.cxx
-    src/vorticity.cxx
+    src/evolve_energy.cxx
     src/evolve_pressure.cxx
     src/evolve_momentum.cxx
     src/isothermal.cxx
@@ -93,6 +93,7 @@ set(HERMES_SOURCES
     src/thermal_force.cxx
     src/ion_viscosity.cxx
     src/transform.cxx
+    src/vorticity.cxx
     include/adas_reaction.hxx
     include/adas_carbon.hxx
     include/adas_neon.hxx
@@ -109,6 +110,7 @@ set(HERMES_SOURCES
     include/electromagnetic.hxx
     include/electron_force_balance.hxx
     include/evolve_density.hxx
+    include/evolve_energy.hxx
     include/evolve_momentum.hxx
     include/evolve_pressure.hxx
     include/fixed_density.hxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ if(HERMES_TESTS)
   hermes_add_integrated_test(neutral_mixed)
   hermes_add_integrated_test(vorticity)
   hermes_add_integrated_test(sod-shock)
+  hermes_add_integrated_test(sod-shock-energy)
 
   # Unit tests
   option(HERMES_UNIT_TESTS "Build the unit tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,3 +232,22 @@ if(HERMES_TESTS)
     target_link_libraries(hermes_unit_tests PRIVATE gtest bout++::bout++ hermes-3-lib)
   endif()
 endif()
+
+# Compile-time options
+
+set(SLOPE_LIMITERS MinMod MC Upwind)
+set(HERMES_SLOPE_LIMITER MinMod CACHE STRING "Set advection slope limiter")
+set_property(CACHE HERMES_SLOPE_LIMITER PROPERTY STRINGS ${SLOPE_LIMITERS})
+message(STATUS "Slope limiter: ${HERMES_SLOPE_LIMITER}")
+
+# Generate the build config header
+
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/hermes_build_config.hxx")
+  # If we do in source builds, this is fine
+  if (NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+    message(FATAL_ERROR "Generated hermes_build_config.hxx header already exists; please remove '${CMAKE_CURRENT_SOURCE_DIR}/include/hermes_build_config.hxx' before continuing")
+  endif()
+endif()
+
+configure_file(include/hermes_build_config.hxx.in include/hermes_build_config.hxx)
+

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -191,6 +191,32 @@ The implementation is in `EvolvePressure`:
 .. doxygenstruct:: EvolvePressure
    :members:
 
+.. _evolve_energy:
+
+evolve_energy
+~~~~~~~~~~~~~
+
+This evolves the species internal energy :math:`\mathcal{E}` in time:
+
+.. math::
+
+   \mathcal{E} = \frac{1}{\gamma - 1} P + \frac{1}{2}m nv_{||}^2
+
+Note that this component requires the parallel velocity :math:`v_{||}`
+to calculate the pressure. It must therefore be listed after a component
+that sets the velocity, such as `evolve_momentum`:
+
+.. code-block:: ini
+
+   [d]
+   type = ..., evolve_momentum, evolve_energy
+
+The energy density will be saved as `E<species>` (e.g `Ed`) and the
+pressure as `P<species>` (e.g. `Pd`). Additional diagnostics, such as the
+temperature, can be saved by setting the option `diagnose = true`.
+
+.. doxygenstruct:: EvolveEnergy
+   :members:
 
 SNB nonlocal heat flux
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -196,7 +196,8 @@ The implementation is in `EvolvePressure`:
 evolve_energy
 ~~~~~~~~~~~~~
 
-This evolves the species internal energy :math:`\mathcal{E}` in time:
+This evolves the sum of species internal energy and parallel kinetic
+energy, :math:`\mathcal{E}`:
 
 .. math::
 

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -196,6 +196,9 @@ The implementation is in `EvolvePressure`:
 evolve_energy
 ~~~~~~~~~~~~~
 
+*Note* This is currently under development and has some unresolved
+issues with boundary conditions.  Only for testing purposes.
+
 This evolves the sum of species internal energy and parallel kinetic
 energy, :math:`\mathcal{E}`:
 

--- a/docs/sphinx/getting_started.rst
+++ b/docs/sphinx/getting_started.rst
@@ -1,0 +1,102 @@
+.. _sec-getting_started:
+
+Getting started
+===============
+
+Installing
+----------
+
+Only CMake is supported for building Hermes-3 and running the tests.
+During configuration `BOUT++
+<https://github.com/boutproject/BOUT-dev/>`_ will be automatically
+downloaded as a submodule, together with some dependencies. `NetCDF
+<https://www.unidata.ucar.edu/software/netcdf/>`_ and `FFTW
+<https://www.fftw.org/>`_ are assumed to be installed already.  The
+`SUNDIALS <https://computing.llnl.gov/projects/sundials>`_ library is
+strongly recommended for time-dependent simulations, and `PETSc
+<https://petsc.org>`_ is needed to run some of the steady-state
+transport solver examples.
+
+If you only want to run time-dependent simulations, then the
+recommended way to build Hermes-3 links to the `SUNDIALS
+<https://computing.llnl.gov/projects/sundials>`_ library:
+
+#. Configure with cmake, downloading and linking to SUNDIALS:
+
+   .. code-block:: bash
+
+      cmake . -B build -DBOUT_DOWNLOAD_SUNDIALS=ON
+
+#. Build, compiling Hermes-3 and all dependencies:
+
+   .. code-block:: bash
+
+      cmake --build build
+
+#. Run the unit and integrated tests to check that everything is working:
+
+   .. code-block:: bash
+
+      cd build
+      ctest
+
+Note that the integrated tests require MPI, and so may not run on the
+head nodes of many computing clusters.
+
+The CMake configuration can be customised: See the [BOUT++
+documentation](https://bout-dev.readthedocs.io/en/latest/user_docs/installing.html#cmake)
+for examples of using `cmake` arguments, or edit the compile options
+interactively before building:
+
+.. code-block:: bash
+
+   ccmake . -B build
+
+If you have already installed BOUT++ and want to use that rather than
+configure and build BOUT++ again, set `HERMES_BUILD_BOUT` to `OFF` and pass
+CMake the path to the BOUT++ `build` directory e.g.
+
+.. code-block:: bash
+
+   cmake . -B build -DHERMES_BUILD_BOUT=OFF -DCMAKE_PREFIX_PATH=$HOME/BOUT-dev/build
+
+Note that Hermes-3 currently requires BOUT++ version 5.
+
+Building with PETSC
+-------------------
+
+When building PETSc it is recommended to include ``hypre``. The
+following PETSc configure line is a good starting point:
+
+.. code-block:: bash
+
+   ./configure --with-mpi=yes --download-hypre --download-make --with-fortran-bindings=0
+
+To configure Hermes-3 with PETSc, use the ``-DBOUT_USE_PETSC=ON`` flag:
+
+.. code-block:: bash
+
+      cmake . -B build -DBOUT_DOWNLOAD_SUNDIALS=ON -DBOUT_USE_PETSC=ON
+
+If the ``PETSC_DIR`` and ``PETSC_ARCH`` environment variables have been set,
+then CMake should pick them up.
+
+Numerical methods
+-----------------
+
+Advection operators in Hermes-3 use slope limiters, also called `flux
+limiters <https://en.wikipedia.org/wiki/Flux_limiter` to suppress
+spurious numerical oscillations near sharp features, while converging
+at 2nd-order in smooth regions. In general there is a trade-off
+between suppression of numerical oscillations and dissipation: Too
+little dissipation results in oscillations that can cause problems
+(e.g. negative densities), while too much dissipation smooths out real
+features and requires higher resolution to converge to the same
+accuracy. The optimal choice of method is problem-dependent.
+
+The CMake option ``HERMES_SLOPE_LIMITER`` sets the choice of slope
+limiter.  The default method is ``MinMod``, which has been found to
+provide a good balance for problems of interest. If less dissipation
+is required then this can be changed to ``MC`` (for Monotonized
+Central); For more dissipation (but 1st-order convergence) change it
+to ``Upwind``.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -8,6 +8,7 @@ Welcome to Hermes-3 documentation!
    :name: contents
 
    introduction
+   getting_started
    examples
    code_structure
    components

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -34,6 +34,7 @@
 #include "include/electromagnetic.hxx"
 #include "include/electron_force_balance.hxx"
 #include "include/evolve_density.hxx"
+#include "include/evolve_energy.hxx"
 #include "include/evolve_momentum.hxx"
 #include "include/evolve_pressure.hxx"
 #include "include/fixed_density.hxx"

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -1,6 +1,6 @@
 /*
   Finite volume discretisations of divergence operators
- 
+
   ***********
 
     Copyright B.Dudson, J.Leddy, University of York, September 2016
@@ -20,204 +20,380 @@
 
     You should have received a copy of the GNU General Public License
     along with Hermes.  If not, see <http://www.gnu.org/licenses/>.
-  
+
  */
 
 #ifndef __DIV_OPS_H__
 #define __DIV_OPS_H__
 
+#include <bout/fv_ops.hxx>
 #include <field3d.hxx>
 #include <vector3d.hxx>
-#include <bout/fv_ops.hxx>
 
 /*!
  * Diffusion in index space
- * 
+ *
  * Similar to using Div_par_diffusion(SQ(mesh->dy)*mesh->g_22, f)
  *
  * @param[in] The field to be differentiated
  * @param[in] bndry_flux  Are fluxes through the boundary calculated?
  */
-const Field3D Div_par_diffusion_index(const Field3D &f, bool bndry_flux=true);
+const Field3D Div_par_diffusion_index(const Field3D& f, bool bndry_flux = true);
 
-const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D &n, const Field3D &f, bool bndry_flux=true, bool poloidal=false, bool positive=false);
+const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f,
+                                    bool bndry_flux = true, bool poloidal = false,
+                                    bool positive = false);
 
-const Field3D Div_Perp_Lap_FV_Index(const Field3D &a, const Field3D &f, bool xflux);
-
+const Field3D Div_Perp_Lap_FV_Index(const Field3D& a, const Field3D& f, bool xflux);
 
 // 4th-order flux conserving term, in index space
-const Field3D D4DX4_FV_Index(const Field3D &f, bool bndry_flux=false);
+const Field3D D4DX4_FV_Index(const Field3D& f, bool bndry_flux = false);
 
 // Div ( k * Grad(f) )
-const Field2D Laplace_FV(const Field2D &k, const Field2D &f);
+const Field2D Laplace_FV(const Field2D& k, const Field2D& f);
 
 /// Perpendicular diffusion including X and Y directions
 const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
 
 namespace FV {
-  template<typename CellEdges = MC>
-  const Field3D Div_par_fvv(const Field3D &f_in, const Field3D &v_in,
-                            const Field3D &wave_speed_in, bool fixflux=true) {
+template <typename CellEdges = MC>
+const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
+                          const Field3D& wave_speed_in, bool fixflux = true) {
 
-    ASSERT1(areFieldsCompatible(f_in, v_in));
-    ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
+  ASSERT1(areFieldsCompatible(f_in, v_in));
+  ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
 
-    Mesh* mesh = f_in.getMesh();
+  Mesh* mesh = f_in.getMesh();
 
-    CellEdges cellboundary;
+  CellEdges cellboundary;
 
-    /// Ensure that f, v and wave_speed are field aligned
-    Field3D f = toFieldAligned(f_in, "RGN_NOX");
-    Field3D v = toFieldAligned(v_in, "RGN_NOX");
-    Field3D wave_speed = toFieldAligned(wave_speed_in, "RGN_NOX");
+  /// Ensure that f, v and wave_speed are field aligned
+  Field3D f = toFieldAligned(f_in, "RGN_NOX");
+  Field3D v = toFieldAligned(v_in, "RGN_NOX");
+  Field3D wave_speed = toFieldAligned(wave_speed_in, "RGN_NOX");
 
-    Coordinates *coord = f_in.getCoordinates();
+  Coordinates* coord = f_in.getCoordinates();
 
-    Field3D result{zeroFrom(f)};
-    
-    // Only need one guard cell, so no need to communicate fluxes
-    // Instead calculate in guard cells to preserve fluxes
-    int ys = mesh->ystart-1;
-    int ye = mesh->yend+1;
+  Field3D result{zeroFrom(f)};
 
-    for (int i = mesh->xstart; i <= mesh->xend; i++) {
+  // Only need one guard cell, so no need to communicate fluxes
+  // Instead calculate in guard cells to preserve fluxes
+  int ys = mesh->ystart - 1;
+  int ye = mesh->yend + 1;
 
-      if (!mesh->firstY(i) || mesh->periodicY(i)) {
-        // Calculate in guard cell to get fluxes consistent between processors
-        ys = mesh->ystart - 1;
-      } else {
-        // Don't include the boundary cell. Note that this implies special
-        // handling of boundaries later
-        ys = mesh->ystart;
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+
+    if (!mesh->firstY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cell to get fluxes consistent between processors
+      ys = mesh->ystart - 1;
+    } else {
+      // Don't include the boundary cell. Note that this implies special
+      // handling of boundaries later
+      ys = mesh->ystart;
+    }
+
+    if (!mesh->lastY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cells
+      ye = mesh->yend + 1;
+    } else {
+      // Not in boundary cells
+      ye = mesh->yend;
+    }
+
+    for (int j = ys; j <= ye; j++) {
+      // Pre-calculate factors which multiply fluxes
+
+      // For right cell boundaries
+      BoutReal common_factor = (coord->J(i, j) + coord->J(i, j + 1))
+                               / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
+
+      BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal flux_factor_rp =
+          common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
+
+      // For left cell boundaries
+      common_factor = (coord->J(i, j) + coord->J(i, j - 1))
+                      / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
+
+      BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal flux_factor_lm =
+          common_factor / (coord->dy(i, j - 1) * coord->J(i, j - 1));
+
+      for (int k = 0; k < mesh->LocalNz; k++) {
+
+        ////////////////////////////////////////////
+        // Reconstruct f at the cell faces
+        // This calculates s.R and s.L for the Right and Left
+        // face values on this cell
+
+        // Reconstruct f at the cell faces
+        Stencil1D s;
+        s.c = f(i, j, k);
+        s.m = f(i, j - 1, k);
+        s.p = f(i, j + 1, k);
+
+        cellboundary(s); // Calculate s.R and s.L
+
+        // Reconstruct v at the cell faces
+        Stencil1D sv;
+        sv.c = v(i, j, k);
+        sv.m = v(i, j - 1, k);
+        sv.p = v(i, j + 1, k);
+
+        cellboundary(sv);
+
+        ////////////////////////////////////////////
+        // Right boundary
+
+        // Calculate velocity at right boundary (y+1/2)
+        BoutReal vpar = 0.5 * (v(i, j, k) + v(i, j + 1, k));
+        BoutReal flux;
+
+        if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
+          // Last point in domain
+
+          BoutReal bndryval = 0.5 * (s.c + s.p);
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = bndryval * vpar * vpar;
+          } else {
+            // Add flux due to difference in boundary values
+            flux =
+                s.R * vpar * sv.R + wave_speed(i, j, k) * (s.R * sv.R - bndryval * vpar);
+          }
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k));
+
+          flux = s.R * 0.5 * (sv.R + amax) * sv.R;
+        }
+
+        result(i, j, k) += flux * flux_factor_rc;
+        result(i, j + 1, k) -= flux * flux_factor_rp;
+
+        ////////////////////////////////////////////
+        // Calculate at left boundary
+
+        vpar = 0.5 * (v(i, j, k) + v(i, j - 1, k));
+
+        if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
+          // First point in domain
+          BoutReal bndryval = 0.5 * (s.c + s.m);
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = bndryval * vpar * vpar;
+          } else {
+            // Add flux due to difference in boundary values
+            flux =
+                s.L * vpar * sv.L - wave_speed(i, j, k) * (s.L * sv.L - bndryval * vpar);
+          }
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k));
+
+          flux = s.L * 0.5 * (sv.L - amax) * sv.L;
+        }
+
+        result(i, j, k) -= flux * flux_factor_lc;
+        result(i, j - 1, k) += flux * flux_factor_lm;
       }
+    }
+  }
+  return fromFieldAligned(result, "RGN_NOBNDRY");
+}
+/// Finite volume parallel divergence
+///
+/// NOTE: Modified version, applies limiter to velocity and field
+///       Performs better (smaller overshoots) than Div_par
+///
+/// Preserves the sum of f*J*dx*dy*dz over the domain
+///
+/// @param[in] f_in   The field being advected.
+///                   This will be reconstructed at cell faces
+///                   using the given CellEdges method
+/// @param[in] v_in   The advection velocity.
+///                   This will be interpolated to cell boundaries
+///                   using linear interpolation
+/// @param[in] wave_speed_in  Local maximum speed of all waves in the system at each
+//                            point in space
+/// @param[in] fixflux     Fix the flux at the boundary to be the value at the
+///                        midpoint (for boundary conditions)
+///
+/// NB: Uses to/from FieldAligned coordinates
+template <typename CellEdges = MC>
+const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
+                          const Field3D& wave_speed_in, bool fixflux = true) {
 
-      if (!mesh->lastY(i) || mesh->periodicY(i)) {
-        // Calculate in guard cells
-        ye = mesh->yend + 1;
-      } else {
-        // Not in boundary cells
-        ye = mesh->yend;
-      }
+  ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
+  ASSERT1_FIELDS_COMPATIBLE(f_in, wave_speed_in);
 
-      for (int j = ys; j <= ye; j++) {
-        // Pre-calculate factors which multiply fluxes
+  Mesh* mesh = f_in.getMesh();
 
+  CellEdges cellboundary;
+
+  ASSERT2(f_in.getDirectionY() == v_in.getDirectionY());
+  ASSERT2(f_in.getDirectionY() == wave_speed_in.getDirectionY());
+  const bool are_unaligned =
+      ((f_in.getDirectionY() == YDirectionType::Standard)
+       and (v_in.getDirectionY() == YDirectionType::Standard)
+       and (wave_speed_in.getDirectionY() == YDirectionType::Standard));
+
+  Field3D f = are_unaligned ? toFieldAligned(f_in, "RGN_NOX") : f_in;
+  Field3D v = are_unaligned ? toFieldAligned(v_in, "RGN_NOX") : v_in;
+  Field3D wave_speed =
+      are_unaligned ? toFieldAligned(wave_speed_in, "RGN_NOX") : wave_speed_in;
+
+  Coordinates* coord = f_in.getCoordinates();
+
+  Field3D result{zeroFrom(f)};
+
+  // Only need one guard cell, so no need to communicate fluxes
+  // Instead calculate in guard cells to preserve fluxes
+  int ys = mesh->ystart - 1;
+  int ye = mesh->yend + 1;
+
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+
+    if (!mesh->firstY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cell to get fluxes consistent between processors
+      ys = mesh->ystart - 1;
+    } else {
+      // Don't include the boundary cell. Note that this implies special
+      // handling of boundaries later
+      ys = mesh->ystart;
+    }
+
+    if (!mesh->lastY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cells
+      ye = mesh->yend + 1;
+    } else {
+      // Not in boundary cells
+      ye = mesh->yend;
+    }
+
+    for (int j = ys; j <= ye; j++) {
+      // Pre-calculate factors which multiply fluxes
+#if not(BOUT_USE_METRIC_3D)
+      // For right cell boundaries
+      BoutReal common_factor = (coord->J(i, j) + coord->J(i, j + 1))
+                               / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
+
+      BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal flux_factor_rp =
+          common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
+
+      // For left cell boundaries
+      common_factor = (coord->J(i, j) + coord->J(i, j - 1))
+                      / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
+
+      BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal flux_factor_lm =
+          common_factor / (coord->dy(i, j - 1) * coord->J(i, j - 1));
+#endif
+      for (int k = 0; k < mesh->LocalNz; k++) {
+#if BOUT_USE_METRIC_3D
         // For right cell boundaries
-        BoutReal common_factor = (coord->J(i, j) + coord->J(i, j + 1)) /
-          (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
-        
-        BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
-        BoutReal flux_factor_rp = common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
+        BoutReal common_factor =
+            (coord->J(i, j, k) + coord->J(i, j + 1, k))
+            / (sqrt(coord->g_22(i, j, k)) + sqrt(coord->g_22(i, j + 1, k)));
+
+        BoutReal flux_factor_rc =
+            common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
+        BoutReal flux_factor_rp =
+            common_factor / (coord->dy(i, j + 1, k) * coord->J(i, j + 1, k));
 
         // For left cell boundaries
-        common_factor = (coord->J(i, j) + coord->J(i, j - 1)) /
-          (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
+        common_factor = (coord->J(i, j, k) + coord->J(i, j - 1, k))
+                        / (sqrt(coord->g_22(i, j, k)) + sqrt(coord->g_22(i, j - 1, k)));
 
-        BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
-        BoutReal flux_factor_lm = common_factor / (coord->dy(i, j - 1) * coord->J(i, j - 1));
-        
-        for (int k = 0; k < mesh->LocalNz; k++) {
+        BoutReal flux_factor_lc =
+            common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
+        BoutReal flux_factor_lm =
+            common_factor / (coord->dy(i, j - 1, k) * coord->J(i, j - 1, k));
+#endif
 
-          ////////////////////////////////////////////
-          // Reconstruct f at the cell faces
-          // This calculates s.R and s.L for the Right and Left
-          // face values on this cell
-          
-          // Reconstruct f at the cell faces
-          Stencil1D s;
-          s.c = f(i, j, k);
-          s.m = f(i, j - 1, k);
-          s.p = f(i, j + 1, k);
-          
-          cellboundary(s); // Calculate s.R and s.L
+        ////////////////////////////////////////////
+        // Reconstruct f at the cell faces
+        // This calculates s.R and s.L for the Right and Left
+        // face values on this cell
 
-          // Reconstruct v at the cell faces
-          Stencil1D sv;
-          sv.c = v(i, j, k);
-          sv.m = v(i, j - 1, k);
-          sv.p = v(i, j + 1, k);
-          
-          cellboundary(sv);
-          
-          ////////////////////////////////////////////
-          // Right boundary
+        // Reconstruct f at the cell faces
+        Stencil1D s;
+        s.c = f(i, j, k);
+        s.m = f(i, j - 1, k);
+        s.p = f(i, j + 1, k);
+
+        cellboundary(s); // Calculate s.R and s.L
+
+        ////////////////////////////////////////////
+        // Reconstruct v at the cell faces
+        Stencil1D sv;
+        sv.c = v(i, j, k);
+        sv.m = v(i, j - 1, k);
+        sv.p = v(i, j + 1, k);
+
+        cellboundary(sv); // Calculate sv.R and sv.L
+
+        ////////////////////////////////////////////
+        // Right boundary
+
+        BoutReal flux;
+
+        if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
+          // Last point in domain
 
           // Calculate velocity at right boundary (y+1/2)
           BoutReal vpar = 0.5 * (v(i, j, k) + v(i, j + 1, k));
-          BoutReal flux;
 
-          if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
-            // Last point in domain
-
-            BoutReal bndryval = 0.5 * (s.c + s.p);
-            if (fixflux) {
-              // Use mid-point to be consistent with boundary conditions
-              flux = bndryval * vpar * vpar;
-            } else {
-              // Add flux due to difference in boundary values
-              flux = s.R * vpar * sv.R + wave_speed(i, j, k) * (s.R * sv.R - bndryval * vpar);
-            }
-
+          BoutReal bndryval = 0.5 * (s.c + s.p);
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = bndryval * vpar;
           } else {
-
-            // Maximum wave speed in the two cells
-            BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k));
-
-            if (vpar > amax) {
-              // Supersonic flow out of this cell
-              flux = s.R * vpar * sv.R;
-            } else if (vpar < -amax) {
-              // Supersonic flow into this cell
-              flux = 0.0;
-            } else {
-              // Subsonic flow, so a mix of right and left fluxes
-              flux = s.R * 0.5 * (vpar + amax) * sv.R;
-            }
+            // Add flux due to difference in boundary values
+            flux = s.R * vpar + wave_speed(i, j, k) * (s.R - bndryval);
           }
+        } else {
 
-          result(i, j, k) += flux * flux_factor_rc;
-          result(i, j + 1, k) -= flux * flux_factor_rp;
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k));
 
-          ////////////////////////////////////////////
-          // Calculate at left boundary
-          
-          vpar = 0.5 * (v(i, j, k) + v(i, j - 1, k));
-
-          if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
-            // First point in domain
-            BoutReal bndryval = 0.5 * (s.c + s.m);
-            if (fixflux) {
-              // Use mid-point to be consistent with boundary conditions
-              flux = bndryval * vpar * vpar;
-            } else {
-              // Add flux due to difference in boundary values
-              flux = s.L * vpar * sv.L - wave_speed(i, j, k) * (s.L * sv.L - bndryval * vpar);
-            }
-          } else {
-            
-            // Maximum wave speed in the two cells
-            BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k));
-
-            if (vpar < -amax) {
-              // Supersonic out of this cell
-              flux = s.L * vpar * sv.L;
-            } else if (vpar > amax) {
-              // Supersonic into this cell
-              flux = 0.0;
-            } else {
-              flux = s.L * 0.5 * (vpar - amax) * sv.L;
-            }
-          }
-          
-          result(i, j, k) -= flux * flux_factor_lc;
-          result(i, j - 1, k) += flux * flux_factor_lm;
-          
+          flux = s.R * 0.5 * (sv.R + amax);
         }
+
+        result(i, j, k) += flux * flux_factor_rc;
+        result(i, j + 1, k) -= flux * flux_factor_rp;
+
+        ////////////////////////////////////////////
+        // Calculate at left boundary
+
+        if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
+          // First point in domain
+          BoutReal bndryval = 0.5 * (s.c + s.m);
+          BoutReal vpar = 0.5 * (v(i, j, k) + v(i, j - 1, k));
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = bndryval * vpar;
+          } else {
+            // Add flux due to difference in boundary values
+            flux = s.L * vpar - wave_speed(i, j, k) * (s.L - bndryval);
+          }
+        } else {
+
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k));
+
+          flux = s.L * 0.5 * (sv.L - amax);
+        }
+
+        result(i, j, k) -= flux * flux_factor_lc;
+        result(i, j - 1, k) += flux * flux_factor_lm;
       }
     }
-    return fromFieldAligned(result, "RGN_NOBNDRY");
   }
-  
+  return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
 }
+
+} // namespace FV
 
 #endif //  __DIV_OPS_H__

--- a/include/evolve_energy.hxx
+++ b/include/evolve_energy.hxx
@@ -2,7 +2,7 @@
 #ifndef EVOLVE_ENERGY_H
 #define EVOLVE_ENERGY_H
 
-#include <field3d.hxx>
+#include <bout/field3d.hxx>
 
 #include "component.hxx"
 

--- a/include/evolve_energy.hxx
+++ b/include/evolve_energy.hxx
@@ -1,0 +1,112 @@
+#pragma once
+#ifndef EVOLVE_ENERGY_H
+#define EVOLVE_ENERGY_H
+
+#include <field3d.hxx>
+
+#include "component.hxx"
+
+/// Evolves species internal energy in time
+///
+/// # Mesh inputs
+///
+/// P<name>_src   A source of pressure, in Pascals per second
+///               This can be over-ridden by the `source` option setting.
+///
+struct EvolveEnergy : public Component {
+  ///
+  /// # Inputs
+  ///
+  /// - <name>
+  ///   - bndry_flux           Allow flows through radial boundaries? Default is true
+  ///   - density_floor        Minimum density floor. Default 1e-5 normalised units.
+  ///   - diagnose             Output additional diagnostic fields?
+  ///   - evolve_log           Evolve logarithm of pressure? Default is false
+  ///   - hyper_z              Hyper-diffusion in Z
+  ///   - kappa_coefficient    Heat conduction constant. Default is 3.16 for
+  ///   electrons, 3.9 otherwise
+  ///   - kappa_limit_alpha    Flux limiter, off by default.
+  ///   - poloidal_flows       Include poloidal ExB flows? Default is true
+  ///   - precon               Enable preconditioner? Note: solver may not use it even if
+  ///   enabled.
+  ///   - thermal_conduction   Include parallel heat conduction? Default is true
+  ///
+  /// - E<name>  e.g. "Ee", "Ed+"
+  ///   - source     Source of energy [W / s].
+  ///                NOTE: This overrides mesh input P<name>_src
+  ///   - source_only_in_core         Zero the source outside the closed field-line
+  ///                                 region?
+  ///   - neumann_boundary_average_z  Apply Neumann boundaries with Z average?
+  ///
+  EvolveEnergy(std::string name, Options& options, Solver* solver);
+
+  /// Inputs
+  /// - species
+  ///   - <name>
+  ///     - density
+  ///     - velocity
+  ///
+  /// Sets
+  /// - species
+  ///   - <name>
+  ///     - pressure
+  ///     - temperature
+  ///
+  void transform(Options& state) override;
+
+  ///
+  /// Optional inputs
+  ///
+  /// - species
+  ///   - <name>
+  ///     - velocity. Must have sound_speed or temperature
+  ///     - energy_source
+  ///     - collision_rate  (needed if thermal_conduction on)
+  /// - fields
+  ///   - phi      Electrostatic potential -> ExB drift
+  ///
+  void finally(const Options& state) override;
+
+  void outputVars(Options& state) override;
+
+  /// Preconditioner
+  ///
+  void precon(const Options& UNUSED(state), BoutReal gamma) override;
+
+private:
+  std::string name; ///< Short name of the species e.g. h+
+
+  Field3D E;    ///< Energy (normalised): P + 1/2 m n v^2
+  Field3D P;    ///< Pressure (normalised)
+  Field3D T, N; ///< Temperature, density
+
+  BoutReal adiabatic_index; ///< Ratio of specific heats, γ = Cp / Cv
+  BoutReal Cv; /// Heat capacity at constant volume (3/2 for ideal monatomic gas)
+  bool bndry_flux;
+  bool neumann_boundary_average_z; ///< Apply neumann boundary with Z average?
+  bool poloidal_flows;
+  bool thermal_conduction;    ///< Include thermal conduction?
+  BoutReal kappa_coefficient; ///< Leading numerical coefficient in parallel heat flux
+                              ///< calculation
+  BoutReal kappa_limit_alpha; ///< Flux limit if >0
+
+  bool evolve_log; ///< Evolve logarithm of E?
+  Field3D logE;    ///< Natural logarithm of E
+
+  BoutReal density_floor; ///< Minimum density for calculating T
+  Field3D kappa_par;      ///< Parallel heat conduction coefficient
+
+  Field3D source; ///< External power source
+  Field3D Se;     ///< Total energy source
+
+  BoutReal hyper_z; ///< Hyper-diffusion
+
+  bool diagnose;      ///< Output additional diagnostics?
+  bool enable_precon; ///< Enable preconditioner?
+};
+
+namespace {
+RegisterComponent<EvolveEnergy> registercomponentevolveenergy("evolve_energy");
+}
+
+#endif // EVOLVE_ENERGY_H

--- a/include/hermes_build_config.hxx.in
+++ b/include/hermes_build_config.hxx.in
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef HERMES_BUILD_CONFIG_HXX
+#define HERMES_BUILD_CONFIG_HXX
+
+#include <bout/fv_ops.hxx>
+
+namespace hermes {
+  /// Slope limiter to use in advection operators
+  using Limiter=FV::@HERMES_SLOPE_LIMITER@;
+}
+
+#endif // HERMES_BUILD_CONFIG_HXX

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -203,7 +203,7 @@ void EvolveDensity::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(N) -= FV::Div_par<hermes::Limiter>(N, V, fastest_wave);
+    ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave);
   }
 
   if (low_n_diffuse) {

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -9,6 +9,7 @@
 #include "../include/div_ops.hxx"
 #include "../include/evolve_density.hxx"
 #include "../include/hermes_utils.hxx"
+#include "../include/hermes_build_config.hxx"
 
 using bout::globals::mesh;
 
@@ -202,7 +203,7 @@ void EvolveDensity::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(N) -= FV::Div_par(N, V, fastest_wave);
+    ddt(N) -= FV::Div_par<hermes::Limiter>(N, V, fastest_wave);
   }
 
   if (low_n_diffuse) {

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -10,6 +10,7 @@
 #include "../include/div_ops.hxx"
 #include "../include/evolve_energy.hxx"
 #include "../include/hermes_utils.hxx"
+#include "../include/hermes_build_config.hxx"
 
 using bout::globals::mesh;
 
@@ -222,7 +223,7 @@ void EvolveEnergy::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(E) -= FV::Div_par(E + P, V, fastest_wave);
+    ddt(E) -= FV::Div_par<hermes::Limiter>(E + P, V, fastest_wave);
   }
 
   if (species.isSet("low_n_coeff")) {

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -136,6 +136,7 @@ void EvolveEnergy::transform(Options& state) {
 
   // Calculate pressure
   // E = Cv * P + (1/2) m n v^2
+  P.allocate();
   BOUT_FOR(i, P.getRegion("RGN_NOBNDRY")) {
     P[i] = (E[i] - 0.5 * AA * N[i] * SQ(V[i])) / Cv;
     if (P[i] < 0.0) {

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -223,7 +223,7 @@ void EvolveEnergy::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(E) -= FV::Div_par<hermes::Limiter>(E + P, V, fastest_wave);
+    ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave);
   }
 
   if (species.isSet("low_n_coeff")) {

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -1,45 +1,53 @@
 
 #include <bout/constants.hxx>
 #include <bout/fv_ops.hxx>
+#include <bout/invert_pardiv.hxx>
+#include <bout/output_bout_types.hxx>
 #include <derivs.hxx>
 #include <difops.hxx>
-#include <bout/output_bout_types.hxx>
 #include <initialprofiles.hxx>
-#include <bout/invert_pardiv.hxx>
 
 #include "../include/div_ops.hxx"
-#include "../include/evolve_pressure.hxx"
+#include "../include/evolve_energy.hxx"
 #include "../include/hermes_utils.hxx"
 
 using bout::globals::mesh;
 
-EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* solver)
+EvolveEnergy::EvolveEnergy(std::string name, Options& alloptions, Solver* solver)
     : name(name) {
   AUTO_TRACE();
 
   auto& options = alloptions[name];
 
-  evolve_log = options["evolve_log"].doc("Evolve the logarithm of pressure?").withDefault<bool>(false);
+  adiabatic_index =
+      options["adiabatic_index"]
+          .doc("Ratio of specific heats γ = Cp/Cv [5/3 for monatomic ideal gas]")
+          .withDefault(5. / 3);
+  Cv = 1. / (adiabatic_index - 1.);
+
+  evolve_log = options["evolve_log"]
+                   .doc("Evolve the logarithm of energy?")
+                   .withDefault<bool>(false);
 
   density_floor = options["density_floor"].doc("Minimum density floor").withDefault(1e-5);
   if (evolve_log) {
-    // Evolve logarithm of pressure
-    solver->add(logP, std::string("logP") + name);
+    // Evolve logarithm of energy
+    solver->add(logE, std::string("logE") + name);
     // Save the pressure to the restart file
-    // so the simulation can be restarted evolving pressure
-    //get_restart_datafile()->addOnce(P, std::string("P") + name);
+    // so the simulation can be restarted evolving energy
+    // get_restart_datafile()->addOnce(E, std::string("E") + name);
 
     if (!alloptions["hermes"]["restarting"]) {
-      // Set logN from N input options
-      initial_profile(std::string("P") + name, P);
-      logP = log(P);
+      // Set logE from E input options
+      initial_profile(std::string("E") + name, E);
+      logE = log(E);
     } else {
       // Ignore these settings
-      Options::root()[std::string("P") + name].setConditionallyUsed();
+      Options::root()[std::string("E") + name].setConditionallyUsed();
     }
   } else {
-    // Evolve the pressure in time
-    solver->add(P, std::string("P") + name);
+    // Evolve the energy in time
+    solver->add(E, std::string("E") + name);
   }
 
   bndry_flux = options["bndry_flux"]
@@ -54,26 +62,24 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
                            .withDefault<bool>(true);
 
   kappa_coefficient = options["kappa_coefficient"]
-    .doc("Numerical coefficient in parallel heat conduction. Default is 3.16 for electrons, 3.9 otherwise")
-    .withDefault((name == "e") ? 3.16 : 3.9);
+                          .doc("Numerical coefficient in parallel heat conduction. "
+                               "Default is 3.16 for electrons, 3.9 otherwise")
+                          .withDefault((name == "e") ? 3.16 : 3.9);
 
   kappa_limit_alpha = options["kappa_limit_alpha"]
-    .doc("Flux limiter factor. < 0 means no limit. Typical is 0.2 for electrons, 1 for ions.")
-    .withDefault(-1.0);
-
-  p_div_v = options["p_div_v"]
-                .doc("Use p*Div(v) form? Default, false => v * Grad(p) form")
-                .withDefault<bool>(false);
+                          .doc("Flux limiter factor. < 0 means no limit. Typical is 0.2 "
+                               "for electrons, 1 for ions.")
+                          .withDefault(-1.0);
 
   hyper_z = options["hyper_z"].doc("Hyper-diffusion in Z").withDefault(-1.0);
 
   diagnose = options["diagnose"]
-    .doc("Save additional output diagnostics")
-    .withDefault<bool>(false);
+                 .doc("Save additional output diagnostics")
+                 .withDefault<bool>(false);
 
   enable_precon = options["precondition"]
-    .doc("Enable preconditioner? (Note: solver may not use it)")
-    .withDefault<bool>(true);
+                      .doc("Enable preconditioner? (Note: solver may not use it)")
+                      .withDefault<bool>(true);
 
   const Options& units = alloptions["units"];
   const BoutReal Nnorm = units["inv_meters_cubed"];
@@ -81,19 +87,20 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
   const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
 
   // Try to read the pressure source from the mesh
-  // Units of Pascals per second
   source = 0.0;
-  mesh->get(source, std::string("P") + name + "_src");
+  mesh->get(source, std::string("P") + name + "_src"); // Units of Pascals per second
+  source *= Cv;                                        // Convert to W/m^3
+
   // Allow the user to override the source
-  source = alloptions[std::string("P") + name]["source"]
-               .doc(std::string("Source term in ddt(P") + name
-                    + std::string("). Units [N/m^2/s]"))
+  source = alloptions[std::string("E") + name]["source"]
+               .doc(std::string("Source term in ddt(E") + name
+                    + std::string("). Units [W/m^3]"))
                .withDefault(source)
            / (SI::qe * Nnorm * Tnorm * Omega_ci);
 
-  if (alloptions[std::string("P") + name]["source_only_in_core"]
-      .doc("Zero the source outside the closed field-line region?")
-      .withDefault<bool>(false)) {
+  if (alloptions[std::string("E") + name]["source_only_in_core"]
+          .doc("Zero the source outside the closed field-line region?")
+          .withDefault<bool>(false)) {
     for (int x = mesh->xstart; x <= mesh->xend; x++) {
       if (!mesh->periodicY(x)) {
         // Not periodic, so not in core
@@ -106,20 +113,35 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
     }
   }
 
-  neumann_boundary_average_z = alloptions[std::string("P") + name]["neumann_boundary_average_z"]
-    .doc("Apply neumann boundary with Z average?")
-    .withDefault<bool>(false);
+  neumann_boundary_average_z =
+      alloptions[std::string("E") + name]["neumann_boundary_average_z"]
+          .doc("Apply neumann boundary with Z average?")
+          .withDefault<bool>(false);
 }
 
-void EvolvePressure::transform(Options& state) {
+void EvolveEnergy::transform(Options& state) {
   AUTO_TRACE();
 
   if (evolve_log) {
-    // Evolving logP, but most calculations use P
-    P = exp(logP);
+    // Evolving logE, but most calculations use E
+    E = exp(logE);
   }
 
-  mesh->communicate(P);
+  mesh->communicate(E);
+
+  auto& species = state["species"][name];
+  N = getNoBoundary<Field3D>(species["density"]);
+  const Field3D V = getNoBoundary<Field3D>(species["velocity"]);
+  const BoutReal AA = get<BoutReal>(species["AA"]);
+
+  // Calculate pressure
+  // E = Cv * P + (1/2) m n v^2
+  BOUT_FOR(i, P.getRegion("RGN_NOBNDRY")) {
+    P[i] = (E[i] - 0.5 * AA * N[i] * SQ(V[i])) / Cv;
+    if (P[i] < 0.0) {
+      P[i] = 0.0;
+    }
+  }
 
   if (neumann_boundary_average_z) {
     // Take Z (usually toroidal) average and apply as X (radial) boundary condition
@@ -155,42 +177,36 @@ void EvolvePressure::transform(Options& state) {
     }
   }
 
-  auto& species = state["species"][name];
-
   // Calculate temperature
-  // Not using density boundary condition
-  N = getNoBoundary<Field3D>(species["density"]);
+  T = P / floor(N, density_floor);
+  P = N * T; // Ensure consistency
 
-  Field3D Pfloor = floor(P, 0.0);
-  T = Pfloor / floor(N, density_floor);
-  Pfloor = N * T; // Ensure consistency
-
-  set(species["pressure"], Pfloor);
+  set(species["pressure"], P);
   set(species["temperature"], T);
 }
 
-void EvolvePressure::finally(const Options& state) {
+void EvolveEnergy::finally(const Options& state) {
   AUTO_TRACE();
 
   /// Get the section containing this species
   const auto& species = state["species"][name];
 
   // Get updated pressure and temperature with boundary conditions
-  // Note: Retain pressures which fall below zero
-  P.setBoundaryTo(get<Field3D>(species["pressure"]));
-  Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
-
+  P = get<Field3D>(species["pressure"]);
   T = get<Field3D>(species["temperature"]);
   N = get<Field3D>(species["density"]);
+  const Field3D V = get<Field3D>(species["velocity"]);
+
+  Field3D Pfloor = P;
 
   if (state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow
 
     Field3D phi = get<Field3D>(state["fields"]["phi"]);
 
-    ddt(P) = -Div_n_bxGrad_f_B_XPPM(P, phi, bndry_flux, poloidal_flows, true);
+    ddt(E) = -Div_n_bxGrad_f_B_XPPM(E, phi, bndry_flux, poloidal_flows, true);
   } else {
-    ddt(P) = 0.0;
+    ddt(E) = 0.0;
   }
 
   if (species.isSet("velocity")) {
@@ -201,32 +217,18 @@ void EvolvePressure::finally(const Options& state) {
     if (state.isSet("fastest_wave")) {
       fastest_wave = get<Field3D>(state["fastest_wave"]);
     } else {
-      BoutReal AA = get<BoutReal>(species["AA"]);
+      const BoutReal AA = get<BoutReal>(species["AA"]);
       fastest_wave = sqrt(T / AA);
     }
 
-    if (p_div_v) {
-      // Use the P * Div(V) form
-      ddt(P) -= FV::Div_par(P, V, fastest_wave);
-
-      // Work done. This balances energetically a term in the momentum equation
-      ddt(P) -= (2. / 3) * Pfloor * Div_par(V);
-
-    } else {
-      // Use V * Grad(P) form
-      // Note: A mixed form has been tried (on 1D neon example)
-      //       -(4/3)*FV::Div_par(P,V) + (1/3)*(V * Grad_par(P) - P * Div_par(V))
-      //       Caused heating of charged species near sheath like p_div_v
-      ddt(P) -= (5. / 3) * FV::Div_par(P, V, fastest_wave);
-
-      ddt(P) += (2. / 3) * V * Grad_par(P);
-    }
+    ddt(E) -= FV::Div_par(E + P, V, fastest_wave);
   }
 
   if (species.isSet("low_n_coeff")) {
     // Low density parallel diffusion
     Field3D low_n_coeff = get<Field3D>(species["low_n_coeff"]);
-    ddt(P) += FV::Div_par_K_Grad_par(low_n_coeff * T, N) + FV::Div_par_K_Grad_par(low_n_coeff, P);
+    ddt(E) += FV::Div_par_K_Grad_par(low_n_coeff * T, N)
+              + FV::Div_par_K_Grad_par(low_n_coeff, P);
   }
 
   // Parallel heat conduction
@@ -284,46 +286,45 @@ void EvolvePressure::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    ddt(P) += (2. / 3) * FV::Div_par_K_Grad_par(kappa_par, T, false);
+    ddt(E) += FV::Div_par_K_Grad_par(kappa_par, T, false);
   }
 
   if (hyper_z > 0.) {
     auto* coord = N.getCoordinates();
-    ddt(P) -= hyper_z * SQ(SQ(coord->dz)) * D4DZ4(P);
+    ddt(E) -= hyper_z * SQ(SQ(coord->dz)) * D4DZ4(E);
   }
 
   //////////////////////
   // Other sources
 
-  Sp = source;
+  Se = source;
   if (species.isSet("energy_source")) {
-    Sp += (2. / 3) * get<Field3D>(species["energy_source"]); // For diagnostic output
+    Se += get<Field3D>(species["energy_source"]); // For diagnostic output
   }
-  ddt(P) += Sp;
-
-  // Term to force evolved P towards N * T
-  // This is active when P < 0 or when N < density_floor
-  ddt(P) += N * T - P;
+  if (species.isSet("energy_source")) {
+    Se += V * get<Field3D>(species["momentum_source"]);
+  }
+  ddt(E) += Se;
 
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
-    ddt(P) *= get<Field3D>(state["scale_timederivs"]);
+    ddt(E) *= get<Field3D>(state["scale_timederivs"]);
   }
 
   if (evolve_log) {
-    ddt(logP) = ddt(P) / P;
+    ddt(logE) = ddt(E) / E;
   }
 
 #if CHECKLEVEL >= 1
-  for (auto& i : P.getRegion("RGN_NOBNDRY")) {
-    if (!std::isfinite(ddt(P)[i])) {
-      throw BoutException("ddt(P{}) non-finite at {}. Sp={}\n", name, i, Sp[i]);
+  for (auto& i : E.getRegion("RGN_NOBNDRY")) {
+    if (!std::isfinite(ddt(E)[i])) {
+      throw BoutException("ddt(E{}) non-finite at {}. Se={}\n", name, i, Se[i]);
     }
   }
 #endif
 }
 
-void EvolvePressure::outputVars(Options& state) {
+void EvolveEnergy::outputVars(Options& state) {
   AUTO_TRACE();
   // Normalisations
   auto Nnorm = get<BoutReal>(state["Nnorm"]);
@@ -334,16 +335,25 @@ void EvolvePressure::outputVars(Options& state) {
   BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
 
   if (evolve_log) {
-    state[std::string("P") + name].force(P);
+    state[std::string("E") + name].force(E);
   }
 
-  state[std::string("P") + name].setAttributes({{"time_dimension", "t"},
-                                                {"units", "Pa"},
+  state[std::string("E") + name].setAttributes({{"time_dimension", "t"},
+                                                {"units", "J/m^3"},
                                                 {"conversion", Pnorm},
-                                                {"standard_name", "pressure"},
-                                                {"long_name", name + " pressure"},
+                                                {"standard_name", "energy density"},
+                                                {"long_name", name + " energy density"},
                                                 {"species", name},
-                                                {"source", "evolve_pressure"}});
+                                                {"source", "evolve_energy"}});
+
+  set_with_attrs(state[std::string("P") + name], P,
+                 {{"time_dimension", "t"},
+                  {"units", "Pa"},
+                  {"conversion", Pnorm},
+                  {"standard_name", "pressure"},
+                  {"long_name", name + " pressure"},
+                  {"species", name},
+                  {"source", "evolve_energy"}});
 
   if (diagnose) {
     if (thermal_conduction) {
@@ -353,7 +363,7 @@ void EvolvePressure::outputVars(Options& state) {
                       {"conversion", Pnorm * Omega_ci * SQ(rho_s0)},
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
-                      {"source", "evolve_pressure"}});
+                      {"source", "evolve_energy"}});
     }
     set_with_attrs(state[std::string("T") + name], T,
                    {{"time_dimension", "t"},
@@ -362,37 +372,38 @@ void EvolvePressure::outputVars(Options& state) {
                     {"standard_name", "temperature"},
                     {"long_name", name + " temperature"},
                     {"species", name},
-                    {"source", "evolve_pressure"}});
+                    {"source", "evolve_energy"}});
 
-    set_with_attrs(state[std::string("ddt(P") + name + std::string(")")], ddt(P),
-                   {{"time_dimension", "t"},
-                    {"units", "Pa s^-1"},
-                    {"conversion", Pnorm * Omega_ci},
-                    {"long_name", std::string("Rate of change of ") + name + " pressure"},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+    set_with_attrs(
+        state[std::string("ddt(E") + name + std::string(")")], ddt(E),
+        {{"time_dimension", "t"},
+         {"units", "J/m^3/s"},
+         {"conversion", Pnorm * Omega_ci},
+         {"long_name", std::string("Rate of change of ") + name + " energy density"},
+         {"species", name},
+         {"source", "evolve_energy"}});
 
-    set_with_attrs(state[std::string("SP") + name], Sp,
+    set_with_attrs(state[std::string("SE") + name], Se,
                    {{"time_dimension", "t"},
-                    {"units", "Pa s^-1"},
+                    {"units", "W/m^3"},
                     {"conversion", Pnorm * Omega_ci},
-                    {"standard_name", "pressure source"},
-                    {"long_name", name + " pressure source"},
+                    {"standard_name", "energy source"},
+                    {"long_name", name + " energy source"},
                     {"species", name},
-                    {"source", "evolve_pressure"}});
+                    {"source", "evolve_energy"}});
 
-    set_with_attrs(state[std::string("P") + name + std::string("_src")], source,
+    set_with_attrs(state[std::string("E") + name + std::string("_src")], source,
                    {{"time_dimension", "t"},
-                    {"units", "Pa s^-1"},
+                    {"units", "W/m^3"},
                     {"conversion", Pnorm * Omega_ci},
-                    {"standard_name", "pressure source"},
-                    {"long_name", name + " pressure source"},
+                    {"standard_name", "energy source"},
+                    {"long_name", name + " energy source"},
                     {"species", name},
-                    {"source", "evolve_pressure"}});
+                    {"source", "evolve_energy"}});
   }
 }
 
-void EvolvePressure::precon(const Options &state, BoutReal gamma) {
+void EvolveEnergy::precon(const Options& state, BoutReal gamma) {
   if (!(enable_precon and thermal_conduction)) {
     return; // Disabled
   }
@@ -407,7 +418,7 @@ void EvolvePressure::precon(const Options &state, BoutReal gamma) {
   const Field3D N = get<Field3D>(species["density"]);
 
   // Set the coefficient in Div_par( B * Grad_par )
-  Field3D coef = -(2. / 3) * gamma * kappa_par / floor(N, density_floor);
+  Field3D coef = -gamma * kappa_par / floor(N, density_floor);
 
   if (state.isSet("scale_timederivs")) {
     coef *= get<Field3D>(state["scale_timederivs"]);

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -3,9 +3,9 @@
 #include <bout/fv_ops.hxx>
 #include <bout/invert_pardiv.hxx>
 #include <bout/output_bout_types.hxx>
-#include <derivs.hxx>
-#include <difops.hxx>
-#include <initialprofiles.hxx>
+#include <bout/derivs.hxx>
+#include <bout/difops.hxx>
+#include <bout/initialprofiles.hxx>
 
 #include "../include/div_ops.hxx"
 #include "../include/evolve_energy.hxx"

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -7,6 +7,7 @@
 
 #include "../include/evolve_momentum.hxx"
 #include "../include/div_ops.hxx"
+#include "../include/hermes_build_config.hxx"
 
 namespace {
 BoutReal floor(BoutReal value, BoutReal min) {
@@ -119,7 +120,7 @@ void EvolveMomentum::finally(const Options &state) {
 
   // Note: Density floor should be consistent with calculation of V
   //       otherwise energy conservation is affected
-  ddt(NV) -= AA * FV::Div_par_fvv(Nlim, V, fastest_wave, fix_momentum_boundary_flux);
+  ddt(NV) -= AA * FV::Div_par_fvv<hermes::Limiter>(Nlim, V, fastest_wave, fix_momentum_boundary_flux);
 
   // Parallel pressure gradient
   if (species.isSet("pressure")) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -10,6 +10,7 @@
 #include "../include/div_ops.hxx"
 #include "../include/evolve_pressure.hxx"
 #include "../include/hermes_utils.hxx"
+#include "../include/hermes_build_config.hxx"
 
 using bout::globals::mesh;
 
@@ -207,7 +208,7 @@ void EvolvePressure::finally(const Options& state) {
 
     if (p_div_v) {
       // Use the P * Div(V) form
-      ddt(P) -= FV::Div_par(P, V, fastest_wave);
+      ddt(P) -= FV::Div_par<hermes::Limiter>(P, V, fastest_wave);
 
       // Work done. This balances energetically a term in the momentum equation
       ddt(P) -= (2. / 3) * Pfloor * Div_par(V);
@@ -217,7 +218,7 @@ void EvolvePressure::finally(const Options& state) {
       // Note: A mixed form has been tried (on 1D neon example)
       //       -(4/3)*FV::Div_par(P,V) + (1/3)*(V * Grad_par(P) - P * Div_par(V))
       //       Caused heating of charged species near sheath like p_div_v
-      ddt(P) -= (5. / 3) * FV::Div_par(P, V, fastest_wave);
+      ddt(P) -= (5. / 3) * FV::Div_par<hermes::Limiter>(P, V, fastest_wave);
 
       ddt(P) += (2. / 3) * V * Grad_par(P);
     }

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -208,7 +208,7 @@ void EvolvePressure::finally(const Options& state) {
 
     if (p_div_v) {
       // Use the P * Div(V) form
-      ddt(P) -= FV::Div_par<hermes::Limiter>(P, V, fastest_wave);
+      ddt(P) -= FV::Div_par_mod<hermes::Limiter>(P, V, fastest_wave);
 
       // Work done. This balances energetically a term in the momentum equation
       ddt(P) -= (2. / 3) * Pfloor * Div_par(V);
@@ -218,7 +218,7 @@ void EvolvePressure::finally(const Options& state) {
       // Note: A mixed form has been tried (on 1D neon example)
       //       -(4/3)*FV::Div_par(P,V) + (1/3)*(V * Grad_par(P) - P * Div_par(V))
       //       Caused heating of charged species near sheath like p_div_v
-      ddt(P) -= (5. / 3) * FV::Div_par<hermes::Limiter>(P, V, fastest_wave);
+      ddt(P) -= (5. / 3) * FV::Div_par_mod<hermes::Limiter>(P, V, fastest_wave);
 
       ddt(P) += (2. / 3) * V * Grad_par(P);
     }

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -6,6 +6,7 @@
 
 #include "../include/div_ops.hxx"
 #include "../include/neutral_mixed.hxx"
+#include "../include/hermes_build_config.hxx"
 
 using bout::globals::mesh;
 
@@ -292,7 +293,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
-  ddt(Nn) = -FV::Div_par(Nn, Vn, sound_speed)      // Advection
+  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed) // Advection
             + FV::Div_a_Grad_perp(DnnNn, logPnlim) // Perpendicular diffusion
       ;
 
@@ -306,9 +307,10 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral momentum
   TRACE("Neutral momentum");
 
-  ddt(NVn) = - AA * FV::Div_par_fvv(Nnlim, Vn, sound_speed)      // Momentum flow
-             - Grad_par(Pn)                                      // Pressure gradient
-             + FV::Div_a_Grad_perp(DnnNVn, logPnlim)             // Perpendicular diffusion
+  ddt(NVn) =
+      -AA * FV::Div_par_fvv<hermes::Limiter>(Nnlim, Vn, sound_speed) // Momentum flow
+      - Grad_par(Pn)                                                 // Pressure gradient
+      + FV::Div_a_Grad_perp(DnnNVn, logPnlim) // Perpendicular diffusion
       ;
 
   if (neutral_viscosity) {
@@ -336,8 +338,8 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = -FV::Div_par(Pn, Vn, sound_speed)      // Advection
-            - (2. / 3) * Pn * Div_par(Vn)          // Compression
+  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed) // Advection
+            - (2. / 3) * Pn * Div_par(Vn)                          // Compression
             + FV::Div_a_Grad_perp(DnnPn, logPnlim) // Perpendicular diffusion
             + FV::Div_a_Grad_perp(DnnNn, Tn)       // Conduction
             + FV::Div_par_K_Grad_par(DnnNn, Tn)    // Parallel conduction

--- a/tests/integrated/1D-fluid/runtest
+++ b/tests/integrated/1D-fluid/runtest
@@ -19,7 +19,7 @@ from numpy import sqrt, max, abs, mean, array, log, concatenate
 shell("ln -s ../../../hermes-3 hermes-3")
 
 # List of NY values to use
-nylist = [20, 40, 80, 160] #, 320, 640]
+nylist = [40, 80, 160, 320]
 
 nout = 1
 timestep = 1

--- a/tests/integrated/1D-recycling/runtest
+++ b/tests/integrated/1D-recycling/runtest
@@ -44,7 +44,7 @@ if Te_up < 50 or Te_up > 70:
 Ti = collect("Td+", tind=-1, path=path)
 Ti_up = Ti[-1,0,0,0] * Tnorm
 # Upstream ion temperature should be about 140eV
-if Ti_up < 130 or Ti_up > 150:
+if Ti_up < 125 or Ti_up > 145:
   success = False
   print("Ion temperature failed: {}eV. Expecting about 140eV".format(Ti_up))
 

--- a/tests/integrated/sod-shock-energy/README.md
+++ b/tests/integrated/sod-shock-energy/README.md
@@ -1,0 +1,15 @@
+# Sod shock tube problem
+
+This version uses the `evolve_energy` component to solve energy
+(internal + kinetic) rather than pressure. The result is a correct
+capturing of the shock front location.
+
+To generate a plot, modify the `runtest` script and set
+`plotting = true`.
+
+Gary A Sod. A Survey of Several Finite Difference Methods for Systems
+of Nonlinear Hyperbolic Conservation Laws. Journal of Computational
+Physics, 1978, 27 (1), pp.1-31. 10.1016/0021-
+9991(78)90023-2. hal-01635155
+
+https://hal.science/hal-01635155

--- a/tests/integrated/sod-shock-energy/data/BOUT.inp
+++ b/tests/integrated/sod-shock-energy/data/BOUT.inp
@@ -1,0 +1,63 @@
+nout = 10
+timestep = 0.02
+
+MXG = 0  # No guard cells in X
+
+[mesh]
+nx = 1
+ny = 100 # dx = 0.01 in Sod paper
+nz = 1
+
+ixseps1 = -1 # Boundaries in Y
+
+Ly = 1  # Length of the domain
+
+dy = Ly / ny
+
+[solver]
+mxstep = 10000
+
+[hermes]
+components = i, sound_speed
+
+loadmetric = false        # Use Rxy, Bpxy etc?
+normalise_metric = false  # Normalise the input metric?
+
+Mp = 1.672621898e-27 # Proton mass
+qe = 1.602176634e-19 # Electron charge
+
+Bnorm = Mp / qe # Sets time to seconds
+Tnorm = Mp / qe # Length to meters
+Nnorm = 1 / Mp  # Sets Pi to Pascals, Ni to kg/m^3
+
+[i]  # Ions
+type = evolve_density, evolve_momentum, evolve_energy
+
+charge = 1.0
+AA = 1.0
+
+thermal_conduction = false  # in evolve_pressure
+
+[Ni]
+
+bndry_all = neumann
+
+# Jumps from rho_L on left to rho_R on right
+rho_L = 1.0
+rho_R = 0.125
+function = rho_L + H(y - pi) * (rho_R - rho_L)
+
+[Ei]
+
+bndry_all = neumann
+
+# Jump from p_L to p_R
+p_L = 1.0
+p_R = 0.1
+function = (3/2) * (p_L + H(y - pi) * (p_R - p_L))
+
+[NVi]
+
+bndry_all = dirichlet
+
+function = 0

--- a/tests/integrated/sod-shock-energy/runtest
+++ b/tests/integrated/sod-shock-energy/runtest
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+#
+# Sod shock tube problem
+#
+# References:
+#   https://en.wikipedia.org/wiki/Sod_shock_tube
+#   https://www.mathworks.com/matlabcentral/fileexchange/46311-sod-shock-tube-problem-solver
+#
+
+resolutions = [
+    (100, "ob", 0.05),
+    (400, "-r", 0.02),
+    # (1600, '-g', 0.01)
+]
+
+plotting = False
+
+from math import sqrt
+import numpy as np
+from boututils.run_wrapper import shell, launch, getmpirun
+from boutdata.collect import collect
+import sys
+
+# Semi-analytic Sod shock problem
+# 5 regions:
+#
+#  P1, rho1  | P2, rho2  |  P3, rho3  | P4, rho4 | P5, rho5
+#           pos12      pos23        pos34      pos45
+
+x0 = 0.5  # Starting position
+gamma = 5.0 / 3
+time = 0.2  # In seconds
+
+G = (gamma - 1) / (gamma + 1)
+beta = (gamma - 1) / (2 * gamma)
+
+P1 = 1.0  # Left pressure
+rho1 = 1.0  # Left density
+
+P5 = 0.1  # Right pressure
+rho5 = 0.125  # Right density
+
+cs1 = sqrt(gamma * P1 / rho1)
+cs5 = sqrt(gamma * P5 / rho5)
+
+# Iteratively calculate P3, the post-shock pressure
+P3 = 0.5 * (P5 + P1)
+while True:
+    u4 = (P3 - P5) * sqrt((1 - G) / (rho5 * (P3 + G * P5)))
+    u3 = u4
+    P3_new = (
+        P1**beta - u3 * sqrt(G**2 * rho1 / ((1 - G**2) * P1 ** (1 / gamma)))
+    ) ** (1 / beta)
+    P3 = 0.5 * (P3 + P3_new)
+    if abs(P3_new - P3) < 1e-10:
+        break
+
+P4 = P3
+
+rho3 = rho1 * (P3 / P1) ** (1 / gamma)
+rho4 = rho5 * (P4 + G * P5) / (P5 + G * P4)
+
+# Velocity of the shock
+v_shock = u3 * ((rho4 / rho5) / ((rho4 / rho5) - 1))
+
+# Key positions
+pos12 = 0.5 - cs1 * time
+pos34 = 0.5 + u3 * time  # Post-shock velocity
+pos45 = 0.5 + v_shock * time
+
+# Determine pos23
+cs2 = cs1 - ((gamma - 1) / 2) * u3
+pos23 = x0 + (u3 - cs2) * time
+
+if plotting:
+    try:
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.axes_grid1.inset_locator import (
+            inset_axes,
+            InsetPosition,
+            mark_inset,
+        )
+
+        # Create x_exact and rho_exact for plotting
+
+        # Region 1
+        x_exact = [0, pos12]
+        rho_exact = [rho1, rho1]
+
+        # Region 2
+        x2 = np.linspace(pos12, pos23, endpoint=True)
+        c = G * ((x0 - x2) / time) + (1 - G) * cs1
+        rho_exact2 = rho1 * (c / cs1) ** (2 / (gamma - 1))
+
+        x_exact += list(x2)
+        rho_exact += list(rho_exact2)
+
+        # Regions 3, 4, 5
+
+        x_exact += [pos23, pos34, pos34, pos45, pos45, 1]
+        rho_exact += [rho3, rho3, rho4, rho4, rho5, rho5]
+
+        fig, ax1 = plt.subplots()
+        ax1.plot(x_exact, rho_exact, "k")
+
+        ax2 = plt.axes([0, 0, 1, 1])
+        ax2.plot(x_exact, rho_exact, "k")
+        ax2.set_xlim(0.82, 0.9)
+        ax2.set_ylim(0.11, 0.25)
+
+        # Manually set the position and relative size of the inset axes within ax1
+        ip = InsetPosition(ax1, [0.01, 0.03, 0.4, 0.4])
+        ax2.set_axes_locator(ip)
+        # Mark the region corresponding to the inset axes on ax1 and draw lines
+        # in grey linking the two axes.
+        mark_inset(ax1, ax2, loc1=2, loc2=4, fc="none", ec="0.5")
+    except:
+        raise
+        print("WARNING: Could not import Matplotlib")
+        plotting = False
+
+# Perform simulations at required resolutions
+
+# Link to the executable
+shell("ln -s ../../../hermes-3 hermes-3")
+
+errs = []
+for ny, sym, tol in resolutions:
+    # Delete old data
+    shell("rm data/BOUT.dmp.*.nc")
+
+    # Launch using MPI
+    s, out = launch(f"./hermes-3 mesh:ny={ny}", nproc=1, pipe=True)
+
+    # Save output to log file
+    f = open(f"run.log.{ny}", "w")
+    f.write(out)
+    f.close()
+
+    n = collect("Ni", path="data", tind=-1, info=False).squeeze()
+
+    assert ny == len(n)
+    xs = (np.arange(ny) + 0.5) / ny
+
+    # Calculate exact solution
+    rho = np.zeros(ny)
+    for i, x in enumerate(xs):
+        if x < pos12:
+            rho[i] = rho1
+        elif x < pos23:
+            c = G * ((x0 - x) / time) + (1 - G) * cs1
+            rho[i] = rho1 * (c / cs1) ** (2 / (gamma - 1))
+        elif x < pos34:
+            rho[i] = rho3
+        elif x < pos45:
+            rho[i] = rho4
+        else:
+            rho[i] = rho5
+
+    err = np.sqrt(np.mean((n - rho) ** 2))
+
+    if err > tol:
+        print(f"ny = {ny} err = {err} tol = {tol}")
+        print(" => Test failed")
+        sys.exit(1)
+
+    errs.append(err)
+
+    if plotting:
+        ax1.plot(xs, n, sym, label=f"n = {ny} $l_2={err:.3}$", mfc="none")
+        ax2.plot(xs, n, sym, mfc="none")
+
+print(errs)
+
+if plotting:
+    ax1.set_xlabel(r"Location $x$")
+    ax1.set_ylabel(r"Density $\rho$")
+    ax1.legend()
+
+    ax2.set_yticks([])
+    ax2.set_xticks([])
+
+    plt.savefig("sod_shock.png")
+    plt.savefig("sod_shock.pdf")
+    plt.show()
+
+
+print(" => Test passed")
+sys.exit(0)

--- a/tests/integrated/sod-shock/runtest
+++ b/tests/integrated/sod-shock/runtest
@@ -75,7 +75,7 @@ pos23 = x0 + (u3 - cs2) * time
 if plotting:
     try:
         import matplotlib.pyplot as plt
-        from mpl_toolkits.axes_grid.inset_locator import (
+        from mpl_toolkits.axes_grid1.inset_locator import (
             inset_axes,
             InsetPosition,
             mark_inset,


### PR DESCRIPTION
This started as a project to add an `evolve_energy` component, but evolved into a fairly major change to the advection operators. The limiter has become a compile-time choice, and by default changed from MC to MinMod. The results of the Sod shock test are now much improved.

The `evolve_energy` component evolves the sum of internal energy and parallel kinetic energy, as an alternative to the evolve_pressure component. The boundary conditions are not yet imposed correctly, so a note has been added to the manual. I think it's still worth merging this early for all the other improvements.