### PR TITLE
WIP: Cell face flow information

### DIFF
--- a/docs/sphinx/code_structure.rst
+++ b/docs/sphinx/code_structure.rst
@@ -64,12 +64,12 @@ for new variables which are added to the state:
     * `momentum_source` Normalised momentum source
     * `energy_source`  Normalised energy source
 
-    * `density_flow_xlow`  Normalised particle flow through lower X cell face
-    * `density_flow_ylow`  Normalised particle flow through lower Y cell face
+    * `particle_flow_xlow` Normalised particle flow through lower X cell face
+    * `particle_flow_ylow` Normalised particle flow through lower Y cell face
     * `momentum_flow_xlow` Normalised momentum flow through lower X cell face
     * `momentum_flow_ylow` Normalised momentum flow through lower Y cell face
-    * `energy_flow_xlow`  Normalised energy flow through lower X cell face
-    * `energy_flow_ylow`  Normalised energy flow through lower Y cell face
+    * `energy_flow_xlow`   Normalised energy flow through lower X cell face
+    * `energy_flow_ylow`   Normalised energy flow through lower Y cell face
 
 * `fields`
 

--- a/docs/sphinx/code_structure.rst
+++ b/docs/sphinx/code_structure.rst
@@ -64,12 +64,12 @@ for new variables which are added to the state:
     * `momentum_source` Normalised momentum source
     * `energy_source`  Normalised energy source
 
-    * `density_flux_xlow`  Normalised particle flux through lower X cell face
-    * `density_flux_ylow`  Normalised particle flux through lower Y cell face
-    * `momentum_flux_xlow` Normalised momentum flux through lower X cell face
-    * `momentum_flux_ylow` Normalised momentum flux through lower Y cell face
-    * `energy_flux_xlow`  Normalised energy flux through lower X cell face
-    * `energy_flux_ylow`  Normalised energy flux through lower Y cell face
+    * `density_flow_xlow`  Normalised particle flow through lower X cell face
+    * `density_flow_ylow`  Normalised particle flow through lower Y cell face
+    * `momentum_flow_xlow` Normalised momentum flow through lower X cell face
+    * `momentum_flow_ylow` Normalised momentum flow through lower Y cell face
+    * `energy_flow_xlow`  Normalised energy flow through lower X cell face
+    * `energy_flow_ylow`  Normalised energy flow through lower Y cell face
 
 * `fields`
 

--- a/docs/sphinx/code_structure.rst
+++ b/docs/sphinx/code_structure.rst
@@ -64,6 +64,13 @@ for new variables which are added to the state:
     * `momentum_source` Normalised momentum source
     * `energy_source`  Normalised energy source
 
+    * `density_flux_xlow`  Normalised particle flux through lower X cell face
+    * `density_flux_ylow`  Normalised particle flux through lower Y cell face
+    * `momentum_flux_xlow` Normalised momentum flux through lower X cell face
+    * `momentum_flux_ylow` Normalised momentum flux through lower Y cell face
+    * `energy_flux_xlow`  Normalised energy flux through lower X cell face
+    * `energy_flux_ylow`  Normalised energy flux through lower Y cell face
+
 * `fields`
 
   * `vorticity`

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -510,8 +510,8 @@ disabled.
 .. doxygenstruct:: SimpleConduction
    :members:
 
-Drifts
-------
+Drifts and transport
+--------------------
 
 The ExB drift is included in the density, momentum and pressure evolution equations if
 potential is calculated. Other drifts can be added with the following components.
@@ -567,6 +567,51 @@ Setting `diagnose = true` saves `DivJ` to the dump files with the divergence of 
 currents except polarisation, and `phi_pol` which is the polarisation flow potential.
 
 .. doxygenstruct:: PolarisationDrift
+   :members:
+
+anomalous_diffusion
+~~~~~~~~~~~~~~~~~~~
+
+Adds cross-field diffusion of particles, momentum and energy to a species.
+
+.. code-block:: ini
+
+   [hermes]
+   components = e, ...
+
+   [e]
+   type = evolve_density, evolve_momentum, evolve_pressure, anomalous_diffusion
+
+   anomalous_D = 1.0   # Density diffusion [m^2/s]
+   anomalous_chi = 0,5 # Thermal diffusion [m^2/s]
+   anomalous_nu = 0.5  # Kinematic viscosity [m^2/s]
+
+Anomalous diffusion coefficients can be functions of `x` and `y`.  The
+coefficients can also be read from the mesh input file: If the mesh
+file contains `D_` + the name of the species, for example `D_e` then
+it will be read and used as the density diffusion coefficient.
+Similarly, `chi_e` is the thermal conduction coefficient, and `nu_e`
+is the kinematic viscosity. All quantities should be in SI units of
+m^2/s.  Values that are set in the options (as above) override those
+in the mesh file.
+
+The sources of particles :math:`S`, momentum :math:`F` and energy
+:math:`E` are calculated from species density :math:`N`, parallel
+velocity :math:`V` and temperature :math:`T` using diffusion
+coefficients :math:`D`, :math:`\chi` and :math:`\nu` as follows:
+
+.. math::
+
+   \begin{aligned}
+   S =& \nabla\cdot\left(D \nabla_\perp N\right) \\
+   F =& \nabla\cdot\left(m V D \nabla_\perp N\right) + \nabla\cdot\left(m N \nu \nabla_\perp V\right)\\
+   E =& \nabla\cdot\left(\frac{3}{2}T D \nabla_\perp N\right) + \nabla\cdot\left(N \chi \nabla_\perp T\right)
+   \end{aligned}
+
+Note that particle diffusion is treated as a density gradient-driven flow
+with velocity :math:`v_D = -D \nabla_\perp N / N`.
+
+.. doxygenstruct:: AnomalousDiffusion
    :members:
 
 Neutral gas models

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -54,6 +54,8 @@ const Field2D Laplace_FV(const Field2D& k, const Field2D& f);
 
 /// Perpendicular diffusion including X and Y directions
 const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
+/// Version of function that returns fluxes
+const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f, Field3D& flux_xlow, Field3D& flux_ylow);
 
 namespace FV {
 

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -54,8 +54,8 @@ const Field2D Laplace_FV(const Field2D& k, const Field2D& f);
 
 /// Perpendicular diffusion including X and Y directions
 const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
-/// Version of function that returns fluxes
-const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f, Field3D& flux_xlow, Field3D& flux_ylow);
+/// Version of function that returns flows
+const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f, Field3D& flux_xlow, Field3D& flux_ylow);
 
 namespace FV {
 

--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -81,6 +81,7 @@ private:
   Field3D Sn; ///< Total density source
 
   bool diagnose; ///< Output additional diagnostics?
+  Field3D flow_xlow, flow_ylow; ///< Particle flow diagnostics
 };
 
 namespace {

--- a/include/evolve_energy.hxx
+++ b/include/evolve_energy.hxx
@@ -103,6 +103,7 @@ private:
 
   bool diagnose;      ///< Output additional diagnostics?
   bool enable_precon; ///< Enable preconditioner?
+  Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
 };
 
 namespace {

--- a/include/evolve_momentum.hxx
+++ b/include/evolve_momentum.hxx
@@ -49,6 +49,7 @@ private:
 
   bool diagnose; ///< Output additional diagnostics?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?
+  Field3D flow_xlow, flow_ylow; ///< Momentum flow diagnostics
 };
 
 namespace {

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -99,6 +99,7 @@ private:
 
   bool diagnose; ///< Output additional diagnostics?
   bool enable_precon; ///< Enable preconditioner?
+  Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
 };
 
 namespace {

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -87,6 +87,8 @@ void AnomalousDiffusion::transform(Options& state) {
     }
   }
 
+  Field3D flux_xlow, flux_ylow; // Fluxes through cell faces
+
   if (include_D) {
     // Particle diffusion. Gradients of density drive flows of particles,
     // momentum and energy. The implementation here is equivalent to an
@@ -94,28 +96,40 @@ void AnomalousDiffusion::transform(Options& state) {
     //
     //  v_D = - D Grad_perp(N) / N
 
-    add(species["density_source"], Div_a_Grad_perp_upwind(anomalous_D, N2D));
+    add(species["density_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_D, N2D,
+                                                                 flux_xlow, flux_ylow));
+    add(species["density_flux_xlow"], flux_xlow);
+    add(species["density_flux_ylow"], flux_ylow);
 
     // Note: Upwind operators used, or unphysical increases
     // in temperature and flow can be produced
     auto AA = get<BoutReal>(species["AA"]);
-    add(species["momentum_source"], Div_a_Grad_perp_upwind(AA * V2D * anomalous_D, N2D));
+    add(species["momentum_source"], Div_a_Grad_perp_upwind_fluxes(AA * V2D * anomalous_D, N2D,
+                                                                  flux_xlow, flux_ylow));
+    add(species["momentum_flux_xlow"], flux_xlow);
+    add(species["momentum_flux_ylow"], flux_ylow);
 
     add(species["energy_source"],
-        Div_a_Grad_perp_upwind((3. / 2) * T2D * anomalous_D, N2D));
+        Div_a_Grad_perp_upwind_fluxes((3. / 2) * T2D * anomalous_D, N2D,
+                                      flux_xlow, flux_ylow));
+    add(species["energy_flux_xlow"], flux_xlow);
+    add(species["energy_flux_ylow"], flux_ylow);
   }
 
   if (include_chi) {
-    // Gradients in temperature which drive energy flows
-    add(species["energy_source"], Div_a_Grad_perp_upwind(anomalous_chi * N2D, T2D));
+    // Gradients in temperature that drive energy flows
+    add(species["energy_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_chi * N2D, T2D, flux_xlow, flux_ylow));
+    add(species["energy_flux_xlow"], flux_xlow);
+    add(species["energy_flux_ylow"], flux_ylow);
   }
 
   if (include_nu) {
-    // Gradients in slow speed which drive momentum flows
+    // Gradients in flow speed that drive momentum flows
     auto AA = get<BoutReal>(species["AA"]);
-    add(species["momentum_source"], Div_a_Grad_perp_upwind(anomalous_nu * AA * N2D, V2D));
+    add(species["momentum_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_nu * AA * N2D, V2D, flux_xlow, flux_ylow));
+    add(species["momentum_flux_xlow"], flux_xlow);
+    add(species["momentum_flux_ylow"], flux_ylow);
   }
-
 }
 
 void AnomalousDiffusion::outputVars(Options& state) {

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -98,8 +98,8 @@ void AnomalousDiffusion::transform(Options& state) {
 
     add(species["density_source"], Div_a_Grad_perp_upwind_flows(anomalous_D, N2D,
                                                                 flow_xlow, flow_ylow));
-    add(species["density_flow_xlow"], flow_xlow);
-    add(species["density_flow_ylow"], flow_ylow);
+    add(species["particle_flow_xlow"], flow_xlow);
+    add(species["particle_flow_ylow"], flow_ylow);
 
     // Note: Upwind operators used, or unphysical increases
     // in temperature and flow can be produced

--- a/src/anomalous_diffusion.cxx
+++ b/src/anomalous_diffusion.cxx
@@ -87,7 +87,7 @@ void AnomalousDiffusion::transform(Options& state) {
     }
   }
 
-  Field3D flux_xlow, flux_ylow; // Fluxes through cell faces
+  Field3D flow_xlow, flow_ylow; // Flows through cell faces
 
   if (include_D) {
     // Particle diffusion. Gradients of density drive flows of particles,
@@ -96,39 +96,39 @@ void AnomalousDiffusion::transform(Options& state) {
     //
     //  v_D = - D Grad_perp(N) / N
 
-    add(species["density_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_D, N2D,
-                                                                 flux_xlow, flux_ylow));
-    add(species["density_flux_xlow"], flux_xlow);
-    add(species["density_flux_ylow"], flux_ylow);
+    add(species["density_source"], Div_a_Grad_perp_upwind_flows(anomalous_D, N2D,
+                                                                flow_xlow, flow_ylow));
+    add(species["density_flow_xlow"], flow_xlow);
+    add(species["density_flow_ylow"], flow_ylow);
 
     // Note: Upwind operators used, or unphysical increases
     // in temperature and flow can be produced
     auto AA = get<BoutReal>(species["AA"]);
-    add(species["momentum_source"], Div_a_Grad_perp_upwind_fluxes(AA * V2D * anomalous_D, N2D,
-                                                                  flux_xlow, flux_ylow));
-    add(species["momentum_flux_xlow"], flux_xlow);
-    add(species["momentum_flux_ylow"], flux_ylow);
+    add(species["momentum_source"], Div_a_Grad_perp_upwind_flows(AA * V2D * anomalous_D, N2D,
+                                                                 flow_xlow, flow_ylow));
+    add(species["momentum_flow_xlow"], flow_xlow);
+    add(species["momentum_flow_ylow"], flow_ylow);
 
     add(species["energy_source"],
-        Div_a_Grad_perp_upwind_fluxes((3. / 2) * T2D * anomalous_D, N2D,
-                                      flux_xlow, flux_ylow));
-    add(species["energy_flux_xlow"], flux_xlow);
-    add(species["energy_flux_ylow"], flux_ylow);
+        Div_a_Grad_perp_upwind_flows((3. / 2) * T2D * anomalous_D, N2D,
+                                     flow_xlow, flow_ylow));
+    add(species["energy_flow_xlow"], flow_xlow);
+    add(species["energy_flow_ylow"], flow_ylow);
   }
 
   if (include_chi) {
     // Gradients in temperature that drive energy flows
-    add(species["energy_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_chi * N2D, T2D, flux_xlow, flux_ylow));
-    add(species["energy_flux_xlow"], flux_xlow);
-    add(species["energy_flux_ylow"], flux_ylow);
+    add(species["energy_source"], Div_a_Grad_perp_upwind_flows(anomalous_chi * N2D, T2D, flow_xlow, flow_ylow));
+    add(species["energy_flow_xlow"], flow_xlow);
+    add(species["energy_flow_ylow"], flow_ylow);
   }
 
   if (include_nu) {
     // Gradients in flow speed that drive momentum flows
     auto AA = get<BoutReal>(species["AA"]);
-    add(species["momentum_source"], Div_a_Grad_perp_upwind_fluxes(anomalous_nu * AA * N2D, V2D, flux_xlow, flux_ylow));
-    add(species["momentum_flux_xlow"], flux_xlow);
-    add(species["momentum_flux_ylow"], flux_ylow);
+    add(species["momentum_source"], Div_a_Grad_perp_upwind_flows(anomalous_nu * AA * N2D, V2D, flow_xlow, flow_ylow));
+    add(species["momentum_flow_xlow"], flow_xlow);
+    add(species["momentum_flow_ylow"], flow_ylow);
   }
 }
 

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -917,11 +917,11 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
 
 /// Div ( a Grad_perp(f) )  -- diffusion
 ///
-/// Returns the fluxes in the final arguments
+/// Returns the flows in the final arguments
 ///
-/// Fluxes are always in the positive {x,y} direction
-/// i.e xlow(i,j) is the flux into cell (i,j) from the left,
-///               and the flux out of cell (i-1,j) to the right
+/// Flows are always in the positive {x,y} direction
+/// i.e xlow(i,j) is the flow into cell (i,j) from the left,
+///               and the flow out of cell (i-1,j) to the right
 /// 
 ///           ylow(i,j+1)
 ///              ^
@@ -932,11 +932,10 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
 ///           +---|---+
 ///           ylow(i,j)
 ///
-/// All fluxes are averaged in Z
 ///
-const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
-                                            Field3D &flux_xlow,
-                                            Field3D &flux_ylow) {
+const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
+                                           Field3D &flow_xlow,
+                                           Field3D &flow_ylow) {
   ASSERT2(a.getLocation() == f.getLocation());
 
   Mesh* mesh = a.getMesh();
@@ -945,9 +944,9 @@ const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
 
   Coordinates* coord = f.getCoordinates();
 
-  // Zero all fluxes
-  flux_xlow = 0.0;
-  flux_ylow = 0.0;
+  // Zero all flows
+  flow_xlow = 0.0;
+  flow_ylow = 0.0;
 
   // Flux in x
 
@@ -970,7 +969,7 @@ const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
         result(i, j, k) += fout / (coord->dx(i, j) * coord->J(i, j));
         result(i + 1, j, k) -= fout / (coord->dx(i + 1, j) * coord->J(i + 1, j));
 
-        flux_xlow(i + 1, j, k) = fout * coord->dy(i, j) * coord->dz(i, j);
+        flow_xlow(i + 1, j, k) = fout * coord->dy(i, j) * coord->dz(i, j);
       }
     }
 
@@ -1004,7 +1003,7 @@ const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
     fup = fdown = fc = toFieldAligned(f);
     aup = adown = ac = toFieldAligned(a);
     yzresult.setDirectionY(YDirectionType::Aligned);
-    flux_ylow.setDirectionY(YDirectionType::Aligned);
+    flow_ylow.setDirectionY(YDirectionType::Aligned);
   }
 
   // Y flux
@@ -1057,7 +1056,7 @@ const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
                * (dfdz - coef_d * dfdy);
 
         yzresult(i, j, k) -= fout / (coord->dy(i, j) * coord->J(i, j));
-        flux_ylow(i, j, k) = fout * coord->dx(i, j) * coord->dz(i, j);
+        flow_ylow(i, j, k) = fout * coord->dx(i, j) * coord->dz(i, j);
       }
     }
   }
@@ -1097,7 +1096,7 @@ const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
     result += yzresult;
   } else {
     result += fromFieldAligned(yzresult);
-    flux_ylow = fromFieldAligned(flux_ylow);
+    flow_ylow = fromFieldAligned(flow_ylow);
   }
 
   return result;

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -969,7 +969,8 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
         result(i, j, k) += fout / (coord->dx(i, j) * coord->J(i, j));
         result(i + 1, j, k) -= fout / (coord->dx(i + 1, j) * coord->J(i + 1, j));
 
-        flow_xlow(i + 1, j, k) = fout * coord->dy(i, j) * coord->dz(i, j);
+        // Flow will be positive in the positive coordinate direction
+        flow_xlow(i + 1, j, k) = -1.0 * fout * coord->dy(i, j) * coord->dz(i, j);
       }
     }
 
@@ -1056,7 +1057,9 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
                * (dfdz - coef_d * dfdy);
 
         yzresult(i, j, k) -= fout / (coord->dy(i, j) * coord->J(i, j));
-        flow_ylow(i, j, k) = fout * coord->dx(i, j) * coord->dz(i, j);
+
+        // Flow will be positive in the positive coordinate direction
+        flow_ylow(i, j, k) = -1.0 * fout * coord->dx(i, j) * coord->dz(i, j);
       }
     }
   }

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -914,3 +914,191 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
 
   return result;
 }
+
+/// Div ( a Grad_perp(f) )  -- diffusion
+///
+/// Returns the fluxes in the final arguments
+///
+/// Fluxes are always in the positive {x,y} direction
+/// i.e xlow(i,j) is the flux into cell (i,j) from the left,
+///               and the flux out of cell (i-1,j) to the right
+/// 
+///           ylow(i,j+1)
+///              ^
+///           +---|---+
+///           |       |
+/// xlow(i,j) -> (i,j) -> xlow(i+1,j)
+///           |   ^   |
+///           +---|---+
+///           ylow(i,j)
+///
+/// All fluxes are averaged in Z
+///
+const Field3D Div_a_Grad_perp_upwind_fluxes(const Field3D& a, const Field3D& f,
+                                            Field3D &flux_xlow,
+                                            Field3D &flux_ylow) {
+  ASSERT2(a.getLocation() == f.getLocation());
+
+  Mesh* mesh = a.getMesh();
+
+  Field3D result{zeroFrom(f)};
+
+  Coordinates* coord = f.getCoordinates();
+
+  // Zero all fluxes
+  flux_xlow = 0.0;
+  flux_ylow = 0.0;
+
+  // Flux in x
+
+  int xs = mesh->xstart - 1;
+  int xe = mesh->xend;
+
+  for (int i = xs; i <= xe; i++)
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+      for (int k = 0; k < mesh->LocalNz; k++) {
+        // Calculate flux from i to i+1
+
+        const BoutReal gradient = (coord->J(i, j) * coord->g11(i, j)
+                                     + coord->J(i + 1, j) * coord->g11(i + 1, j))
+                                  * (f(i + 1, j, k) - f(i, j, k))
+                                  / (coord->dx(i, j) + coord->dx(i + 1, j));
+
+        // Use the upwind coefficient
+        const BoutReal fout = gradient * ((gradient > 0) ? a(i + 1, j, k) : a(i, j, k));
+
+        result(i, j, k) += fout / (coord->dx(i, j) * coord->J(i, j));
+        result(i + 1, j, k) -= fout / (coord->dx(i + 1, j) * coord->J(i + 1, j));
+
+        flux_xlow(i + 1, j, k) = fout * coord->dy(i, j) * coord->dz(i, j);
+      }
+    }
+
+  // Y and Z fluxes require Y derivatives
+
+  // Fields containing values along the magnetic field
+  Field3D fup(mesh), fdown(mesh);
+  Field3D aup(mesh), adown(mesh);
+
+  // Values on this y slice (centre).
+  // This is needed because toFieldAligned may modify the field
+  Field3D fc = f;
+  Field3D ac = a;
+
+  // Result of the Y and Z fluxes
+  Field3D yzresult(mesh);
+  yzresult.allocate();
+
+  if (f.hasParallelSlices() && a.hasParallelSlices()) {
+    // Both inputs have yup and ydown
+
+    fup = f.yup();
+    fdown = f.ydown();
+
+    aup = a.yup();
+    adown = a.ydown();
+  } else {
+    // At least one input doesn't have yup/ydown fields.
+    // Need to shift to/from field aligned coordinates
+
+    fup = fdown = fc = toFieldAligned(f);
+    aup = adown = ac = toFieldAligned(a);
+    yzresult.setDirectionY(YDirectionType::Aligned);
+    flux_ylow.setDirectionY(YDirectionType::Aligned);
+  }
+
+  // Y flux
+
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+
+      BoutReal coef_u =
+          0.5
+          * (coord->g_23(i, j) / SQ(coord->J(i, j) * coord->Bxy(i, j))
+             + coord->g_23(i, j + 1) / SQ(coord->J(i, j + 1) * coord->Bxy(i, j + 1)));
+
+      BoutReal coef_d =
+          0.5
+          * (coord->g_23(i, j) / SQ(coord->J(i, j) * coord->Bxy(i, j))
+             + coord->g_23(i, j - 1) / SQ(coord->J(i, j - 1) * coord->Bxy(i, j - 1)));
+
+      for (int k = 0; k < mesh->LocalNz; k++) {
+        // Calculate flux between j and j+1
+        int kp = (k + 1) % mesh->LocalNz;
+        int km = (k - 1 + mesh->LocalNz) % mesh->LocalNz;
+
+        // Calculate Z derivative at y boundary
+        BoutReal dfdz =
+            0.25 * (fc(i, j, kp) - fc(i, j, km) + fup(i, j + 1, kp) - fup(i, j + 1, km))
+            / coord->dz(i, j);
+
+        // Y derivative
+        BoutReal dfdy = 2. * (fup(i, j + 1, k) - fc(i, j, k))
+                        / (coord->dy(i, j + 1) + coord->dy(i, j));
+
+        BoutReal fout = 0.25 * (ac(i, j, k) + aup(i, j + 1, k))
+                            * (coord->J(i, j) * coord->g23(i, j)
+                               + coord->J(i, j + 1) * coord->g23(i, j + 1))
+                            * (dfdz - coef_u * dfdy);
+
+        yzresult(i, j, k) = fout / (coord->dy(i, j) * coord->J(i, j));
+
+        // Calculate flux between j and j-1
+        dfdz = 0.25
+               * (fc(i, j, kp) - fc(i, j, km) + fdown(i, j - 1, kp) - fdown(i, j - 1, km))
+               / coord->dz(i, j);
+
+        dfdy = 2. * (fc(i, j, k) - fdown(i, j - 1, k))
+               / (coord->dy(i, j) + coord->dy(i, j - 1));
+
+        fout = 0.25 * (ac(i, j, k) + adown(i, j - 1, k))
+               * (coord->J(i, j) * coord->g23(i, j)
+                  + coord->J(i, j - 1) * coord->g23(i, j - 1))
+               * (dfdz - coef_d * dfdy);
+
+        yzresult(i, j, k) -= fout / (coord->dy(i, j) * coord->J(i, j));
+        flux_ylow(i, j, k) = fout * coord->dx(i, j) * coord->dz(i, j);
+      }
+    }
+  }
+
+  // Z flux
+  // Easier since all metrics constant in Z
+
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+      // Coefficient in front of df/dy term
+      BoutReal coef = coord->g_23(i, j)
+                      / (coord->dy(i, j + 1) + 2. * coord->dy(i, j) + coord->dy(i, j - 1))
+                      / SQ(coord->J(i, j) * coord->Bxy(i, j));
+
+      for (int k = 0; k < mesh->LocalNz; k++) {
+        // Calculate flux between k and k+1
+        int kp = (k + 1) % mesh->LocalNz;
+
+        BoutReal gradient =
+            // df/dz
+            (fc(i, j, kp) - fc(i, j, k)) / coord->dz(i, j)
+
+            // - g_yz * df/dy / SQ(J*B)
+            - coef
+                  * (fup(i, j + 1, k) + fup(i, j + 1, kp) - fdown(i, j - 1, k)
+                     - fdown(i, j - 1, kp));
+
+        BoutReal fout = gradient * ((gradient > 0) ? ac(i, j, kp) : ac(i, j, k));
+
+        yzresult(i, j, k) += fout / coord->dz(i, j);
+        yzresult(i, j, kp) -= fout / coord->dz(i, j);
+      }
+    }
+  }
+  // Check if we need to transform back
+  if (f.hasParallelSlices() && a.hasParallelSlices()) {
+    result += yzresult;
+  } else {
+    result += fromFieldAligned(yzresult);
+    flux_ylow = fromFieldAligned(flux_ylow);
+  }
+
+  return result;
+}

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -249,11 +249,11 @@ void EvolveDensity::finally(const Options& state) {
   if (diagnose) {
     // Save flows if they are set
 
-    if (species.isSet("density_flow_xlow")) {
-      flow_xlow = get<Field3D>(state["density_flow_xlow"]);
+    if (species.isSet("particle_flow_xlow")) {
+      flow_xlow = get<Field3D>(state["particle_flow_xlow"]);
     }
-    if (species.isSet("density_flow_ylow")) {
-      flow_ylow = get<Field3D>(state["density_flow_ylow"]);
+    if (species.isSet("particle_flow_ylow")) {
+      flow_ylow = get<Field3D>(state["particle_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -250,10 +250,10 @@ void EvolveDensity::finally(const Options& state) {
     // Save flows if they are set
 
     if (species.isSet("particle_flow_xlow")) {
-      flow_xlow = get<Field3D>(state["particle_flow_xlow"]);
+      flow_xlow = get<Field3D>(species["particle_flow_xlow"]);
     }
     if (species.isSet("particle_flow_ylow")) {
-      flow_ylow = get<Field3D>(state["particle_flow_ylow"]);
+      flow_ylow = get<Field3D>(species["particle_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -312,7 +312,7 @@ void EvolveDensity::outputVars(Options& state) {
                     {"units", "s^-1"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
                     {"standard_name", "particle flow"},
-                    {"long_name", name + " particle flow in X"},
+                    {"long_name", name + " particle flow in X. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_density"}});
     }
@@ -322,7 +322,7 @@ void EvolveDensity::outputVars(Options& state) {
                     {"units", "s^-1"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
                     {"standard_name", "particle flow"},
-                    {"long_name", name + " particle flow in Y"},
+                    {"long_name", name + " particle flow in Y. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_density"}});
     }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -245,6 +245,17 @@ void EvolveDensity::finally(const Options& state) {
     }
   }
 #endif
+
+  if (diagnose) {
+    // Save flows if they are set
+
+    if (species.isSet("density_flow_xlow")) {
+      flow_xlow = get<Field3D>(state["density_flow_xlow"]);
+    }
+    if (species.isSet("density_flow_ylow")) {
+      flow_ylow = get<Field3D>(state["density_flow_ylow"]);
+    }
+  }
 }
 
 void EvolveDensity::outputVars(Options& state) {
@@ -291,5 +302,29 @@ void EvolveDensity::outputVars(Options& state) {
                     {"long_name", name + " number density source"},
                     {"species", name},
                     {"source", "evolve_density"}});
+
+    // If fluxes have been set then add them to the output
+    auto rho_s0 = get<BoutReal>(state["rho_s0"]);
+
+    if (flow_xlow.isAllocated()) {
+      set_with_attrs(state[std::string("ParticleFlow_") + name + std::string("_xlow")], flow_xlow,
+                   {{"time_dimension", "t"},
+                    {"units", "s^-1"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
+                    {"standard_name", "particle flow"},
+                    {"long_name", name + " particle flow in X"},
+                    {"species", name},
+                    {"source", "evolve_density"}});
+    }
+    if (flow_ylow.isAllocated()) {
+      set_with_attrs(state[std::string("ParticleFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "s^-1"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
+                    {"standard_name", "particle flow"},
+                    {"long_name", name + " particle flow in Y"},
+                    {"species", name},
+                    {"source", "evolve_density"}});
+    }
   }
 }

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -331,10 +331,10 @@ void EvolveEnergy::finally(const Options& state) {
     // Save flows of energy if they are set
 
     if (species.isSet("energy_flow_xlow")) {
-      flow_xlow = get<Field3D>(state["energy_flow_xlow"]);
+      flow_xlow = get<Field3D>(species["energy_flow_xlow"]);
     }
     if (species.isSet("energy_flow_ylow")) {
-      flow_ylow = get<Field3D>(state["energy_flow_ylow"]);
+      flow_ylow = get<Field3D>(species["energy_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -326,6 +326,17 @@ void EvolveEnergy::finally(const Options& state) {
     }
   }
 #endif
+
+  if (diagnose) {
+    // Save flows of energy if they are set
+
+    if (species.isSet("energy_flow_xlow")) {
+      flow_xlow = get<Field3D>(state["energy_flow_xlow"]);
+    }
+    if (species.isSet("energy_flow_ylow")) {
+      flow_ylow = get<Field3D>(state["energy_flow_ylow"]);
+    }
+  }
 }
 
 void EvolveEnergy::outputVars(Options& state) {
@@ -404,6 +415,27 @@ void EvolveEnergy::outputVars(Options& state) {
                     {"long_name", name + " energy source"},
                     {"species", name},
                     {"source", "evolve_energy"}});
+
+    if (flow_xlow.isAllocated()) {
+      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_xlow")], flow_xlow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through X cell face"},
+                    {"species", name},
+                    {"source", "evolve_energy"}});
+    }
+    if (flow_ylow.isAllocated()) {
+      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through Y cell face"},
+                    {"species", name},
+                    {"source", "evolve_energy"}});
+    }
   }
 }
 

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -422,7 +422,7 @@ void EvolveEnergy::outputVars(Options& state) {
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
                     {"standard_name", "power"},
-                    {"long_name", name + " power through X cell face"},
+                    {"long_name", name + " power through X cell face. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_energy"}});
     }
@@ -432,7 +432,7 @@ void EvolveEnergy::outputVars(Options& state) {
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
                     {"standard_name", "power"},
-                    {"long_name", name + " power through Y cell face"},
+                    {"long_name", name + " power through Y cell face. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_energy"}});
     }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -228,7 +228,7 @@ void EvolveMomentum::outputVars(Options &state) {
                     {"units", "N"},
                     {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
                     {"standard_name", "momentum flow"},
-                    {"long_name", name + " momentum flow in X"},
+                    {"long_name", name + " momentum flow in X. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_momentum"}});
     }
@@ -238,7 +238,7 @@ void EvolveMomentum::outputVars(Options &state) {
                     {"units", "N"},
                     {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
                     {"standard_name", "momentum flow"},
-                    {"long_name", name + " momentum flow in Y"},
+                    {"long_name", name + " momentum flow in Y. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_momentum"}});
     }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -163,6 +163,17 @@ void EvolveMomentum::finally(const Options &state) {
     }
   }
 #endif
+
+  if (diagnose) {
+    // Save flows if they are set
+
+    if (species.isSet("momentum_flow_xlow")) {
+      flow_xlow = get<Field3D>(state["momentum_flow_xlow"]);
+    }
+    if (species.isSet("momentum_flux_ylow")) {
+      flow_ylow = get<Field3D>(state["momentum_flow_ylow"]);
+    }
+  }
 }
 
 void EvolveMomentum::outputVars(Options &state) {
@@ -207,5 +218,29 @@ void EvolveMomentum::outputVars(Options &state) {
                     {"long_name", name + " momentum source"},
                     {"species", name},
                     {"source", "evolve_momentum"}});
+
+    // If fluxes have been set then add them to the output
+    auto rho_s0 = get<BoutReal>(state["rho_s0"]);
+
+    if (flow_xlow.isAllocated()) {
+      set_with_attrs(state[std::string("MomentumFlow_") + name + std::string("_xlow")], flow_xlow,
+                   {{"time_dimension", "t"},
+                    {"units", "N"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+                    {"standard_name", "momentum flow"},
+                    {"long_name", name + " momentum flow in X"},
+                    {"species", name},
+                    {"source", "evolve_momentum"}});
+    }
+    if (flow_ylow.isAllocated()) {
+      set_with_attrs(state[std::string("MomentumFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "N"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+                    {"standard_name", "momentum flow"},
+                    {"long_name", name + " momentum flow in Y"},
+                    {"species", name},
+                    {"source", "evolve_momentum"}});
+    }
   }
 }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -168,10 +168,10 @@ void EvolveMomentum::finally(const Options &state) {
     // Save flows if they are set
 
     if (species.isSet("momentum_flow_xlow")) {
-      flow_xlow = get<Field3D>(state["momentum_flow_xlow"]);
+      flow_xlow = get<Field3D>(species["momentum_flow_xlow"]);
     }
     if (species.isSet("momentum_flux_ylow")) {
-      flow_ylow = get<Field3D>(state["momentum_flow_ylow"]);
+      flow_ylow = get<Field3D>(species["momentum_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -333,6 +333,17 @@ void EvolvePressure::finally(const Options& state) {
     }
   }
 #endif
+
+  if (diagnose) {
+    // Save flows of energy if they are set
+
+    if (species.isSet("energy_flow_xlow")) {
+      flow_xlow = get<Field3D>(state["energy_flow_xlow"]);
+    }
+    if (species.isSet("energy_flow_ylow")) {
+      flow_ylow = get<Field3D>(state["energy_flow_ylow"]);
+    }
+  }
 }
 
 void EvolvePressure::outputVars(Options& state) {
@@ -401,6 +412,27 @@ void EvolvePressure::outputVars(Options& state) {
                     {"long_name", name + " pressure source"},
                     {"species", name},
                     {"source", "evolve_pressure"}});
+
+    if (flow_xlow.isAllocated()) {
+      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_xlow")], flow_xlow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through X cell face"},
+                    {"species", name},
+                    {"source", "evolve_pressure"}});
+    }
+    if (flow_ylow.isAllocated()) {
+      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through Y cell face"},
+                    {"species", name},
+                    {"source", "evolve_pressure"}});
+    }
   }
 }
 

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -338,10 +338,10 @@ void EvolvePressure::finally(const Options& state) {
     // Save flows of energy if they are set
 
     if (species.isSet("energy_flow_xlow")) {
-      flow_xlow = get<Field3D>(state["energy_flow_xlow"]);
+      flow_xlow = get<Field3D>(species["energy_flow_xlow"]);
     }
     if (species.isSet("energy_flow_ylow")) {
-      flow_ylow = get<Field3D>(state["energy_flow_ylow"]);
+      flow_ylow = get<Field3D>(species["energy_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -419,7 +419,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
                     {"standard_name", "power"},
-                    {"long_name", name + " power through X cell face"},
+                    {"long_name", name + " power through X cell face. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_pressure"}});
     }
@@ -429,7 +429,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
                     {"standard_name", "power"},
-                    {"long_name", name + " power through Y cell face"},
+                    {"long_name", name + " power through Y cell face. Note: May be incomplete."},
                     {"species", name},
                     {"source", "evolve_pressure"}});
     }


### PR DESCRIPTION
The `anomalous_diffusion` component now saves flows of particles, momentum and energy through cell faces in the state. The plan is for this to be extended to other components, making cell face flows easier to diagnose.

`PFx = state["species"]["e"]["particle_flow_xlow"]` is the (normalised) number of particles per second passing through the lower X cell face: `PFx(i,j,k)` is the number of particles per second passing from cell `(i-1,j,k)` to `(i,j,k)`. Note that positive flow means flow in the positive coordinate direction. 

Similarly, `PFy = state["species"]["e"]["particle_flow_ylow"]` is the flow of particles through the lower Y cell face.

The rate of change of density in cell `(i,j,k)` due to the flows is:
```
ddt(Ne) = ( PFx(i,j,k) + PFy(i,j,k) - PFx(i+1, j, k) - PFy(i,j+1,k) ) / dV
```
where `dV = J * dx * dy * dz` is the volume of the cell.