### PR TITLE
WIP: Add time-dependent sources

### DIFF
--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -80,6 +80,15 @@ private:
   Field3D source; ///< External input source
   Field3D Sn; ///< Total density source
 
+  bool source_only_in_core;  ///< Zero source where Y is non-periodic?
+  bool source_time_dependent; ///< Is the input source time dependent?
+  BoutReal source_normalisation; ///< Normalisation factor [m^-3/s]
+  BoutReal time_normalisation; ///< Normalisation factor [s]
+  FieldGeneratorPtr source_generator;
+
+  /// Modifies the `source` member variable
+  void updateSource(BoutReal time);
+
   bool diagnose; ///< Output additional diagnostics?
 };
 


### PR DESCRIPTION
Implemented for density first, for discussion. There are several ways this can be done; so input on use-cases and the "least surprising" approach would be helpful.

The present implementation wouldn't allow a time-dependent source that added to or modified a source in the mesh input file, for example. Is that a useful thing to do?

If `source_time_dependent` switch is set, then the input source is re-evaluated every iteration. The source must be in the input options, and any value in the mesh file is ignored.

```
[e]
type = evolve_density

[Ne]
source_time_dependent = true
source = x * (1-x) * t  # Can depend on 't' in seconds
```

Note: The time 't' is in seconds, and the source should be in SI units i.e. m^-3/s