### PR TITLE
Ion viscosity

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -345,6 +345,113 @@ and all other species therefore need to be calculated before this component is r
 .. doxygenstruct:: ElectronViscosity
    :members:
 
+ion_viscosity
+-------------
+
+Adds ion viscosity terms to all charged species that are not electrons.
+The collision frequency is required so this is a top-level component that
+must be calculated after collisions:
+
+.. code-block:: ini
+
+   [hermes]
+   components =  ..., collisions, ion_viscosity
+
+By default only the parallel diffusion of momentum is included, adding a force to each
+ion's momentum equation:
+
+.. math::
+
+   F = \sqrt{B}\nabla\cdot\left[\frac{\eta_i}{B}\mathbf{b}\mathbf{b}\cdot\nabla\left(\sqrt{B}V_{||i}\right)\right]
+
+The ion parallel viscosity is
+
+.. math::
+
+   \eta_i = \frac{4}{3} 0.96 p_i \tau_i
+
+If the `perpendicular` option is set:
+
+.. code-block:: ini
+
+   [ion_viscosity]
+   perpendicular = true # Include perpendicular flows
+
+Then the ion scalar viscous pressure is calculated as:
+
+.. math::
+
+   \Pi_{ci} = \Pi_{ci||} + \Pi_{ci\perp}
+
+where :math:`\Pi_{ci||}` corresponds to the parallel diffusion of momentum above.
+
+.. math::
+
+   \Pi_{ci||} = - 0.96 \frac{2p_i\tau_i}{\sqrt{B}} \partial_{||}\left(\sqrt{B} V_{||i}\right)
+
+The perpendicular part is calculated from:
+
+.. math::
+
+   \begin{aligned}\Pi_{ci\perp} =& 0.96 p_i\tau_i \kappa \cdot \left[\mathbf{V}_E + \mathbf{V}_{di} + 1.16\frac{\mathbf{b}\times\nabla T_i}{B} \right] \\
+   =& -0.96 p_i\tau_i\frac{1}{B}\left(\mathbf{b}\times\kappa\right)\cdot\left[\nabla\phi + \frac{\nabla p_i}{en_i} + 1.61\nabla T_i \right]\end{aligned}
+
+
+A parallel force term is added, in addition to the parallel viscosity above:
+
+.. math::
+
+   F = -\frac{2}{3}B^{3/2}\partial_{||}\left(\frac{\Pi_{ci\perp}{B^{3/2}}\right)
+   
+In the vorticity equation the viscosity appears as a divergence of a current:
+
+.. math::
+
+   \mathbf{J}_{ci} = \frac{\Pi_{ci}}{2}\nabla\times\frac{\mathbf{b}}{B} - \frac{1}{3}\frac{\mathbf{b}\times\nabla\Pi_{ci}}{B}
+
+that transfers energy between ion internal energy and $E\times B$ energy:
+
+.. math::
+
+   \begin{aligned}\frac{\partial \omega}{\partial t} =& \ldots + \nabla\cdot\mathbf{J}_{ci} \\
+   \frac{\partial p_i}{\partial t} =& \ldots - \mathbf{J}_{ci}\cdot\nabla\left(\phi + \frac{p_i}{n_0}\right)
+
+Note that the sum of the perpendicular and parallel contributions to the ion viscosity act to damp
+the net poloidal flow. This can be seen by assuming that :math:`\phi`, :math:`p_i` and :math:`T_i`
+are flux functions. We can then write:
+
+.. math::
+
+   \Pi_{ci\perp} = -0.96 p_i\tau_i \frac{1}{B}\left(\mathbf{b}\times\kappa\right)\cdot\nabla\psi F\left(\psi\right)
+
+where
+
+.. math::
+
+   F\left(\psi\right) = \frac{\partial\phi}{\partial\psi} + \frac{1}{en}\frac{\partial p_i}{\partial\psi} + 1.61\frac{\partial T_i}{\partial\psi}
+
+Using the approximation
+
+.. math::
+
+   \left(\mathbf{b}\times\kappa\right)\cdot\nabla\psi \simeq -RB_\zeta \partial_{||}\ln B
+
+expanding:
+
+.. math::
+
+   \frac{2}{\sqrt{B}}\partial_{||}\left(\sqrt{B}V_{||i}\right) = 2\partial_{||}V_{||i} + V_{||i}\partial_{||}\ln B
+
+and neglecting parallel gradients of velocity gives:
+
+.. math::
+
+   \Pi_{ci} \simeq 0.96 p_i\tau_i \left[ \frac{RB_{\zeta}}{B}F\left(\psi\right) - V_{||i} \right]\partial_{||}\ln B
+
+   
+.. doxygenstruct:: IonViscosity
+   :members:
+
 simple_conduction
 -----------------
 

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1408,26 +1408,77 @@ vorticity
 Evolves a vorticity equation, and at each call to transform() uses a matrix
 inversion to calculate potential from vorticity.
 
-In this component the Boussinesq approximation is made, so the vorticity equation solved is
+In this component the Boussinesq approximation is made, so the
+vorticity equation solved is
 
 .. math::
 
-   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi + \sum_i\frac{A_i}{B^2}\nabla_\perp p_i\right) = \Omega
+   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi \underbrace{+ \sum_i\frac{A_i}{Z_i B^2}\nabla_\perp p_i}_{\mathrm{if diamagnetic_polarisation}}}\right) = \Omega
 
 Where the sum is over species, :math:`\overline{A}` is the average ion
 atomic number, and :math:`\overline{n}` is the normalisation density
-(i.e. goes to 1 in the normalised equations).  This is a simplified
-version of the full expression which is:
+(i.e. goes to 1 in the normalised equations). The ion diamagnetic flow
+terms in this Boussinesq approximation can be written in terms of an
+effective ion pressure :math:`\hat{p}`:
 
 .. math::
 
-   \nabla\cdot\left(\sum_i \frac{A_i n_i}{B^2}\nabla_\perp \phi + \sum_i \frac{A_i}{B^2}\nabla_\perp p_i\right) = \Omega
+   \hat{p} \equiv \sum_i \frac{A_i}{overline{A} Z_i} p_i
+
+as
+
+.. math::
+
+   \nabla\cdot\left[\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \left(\phi + \frac{\hat{p}}{\overline{n}}\right) \right] = \Omega
+   
+Note that if ``diamagnetic_polarisation = false`` then the ion
+pressure terms are removed from the vorticity, and also from other ion
+pressure terms coming from the polarisation current
+(i.e. :math:`\hat{p}\rightarrow 0`.
+
+This is a simplified version of the full vorticity definition which is:
+
+.. math::
+
+   \nabla\cdot\left(\sum_i \frac{A_i n_i}{B^2}\nabla_\perp \phi + \sum_i \frac{A_i}{Z_i B^2}\nabla_\perp p_i\right) = \Omega
 
 and is derived by replacing
 
 .. math::
 
    \sum_i A_i n_i \rightarrow \overline{A}\overline{n}
+
+In the case of multiple species, this Boussinesq approximation means that the ion diamagnetic flow
+terms 
+
+The vorticity equation that is integrated in time is
+
+.. math::
+
+   \begin{aligned}\frac{\partial \Omega}{\partial t} =& \nabla\cdot\left(\mathbf{b}\sum_s Z_s n_sV_{||s}\right) \\
+   &+ \underbrace{\nabla\cdot\left(\nabla\times\frac{\mathbf{b}}{B}\sum_s p_s\right)}_{\textrm{if diamagnetic}} + \underbrace{\nabla\cdot\mathbf{J_{exb}}}_{\mathrm{if exb_advection}} \\
+   &+ \nabla\cdot\left(\mathbf{b}J_{extra}\right)\end{aligned}
+
+The nonlinearity :math:`\nabla\cdot\mathbf{J_{exb}}` is part of the
+divergence of polarisation current. In its simplified form when
+``exb_advection_simplified = true``, this is the :math:`E\times B`
+advection of vorticity:
+
+.. math::
+
+   \nabla\cdot\mathbf{J_{exb}} = -\nabla\cdot\left(\Omega \mathbf{V}_{E\times B}\right)
+
+When ``exb_advection_simplified = false`` then the more complete
+(Boussinesq approximation) form is used:
+
+.. math::
+
+   \nabla\cdot\mathbf{J_{exb}} = -\nabla\cdot\left[\frac{\overline{A}}{2B^2}\nabla_\perp\left(\mathbf{V}_{E\times B}\cdot\nabla \hat{p}\right) + \frac{\Omega}{2} \mathbf{V}_{E\times B} + \frac{\overline{A}\overline{n}}{2B^2}\nabla_\perp^2\phi\left(\mathbf{V}_{E\times B} + \frac{\mathbf{b}}{B}\times\nabla\hat{p}\right) \right]
+   
+The form of the vorticity equation is based on Simakov & Catto
+(erratum 2004), with the first term modified to conserve energy. In
+the limit of zero ion pressure and constant :math:`B` it reduces to
+the simplified form.
 
 .. doxygenstruct:: Vorticity
    :members:

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -424,7 +424,7 @@ A parallel force term is added, in addition to the parallel viscosity above:
 
 .. math::
 
-   F = -\frac{2}{3}B^{3/2}\partial_{||}\left(\frac{\Pi_{ci\perp}{B^{3/2}}\right)
+   F = -\frac{2}{3}B^{3/2}\partial_{||}\left(\frac{\Pi_{ci\perp}}{B^{3/2}}\right)
    
 In the vorticity equation the viscosity appears as a divergence of a current:
 
@@ -432,12 +432,12 @@ In the vorticity equation the viscosity appears as a divergence of a current:
 
    \mathbf{J}_{ci} = \frac{\Pi_{ci}}{2}\nabla\times\frac{\mathbf{b}}{B} - \frac{1}{3}\frac{\mathbf{b}\times\nabla\Pi_{ci}}{B}
 
-that transfers energy between ion internal energy and $E\times B$ energy:
+that transfers energy between ion internal energy and :math:`E\times B` energy:
 
 .. math::
 
    \begin{aligned}\frac{\partial \omega}{\partial t} =& \ldots + \nabla\cdot\mathbf{J}_{ci} \\
-   \frac{\partial p_i}{\partial t} =& \ldots - \mathbf{J}_{ci}\cdot\nabla\left(\phi + \frac{p_i}{n_0}\right)
+   \frac{\partial p_i}{\partial t} =& \ldots - \mathbf{J}_{ci}\cdot\nabla\left(\phi + \frac{p_i}{n_0}\right)\end{aligned}
 
 Note that the sum of the perpendicular and parallel contributions to the ion viscosity act to damp
 the net poloidal flow. This can be seen by assuming that :math:`\phi`, :math:`p_i` and :math:`T_i`
@@ -470,6 +470,13 @@ and neglecting parallel gradients of velocity gives:
 .. math::
 
    \Pi_{ci} \simeq 0.96 p_i\tau_i \left[ \frac{RB_{\zeta}}{B}F\left(\psi\right) - V_{||i} \right]\partial_{||}\ln B
+
+   
+**Notes** and implementation details:
+- The magnitude of :math:`\Pi_{ci\perp}` and :math:`\Pi_{ci||}` are individually
+  limited to be less than or equal to the scalar pressure :math:`Pi` (though can have
+  opposite sign). The reasoning is that if these off-diagonal terms become large then
+  the model is likely breaking down. Occasionally happens in low-density regions.
 
    
 .. doxygenstruct:: IonViscosity
@@ -1413,7 +1420,7 @@ vorticity equation solved is
 
 .. math::
 
-   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi \underbrace{+ \sum_i\frac{A_i}{Z_i B^2}\nabla_\perp p_i}_{\mathrm{if diamagnetic_polarisation}}}\right) = \Omega
+   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi \underbrace{+ \sum_i\frac{A_i}{Z_i B^2}\nabla_\perp p_i}_{\mathrm{if diamagnetic_polarisation}}\right) = \Omega
 
 Where the sum is over species, :math:`\overline{A}` is the average ion
 atomic number, and :math:`\overline{n}` is the normalisation density
@@ -1423,7 +1430,7 @@ effective ion pressure :math:`\hat{p}`:
 
 .. math::
 
-   \hat{p} \equiv \sum_i \frac{A_i}{overline{A} Z_i} p_i
+   \hat{p} \equiv \sum_i \frac{A_i}{\overline{A} Z_i} p_i
 
 as
 
@@ -1456,7 +1463,7 @@ The vorticity equation that is integrated in time is
 .. math::
 
    \begin{aligned}\frac{\partial \Omega}{\partial t} =& \nabla\cdot\left(\mathbf{b}\sum_s Z_s n_sV_{||s}\right) \\
-   &+ \underbrace{\nabla\cdot\left(\nabla\times\frac{\mathbf{b}}{B}\sum_s p_s\right)}_{\textrm{if diamagnetic}} + \underbrace{\nabla\cdot\mathbf{J_{exb}}}_{\mathrm{if exb_advection}} \\
+   &+ \underbrace{\nabla\cdot\left(\nabla\times\frac{\mathbf{b}}{B}\sum_s p_s\right)}_{\textrm{if diamagnetic}} + \underbrace{\nabla\cdot\mathbf{J_{exb}}}_{\mathrm{if exb\_advection}} \\
    &+ \nabla\cdot\left(\mathbf{b}J_{extra}\right)\end{aligned}
 
 The nonlinearity :math:`\nabla\cdot\mathbf{J_{exb}}` is part of the

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1420,7 +1420,7 @@ vorticity equation solved is
 
 .. math::
 
-   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi \underbrace{+ \sum_i\frac{A_i}{Z_i B^2}\nabla_\perp p_i}_{\mathrm{if diamagnetic_polarisation}}\right) = \Omega
+   \nabla\cdot\left(\frac{\overline{A}\overline{n}}{B^2}\nabla_\perp \phi\right) \underbrace{+ \nabla\cdot\left(\sum_i\frac{A_i}{Z_i B^2}\nabla_\perp p_i\right)}_{\mathrm{if diamagnetic\_polarisation}} = \Omega
 
 Where the sum is over species, :math:`\overline{A}` is the average ion
 atomic number, and :math:`\overline{n}` is the normalisation density
@@ -1482,10 +1482,11 @@ When ``exb_advection_simplified = false`` then the more complete
 
    \nabla\cdot\mathbf{J_{exb}} = -\nabla\cdot\left[\frac{\overline{A}}{2B^2}\nabla_\perp\left(\mathbf{V}_{E\times B}\cdot\nabla \hat{p}\right) + \frac{\Omega}{2} \mathbf{V}_{E\times B} + \frac{\overline{A}\overline{n}}{2B^2}\nabla_\perp^2\phi\left(\mathbf{V}_{E\times B} + \frac{\mathbf{b}}{B}\times\nabla\hat{p}\right) \right]
    
-The form of the vorticity equation is based on Simakov & Catto
-(erratum 2004), with the first term modified to conserve energy. In
-the limit of zero ion pressure and constant :math:`B` it reduces to
-the simplified form.
+The form of the vorticity equation is based on `Simakov & Catto
+<https://doi.org/10.1063/1.1623492>`_ (corrected in `erratum 2004
+<https://doi.org/10.1063/1.1703527>`_), in the Boussinesq limit and
+with the first term modified to conserve energy. In the limit of zero
+ion pressure and constant :math:`B` it reduces to the simplified form.
 
 .. doxygenstruct:: Vorticity
    :members:

--- a/include/ion_viscosity.hxx
+++ b/include/ion_viscosity.hxx
@@ -47,10 +47,24 @@ struct IonViscosity : public Component {
   ///     - momentum_source
   ///
   void transform(Options &state) override;
+
+  /// Save variables to the output
+  void outputVars(Options &state) override;
 private:
   BoutReal eta_limit_alpha; ///< Flux limit coefficient
   bool perpendicular; ///< Include perpendicular flow? (Requires phi)
   Vector2D Curlb_B; ///< Curvature vector Curl(b/B)
+
+  bool diagnose; ///< Output additional diagnostics?
+
+  /// Per-species diagnostics
+  struct Diagnostics {
+    Field3D Pi_ciperp; ///< Perpendicular part of Pi scalar
+    Field3D Pi_cipar;  ///< Parallel part of Pi scalar
+  };
+
+  /// Store diagnostics for each species
+  std::map<std::string, Diagnostics> diagnostics;
 };
 
 namespace {

--- a/include/ion_viscosity.hxx
+++ b/include/ion_viscosity.hxx
@@ -13,10 +13,25 @@
 ///
 /// Needs to be calculated after collisions, because collision
 /// frequency is used to calculate parallel viscosity
+///
+/// The ion stress tensor Pi_ci is split into perpendicular and
+/// parallel pieces:
+///
+///    Pi_ci = Pi_ciperp + Pi_cipar
+///
+/// In the parallel ion momentum equation the Pi_cipar term
+/// is solved as a parallel diffusion, so is treated separately
+/// All other terms are added to Pi_ciperp, even if they are
+/// not really parallel parts
 struct IonViscosity : public Component {
   /// Inputs
   /// - <name>
-  ///   - eta_limit_alpha    Flux limiter coefficient
+  ///   - eta_limit_alpha: float, default -1
+  ///         Flux limiter coefficient. < 0 means off.
+  ///   - perpendicular: bool, default false
+  ///         Include perpendicular flows?
+  ///         Requires curvature vector and phi potential
+  ///
   IonViscosity(std::string name, Options& alloptions, Solver*);
 
   /// Inputs
@@ -34,6 +49,8 @@ struct IonViscosity : public Component {
   void transform(Options &state) override;
 private:
   BoutReal eta_limit_alpha; ///< Flux limit coefficient
+  bool perpendicular; ///< Include perpendicular flow? (Requires phi)
+  Vector2D Curlb_B; ///< Curvature vector Curl(b/B)
 };
 
 namespace {

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -100,11 +100,14 @@ struct Vorticity : public Component {
   }
 private:
   Field3D Vort; // Evolving vorticity
-  
+
   Field3D phi; // Electrostatic potential
   std::unique_ptr<Laplacian> phiSolver; // Laplacian solver in X-Z
 
+  Field3D Pi_hat; ///< Contribution from ion pressure, weighted by atomic mass / charge
+
   bool exb_advection; // Include nonlinear ExB advection?
+  bool exb_advection_simplified; // Simplify nonlinear ExB advection form?
   bool diamagnetic; // Include diamagnetic current?
   bool diamagnetic_polarisation; // Include diamagnetic drift in polarisation current
   BoutReal average_atomic_mass; // Weighted average atomic mass, for polarisaion current (Boussinesq approximation)

--- a/src/ion_viscosity.cxx
+++ b/src/ion_viscosity.cxx
@@ -60,7 +60,7 @@ void IonViscosity::transform(Options &state) {
 
   Options& allspecies = state["species"];
 
-  Coordinates *coord = P.getCoordinates();
+  auto coord = mesh->getCoordinates();
   const Field3D Bxy = coord->Bxy;
   const Field3D sqrtB = sqrt(Bxy);
   const Field3D Grad_par_logB = Grad_par(log(Bxy));

--- a/src/ion_viscosity.cxx
+++ b/src/ion_viscosity.cxx
@@ -5,6 +5,9 @@
 #include <bout/mesh.hxx>
 
 #include "../include/ion_viscosity.hxx"
+#include "../include/div_ops.hxx"
+
+using bout::globals::mesh;
 
 IonViscosity::IonViscosity(std::string name, Options& alloptions, Solver*) {
   auto& options = alloptions[name];
@@ -12,12 +15,55 @@ IonViscosity::IonViscosity(std::string name, Options& alloptions, Solver*) {
   eta_limit_alpha = options["eta_limit_alpha"]
     .doc("Viscosity flux limiter coefficient. <0 = turned off")
     .withDefault(-1.0);
+
+  perpendicular = options["perpendicular"]
+    .doc("Include perpendicular flow? (Requires phi)")
+    .withDefault<bool>(false);
+
+  if (perpendicular) {
+    // Read curvature vector
+    try {
+      Curlb_B.covariant = false; // Contravariant
+      mesh->get(Curlb_B, "bxcv");
+    } catch (BoutException& e) {
+      // May be 2D, reading as 3D
+      Vector2D curv2d;
+      curv2d.covariant = false;
+      mesh->get(curv2d, "bxcv");
+      Curlb_B = curv2d;
+    }
+
+    if (Options::root()["mesh"]["paralleltransform"]["type"].as<std::string>()
+        == "shifted") {
+      Field2D I;
+      mesh->get(I, "sinty");
+      Curlb_B.z += I * Curlb_B.x;
+    }
+
+    // Normalisations
+    const Options& units = alloptions["units"];
+    const BoutReal Bnorm = units["Tesla"];
+    const BoutReal Lnorm = units["meters"];
+
+    auto coord = mesh->getCoordinates();
+
+    Curlb_B.x /= Bnorm;
+    Curlb_B.y *= SQ(Lnorm);
+    Curlb_B.z *= SQ(Lnorm);
+    
+    Curlb_B *= 2. / coord->Bxy;
+  }
 }
 
 void IonViscosity::transform(Options &state) {
   AUTO_TRACE();
 
   Options& allspecies = state["species"];
+
+  Coordinates *coord = P.getCoordinates();
+  const Field3D Bxy = coord->Bxy;
+  const Field3D sqrtB = sqrt(Bxy);
+  const Field3D Grad_par_logB = Grad_par(log(Bxy));
 
   // Loop through all species
   for (auto& kv : allspecies.getChildren()) {
@@ -27,18 +73,20 @@ void IonViscosity::transform(Options &state) {
     Options& species = allspecies[kv.first];
 
     if (!(isSetFinal(species["pressure"], "ion_viscosity") and
-          isSetFinal(species["velocity"], "ion_viscosity"))) {
-      // Species doesn't have a pressure and velocity => Skip
+          isSetFinal(species["velocity"], "ion_viscosity") and
+          isSetFinal(species["charge"], "ion_viscosity"))) {
+      // Species doesn't have a pressure, velocity and charge => Skip
+      continue;
+    }
+
+    if (std::fabs(get<BoutReal>(species["charge"])) < 1e-3) {
+      // No charge
       continue;
     }
 
     const Field3D tau = 1. / get<Field3D>(species["collision_frequency"]);
     const Field3D P = get<Field3D>(species["pressure"]);
     const Field3D V = get<Field3D>(species["velocity"]);
-
-    Coordinates *coord = P.getCoordinates();
-    const Field3D Bxy = coord->Bxy;
-    const Field3D sqrtB = sqrt(Bxy);
 
     // Parallel ion viscosity (4/3 * 0.96 coefficient)
     Field3D eta = 1.28 * P * tau;
@@ -55,8 +103,53 @@ void IonViscosity::transform(Options &state) {
       eta.getMesh()->communicate(eta);
       eta.applyBoundary("neumann");
     }
+    
+    // This term is the parallel flow part of
+    // -(2/3) B^(3/2) Grad_par(Pi_ci / B^(3/2))
+    const Field3D div_Pi_cipar = sqrtB * FV::Div_par_K_Grad_par(eta / Bxy, sqrtB * V);
 
-    add(species["momentum_source"],
-        sqrtB * FV::Div_par_K_Grad_par(eta / Bxy, sqrtB * V));
+    add(species["momentum_source"], div_Pi_cipar);
+    subtract(species["energy_source"], V * div_Pi_cipar); // Internal energy
+
+    if (!perpendicular) {
+      continue; // Skip perpendicular flow parts below
+    }
+
+    // Need electrostatic potential for ExB flow
+    const Field3D phi = get<Field3D>(state["fields"]["phi"]);
+
+    // Density and temperature needed for diamagnetic flows
+    const Field3D N = get<Field3D>(species["density"]);
+    const Field3D T = get<Field3D>(species["temperature"]);
+
+    // Parallel ion stress tensor component
+    Field3D Pi_cipar = -0.96 * P * tau *
+      (2. * Grad_par(V) + V * Grad_par_logB);
+    // Could also be written as:
+    // Pi_cipar = -0.96*Pi*tau*2.*Grad_par(sqrt(Bxy)*Vi)/sqrt(Bxy);
+
+    // Perpendicular ion stress tensor
+    // 0.96 P tau kappa * (V_E + V_di + 1.61 b x Grad(T)/B )
+    // Note: Heat flux terms are neglected for now
+    Field3D Pi_ciperp = -0.5 * 0.96 * P * tau *
+      (Curlb_B * Grad(phi + 1.61 * T) - Curlb_B * Grad(P) / N);
+
+    const Field3D div_Pi_ciperp = - (2. / 3) * Grad_par(Pi_ciperp) + Pi_ciperp * Grad_par_logB;
+    //const Field3D div_Pi_ciperp = - (2. / 3) * B32 * Grad_par(Pi_ciperp / B32);
+
+    add(species["momentum_source"], div_Pi_ciperp);
+    subtract(species["energy_source"], V * div_Pi_ciperp);
+
+    // Total scalar ion viscous pressure
+    Field3D Pi_ci = Pi_cipar + Pi_ciperp;
+
+    // Divergence of current in vorticity equation
+    Field3D DivJ = Div(0.5 * Pi_ci * Curlb_B) -
+      Div_n_bxGrad_f_B_XPPM(1. / 3, Pi_ci, false);
+    add(state["fields"]["DivJextra"], DivJ);
+
+    // Transfer of energy between ion internal energy and ExB flow
+    subtract(species["energy_source"], 0.5 * Pi_ci * Curlb_B * Grad(phi + P)
+             - (1 / 3) * bracket(Pi_ci, phi + P, BRACKET_ARAKAWA));
   }
 }

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -41,6 +41,10 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
                       .doc("Include ExB advection (nonlinear term)?")
                       .withDefault<bool>(true);
 
+  exb_advection_simplified = options["exb_advection_simplified"]
+                      .doc("Simplify nonlinear ExB advection form?")
+                      .withDefault<bool>(true);
+
   diamagnetic =
       options["diamagnetic"].doc("Include diamagnetic current?").withDefault<bool>(true);
 
@@ -189,7 +193,7 @@ void Vorticity::transform(Options& state) {
   // is constant in Z. This is for efficiency, to reduce the number of conversions.
   // Note: For now the boundary values are all at the midpoint,
   //       and only phi is considered, not phi + Pi which is handled in Boussinesq solves
-  Field3D Pi_sum = 0.0; ///< Contribution from ion pressure, weighted by atomic mass
+  Pi_hat = 0.0; // Contribution from ion pressure, weighted by atomic mass / charge
   if (diamagnetic_polarisation) {
     // Diamagnetic term in vorticity. Note this is weighted by the mass
     // This includes all species, including electrons
@@ -202,15 +206,21 @@ void Vorticity::transform(Options& state) {
         continue; // No pressure, charge or mass -> no polarisation current
       }
 
-      // Don't need sheath boundary
-      auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
-      auto AA = get<BoutReal>(species["AA"]);
+      const auto charge = get<BoutReal>(species["charge"]);
+      if (fabs(charge) < 1e-5) {
+        // No charge
+        continue;
+      }
 
-      Pi_sum += P * (AA / average_atomic_mass);
+      // Don't need sheath boundary
+      const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+      const auto AA = get<BoutReal>(species["AA"]);
+
+      Pi_hat += P * (AA / average_atomic_mass / charge);
     }
   }
 
-  Pi_sum.applyBoundary("neumann");
+  Pi_hat.applyBoundary("neumann");
 
   if (phi_boundary_relax) {
     // Update the boundary regions by relaxing towards zero gradient
@@ -351,7 +361,7 @@ void Vorticity::transform(Options& state) {
   //    and sets the boundary between cells to this value.
   //    This shift by 1/2 grid cell is important.
 
-  Field3D phi_plus_pi = phi + Pi_sum;
+  Field3D phi_plus_pi = phi + Pi_hat;
 
   if (mesh->firstX()) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
@@ -387,10 +397,10 @@ void Vorticity::transform(Options& state) {
     // Solve non-axisymmetric part using X-Z solver
     phi = phi_plus_pi_2d
           + phiSolver->solve((Vort - Vort2D) * (Bsq / average_atomic_mass), phi_plus_pi)
-          - Pi_sum;
+          - Pi_hat;
 
   } else {
-    phi = phiSolver->solve(Vort * (Bsq / average_atomic_mass), phi_plus_pi) - Pi_sum;
+    phi = phiSolver->solve(Vort * (Bsq / average_atomic_mass), phi_plus_pi) - Pi_hat;
   }
 
   // Ensure that potential is set in the communication guard cells
@@ -436,6 +446,11 @@ void Vorticity::transform(Options& state) {
       if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"]))) {
         continue; // No pressure or charge -> no diamagnetic current
       }
+      if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
+        // No charge
+        continue;
+      }
+
       // Note that the species must have a charge, but charge is not used,
       // because it cancels out in the expression for current
 
@@ -466,11 +481,18 @@ void Vorticity::transform(Options& state) {
           continue; // No pressure, charge or mass -> no polarisation current due to
                     // diamagnetic flow
         }
-        auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
-        auto AA = get<BoutReal>(species["AA"]);
+
+        const auto charge = get<BoutReal>(species["charge"]);
+        if (fabs(charge) < 1e-5) {
+          // No charge
+          continue;
+        }
+
+        const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+        const auto AA = get<BoutReal>(species["AA"]);
 
         add(species["energy_source"],
-            (3. / 2) * P * (AA / average_atomic_mass) * DivJdia);
+            (3. / 2) * P * (AA / average_atomic_mass / charge) * DivJdia);
       }
     }
 
@@ -509,7 +531,7 @@ void Vorticity::transform(Options& state) {
     weighted_collision_frequency.applyBoundary("neumann");
 
     DivJcol = -FV::Div_a_Grad_perp(
-        weighted_collision_frequency * average_atomic_mass / Bsq, phi);
+        weighted_collision_frequency * average_atomic_mass / Bsq, phi + Pi_hat);
 
     ddt(Vort) += DivJcol;
     set(fields["DivJcol"], DivJcol);
@@ -525,23 +547,36 @@ void Vorticity::finally(const Options& state) {
   phi = get<Field3D>(state["fields"]["phi"]);
 
   if (exb_advection) {
-    ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(Vort, phi, bndry_flux, poloidal_flows);
+    // These terms come from divergence of polarisation current
 
-    /*
+    if (exb_advection_simplified) {
+      // By default this is a simplified nonlinear term
+      ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(Vort, phi, bndry_flux, poloidal_flows);
+
+    } else {
+      // If diamagnetic_polarisation = false and B is constant, then
+      // this term reduces to the simplified form above.
+      //
+      // Because this is implemented in terms of an operation on the result
+      // of an operation, we need to communicate and the resulting stencil is
+      // wider than the simple form.
       ddt(Vort) -=
         Div_n_bxGrad_f_B_XPPM(0.5 * Vort, phi, bndry_flux, poloidal_flows);
 
-    // V_ExB dot Grad(Pi)
-    Field3D vEdotGradPi = bracket(phi, Pi, BRACKET_ARAKAWA);
-    vEdotGradPi.applyBoundary("free_o2");
-    // delp2(phi) term
-    Field3D DelpPhi_2B2 = 0.5 * Delp2(phi) / Bsq;
-    DelpPhi_2B2.applyBoundary("free_o2");
+      // V_ExB dot Grad(Pi)
+      Field3D vEdotGradPi = bracket(phi, Pi_hat, BRACKET_ARAKAWA);
+      vEdotGradPi.applyBoundary("free_o2");
 
-    mesh->communicate(vEdotGradPi, DelpPhi_2B2);
+      // delp2(phi) term
+      Field3D DelpPhi_2B2 = 0.5 * average_atomic_mass * Delp2(phi) / Bsq;
+      DelpPhi_2B2.applyBoundary("free_o2");
 
-    ddt(Vort) -= FV::Div_a_Laplace_perp(0.5 / Bsq, vEdotGradPi);
-    */
+      mesh->communicate(vEdotGradPi, DelpPhi_2B2);
+
+      ddt(Vort) -= FV::Div_a_Grad_perp(0.5 * average_atomic_mass / Bsq, vEdotGradPi);
+      ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(DelpPhi_2B2, phi + Pi_hat, bndry_flux,
+                                         poloidal_flows);
+    }
   }
 
   if (state.isSection("fields") and state["fields"].isSet("DivJextra")) {


### PR DESCRIPTION
Add perpendicular flow parts of the ion viscosity.
If enabled, this damps the ion poloidal flow velocity, with terms in both ion parallel momentum and vorticity equations.


