### PR TITLE
Add component for stellarator two-point model 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(HERMES_SOURCES
     src/zero_current.cxx
     src/collisions.cxx
     src/anomalous_diffusion.cxx
+    src/binormal_stpm.cxx
     src/recycling.cxx
     src/amjuel_hyd_ionisation.cxx
     src/amjuel_hyd_recombination.cxx
@@ -103,6 +104,7 @@ set(HERMES_SOURCES
     include/amjuel_hyd_recombination.hxx
     include/amjuel_reaction.hxx
     include/anomalous_diffusion.hxx
+    include/binormal_stpm.hxx
     include/collisions.hxx
     include/component.hxx
     include/component_scheduler.hxx

--- a/examples/stellarator-2pt-model/BOUT.inp
+++ b/examples/stellarator-2pt-model/BOUT.inp
@@ -1,0 +1,111 @@
+# 1D system with:
+#  - no-flow boundary on lower Y
+#  - sheath boundary on upper Y
+#  - Evolving electron and ion species
+#  - evolving density, pressure and momentum
+#  - heat conduction
+#  - Uniform source of heat and particles throughout domain
+#  - field line pitch from stellarator 2pt model
+
+nout = 50 # number of timesteps to output
+timestep = 5e4 # timestep between outputs [1/omega_ci]
+
+MXG = 0  # No guard cells in X
+
+[mesh]
+nx = 1
+ny = 200   # Resolution along field-line
+nz = 1
+
+length = 100          # Length of the domain in meters
+length_xpt = length   # Length from midplane to X-point [m]
+
+dy = length / ny      # Resolution in y
+
+ypos = y * length / (2*pi) # Y position [m]
+
+ixseps1 = -1          # Necessary to set boundary conditions in y
+ixseps2 = -1          # Necessary to set boundary conditions in y
+
+[hermes]
+# Evolve ion density, ion and electron pressure, then calculate force on ions due
+# to electron pressure using electron force balance
+# Collisions are needed to calculate heat conduction
+
+components = i, e, sheath_boundary, collisions, binormal_stpm, electron_force_balance
+
+loadmetric = false        # Use Rxy, Bpxy etc?
+normalise_metric = true   # Normalise the input metric?
+
+Nnorm = 1e19   # [m^-3]
+Bnorm = 2.5    # [T]
+Tnorm = 100    # [eV] 
+
+[solver]
+mxstep = 10000   # maximum step for solver before failure.
+
+[sheath_boundary]
+lower_y = false  
+upper_y = true
+
+[binormal_stpm]
+D = 1         # [m^2/s]  Density diffusion coefficient
+chi = 3       # [m^2/s]  Thermal diffusion coefficient
+nu = 1        # [m^2/s]  Momentum diffusion coefficient
+
+Theta = 1e-3  # Field line pitch
+
+####################################
+
+[i]  # Ions
+type = evolve_density, evolve_pressure, evolve_momentum, noflow_boundary
+
+noflow_lower_y = true
+noflow_upper_y = false  # Sheath boundary at upper y
+
+charge = 1
+AA = 1.0
+
+thermal_conduction = true  # in evolve_pressure
+
+diagnose = true
+
+[Ni]
+
+function = 1
+
+flux = 4e23  # Particles per m^2 per second input
+source = (flux/(mesh:length_xpt))*H(mesh:length_xpt - mesh:ypos)
+
+[Pi]
+function = 1
+
+powerflux = 2e7  # Input power flux in W/m^2
+
+source = (powerflux*2/3 / (mesh:length_xpt))*H(mesh:length_xpt - mesh:ypos)  # Input power as function of y
+
+[NVi]
+
+function = 0
+
+####################################
+
+[e] # Electrons
+type = quasineutral, evolve_pressure, zero_current, evolve_momentum, noflow_boundary
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+
+thermal_conduction = true  # in evolve_pressure
+
+[Pe]
+
+function = Pi:function  # Same as ion pressure initially
+
+source = Pi:source  # Same as ion pressure source
+
+[NVe]
+
+function = 0

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -29,6 +29,7 @@
 #include "include/amjuel_hyd_ionisation.hxx"
 #include "include/amjuel_hyd_recombination.hxx"
 #include "include/anomalous_diffusion.hxx"
+#include "include/binormal_stpm.hxx"
 #include "include/collisions.hxx"
 #include "include/diamagnetic_drift.hxx"
 #include "include/electromagnetic.hxx"

--- a/include/binormal_stpm.hxx
+++ b/include/binormal_stpm.hxx
@@ -8,7 +8,7 @@
 
 /// Adds terms to Density, Pressure and Momentum equations following the
 /// stellarator 2-point model from Yuhe Feng et al., PPCF 53 (2011) 024009
-/// The terms add the effective parallel contribution of perpendicular drifts
+/// The terms add the effective parallel contribution of perpendicular transport
 /// in long connection length scenarios.
 /// B Shanahan 2023 <brendan.shanahan@ipp.mpg.de>
 struct BinormalSTPM : public Component {

--- a/include/binormal_stpm.hxx
+++ b/include/binormal_stpm.hxx
@@ -19,7 +19,6 @@ struct BinormalSTPM : public Component {
   ///   - D           Perpendicular density diffusion coefficient
   ///   - chi         Perpendicular heat diffusion coefficient
   ///   - nu          Perpendicular momentum diffusion coefficient
-  ///   - Vbn         Binormal velocity from cross-field drifts
   ///   - Theta       Field line pitch as described by Feng et al.
   ///
   BinormalSTPM(std::string name, Options& options, Solver* solver);
@@ -37,7 +36,6 @@ struct BinormalSTPM : public Component {
 private:
   std::string name; ///< Short name of the species e.g. h+
   Field3D Theta, chi, D, nu; ///< Field line pitch, anomalous thermal, momentum diffusion
-  Field3D Vbn;  ///< Binormal velocity from cross-field drifts input
   Field3D nu_Theta, chi_Theta, D_Theta; ///< nu/Theta, chi/Theta, D/Theta, precalculated
 
 };

--- a/include/binormal_stpm.hxx
+++ b/include/binormal_stpm.hxx
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef BINORMAL_STPM_H
+#define BINORMAL_STPM_H
+
+#include <bout/field3d.hxx>
+
+#include "component.hxx"
+
+/// Adds terms to Density, Pressure and Momentum equations following the
+/// stellarator 2-point model from Yuhe Feng et al., PPCF 53 (2011) 024009
+/// The terms add the effective parallel contribution of perpendicular drifts
+/// in long connection length scenarios.
+/// B Shanahan 2023 <brendan.shanahan@ipp.mpg.de>
+struct BinormalSTPM : public Component {
+  ///
+  /// # Inputs
+  ///
+  /// - <name>
+  ///   - D           Perpendicular density diffusion coefficient
+  ///   - chi         Perpendicular heat diffusion coefficient
+  ///   - nu          Perpendicular momentum diffusion coefficient
+  ///   - Vbn         Binormal velocity from cross-field drifts
+  ///   - Theta       Field line pitch as described by Feng et al.
+  ///
+  BinormalSTPM(std::string name, Options& options, Solver* solver);
+  
+  /// Sets
+  /// - species
+  ///   - <name>
+  ///     - pressure correction 
+  ///     - momentum correction
+  ///     - density correction
+  ///
+  void transform(Options& state) override;
+
+
+private:
+  std::string name; ///< Short name of the species e.g. h+
+  Field3D Theta, chi, D, nu; ///< Field line pitch, anomalous thermal, momentum diffusion
+  Field3D Vbn;  ///< Binormal velocity from cross-field drifts input
+  Field3D nu_Theta, chi_Theta, D_Theta; ///< nu/Theta, chi/Theta, D/Theta, precalculated
+
+};
+
+namespace {
+RegisterComponent<BinormalSTPM> registercomponentbinormalstpm("binormal_stpm");
+}
+
+#endif // BINORMAL_STPM

--- a/include/binormal_stpm.hxx
+++ b/include/binormal_stpm.hxx
@@ -9,7 +9,7 @@
 /// Adds terms to Density, Pressure and Momentum equations following the
 /// stellarator 2-point model from Yuhe Feng et al., PPCF 53 (2011) 024009
 /// The terms add the effective parallel contribution of perpendicular transport
-/// in long connection length scenarios.
+/// which is of significance in long connection length scenarios.
 /// B Shanahan 2023 <brendan.shanahan@ipp.mpg.de>
 struct BinormalSTPM : public Component {
   ///

--- a/src/binormal_stpm.cxx
+++ b/src/binormal_stpm.cxx
@@ -1,9 +1,6 @@
 
 #include <bout/fv_ops.hxx>
-#include <bout/difops.hxx>
 #include <bout/output_bout_types.hxx>
-#include <bout/initialprofiles.hxx>
-#include "../include/div_ops.hxx"
 #include "../include/binormal_stpm.hxx"
 #include "../include/hermes_utils.hxx"
 #include "../include/hermes_build_config.hxx"
@@ -19,7 +16,6 @@ BinormalSTPM::BinormalSTPM(std::string name, Options& alloptions, Solver* solver
   const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
 
   const BoutReal diffusion_norm = rho_s0 * rho_s0 * Omega_ci; // m^2/s
-  const BoutReal speed_norm = rho_s0 * Omega_ci; // m/s
   
   Theta = options["Theta"]
     .doc("Field-line Pitch defined by Feng et al.")
@@ -39,11 +35,6 @@ BinormalSTPM::BinormalSTPM(std::string name, Options& alloptions, Solver* solver
     .doc("Anomalous momentum diffusion.")
     .withDefault(1.)
     /diffusion_norm;
-
-  Vbn = options["Vbn"]
-    .doc("Binormal velocity.")
-    .withDefault(0.)
-    /speed_norm;
 
   chi_Theta = chi/Theta;
   D_Theta = D/Theta;
@@ -72,9 +63,6 @@ void BinormalSTPM::transform(Options& state) {
     
     add(species["density_source"],
 	(1/Theta) * FV::Div_par_K_Grad_par(D_Theta, N, false));
-
-    add(species["pressure_source"], (2. / 3) * Theta * Grad_par(P*Vbn/Theta));
-    add(species["density_source"], (1/Theta) * Grad_par(N*Vbn/Theta));    
 
   }
 }

--- a/src/binormal_stpm.cxx
+++ b/src/binormal_stpm.cxx
@@ -1,0 +1,76 @@
+
+#include <bout/fv_ops.hxx>
+#include <bout/difops.hxx>
+#include <bout/output_bout_types.hxx>
+#include <bout/initialprofiles.hxx>
+#include "../include/div_ops.hxx"
+#include "../include/binormal_stpm.hxx"
+#include "../include/hermes_utils.hxx"
+#include "../include/hermes_build_config.hxx"
+
+using bout::globals::mesh;
+
+BinormalSTPM::BinormalSTPM(std::string name, Options& alloptions, Solver* solver)
+  : name(name) {
+  AUTO_TRACE();
+  auto& options = alloptions[name];
+  const Options& units = alloptions["units"];
+  const BoutReal rho_s0 = units["meters"];
+  const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
+
+  const BoutReal diffusion_norm = rho_s0 * rho_s0 * Omega_ci; // m^2/s
+  
+  Theta = options["Theta"]
+    .doc("Field-line Pitch defined by Feng et al.")
+    .withDefault(1e-3);
+
+  chi = options["chi"]
+    .doc("Anomalous heat diffusion.")
+    .withDefault(3.)
+    /diffusion_norm;
+
+  D = options["D"]
+    .doc("Anomalous density diffusion.")
+    .withDefault(1.)
+    /diffusion_norm;
+  
+  nu = options["nu"]
+    .doc("Anomalous momentum diffusion.")
+    .withDefault(1.)
+    /diffusion_norm;
+
+  Vbn = options["Vbn"]
+    .doc("Binormal velocity.")
+    .withDefault(0.);
+
+  chi_Theta = chi/Theta;
+  D_Theta = D/Theta;
+  nu_Theta = nu/Theta;
+  
+}
+
+void BinormalSTPM::transform(Options& state) {
+  AUTO_TRACE();
+  Options& allspecies = state["species"];
+  // Loop through all species
+  for (auto& kv : allspecies.getChildren()) {
+    const auto& species_name = kv.first;
+
+    Options& species = allspecies[species_name];
+
+    const Field3D T = get<Field3D>(species["temperature"]);
+    const Field3D NV = get<Field3D>(species["momentum"]);
+    const Field3D N = get<Field3D>(species["density"]);
+    
+    add(species["pressure_source"], (1/Theta) * FV::Div_par_K_Grad_par(chi_Theta, T, false));
+    add(species["pressure_source"], (3/(2*Theta)) * Grad_par(N*T*Vbn/Theta));    
+
+    add(species["momentum_source"], FV::Div_par_K_Grad_par(nu_Theta, NV, false));
+    
+    add(species["density_source"], (1/Theta) * FV::Div_par_K_Grad_par(D_Theta, N, false));
+    add(species["density_source"], (1/Theta) * Grad_par(N*Vbn/Theta));
+  }
+}
+
+
+

--- a/src/binormal_stpm.cxx
+++ b/src/binormal_stpm.cxx
@@ -68,7 +68,7 @@ void BinormalSTPM::transform(Options& state) {
 	(2. / 3) * (1/Theta) * FV::Div_par_K_Grad_par(chi_Theta, P, false));
 
     add(species["momentum_source"],
-	FV::Div_par_K_Grad_par(nu_Theta, NV, false));
+	(1/Theta) * FV::Div_par_K_Grad_par(nu_Theta, NV, false));
     
     add(species["density_source"],
 	(1/Theta) * FV::Div_par_K_Grad_par(D_Theta, N, false));


### PR DESCRIPTION
This adds a component which adds binormal transport terms from the stellarator two point model:
http://dx.doi.org/10.1088/0741-3335/53/2/024009

Here we include the field-line pitch effects in the density equation (not just pressure and momentum as in the cited source). There are also additional terms for cross-field drifts in the density  and pressure equations.
 
There is an example provided.