### PR TITLE
Update the readme to include BOUT++ commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ CMake the path to the BOUT++ `build` directory e.g.
 
     $ cmake . -B build -DHERMES_BUILD_BOUT=OFF -DCMAKE_PREFIX_PATH=$HOME/BOUT-dev/build
 
-Note that Hermes-3 currently requires BOUT++ version 5.
+Note that Hermes-3 currently requires a specific version of BOUT++:
+https://github.com/boutproject/BOUT-dev/commit/7152948fbde505f6708d5ca4a9c21e5828d1e0a1
 
 ## Examples
 


### PR DESCRIPTION
A couple of new users recently didn't realise a specific BOUT++ commit is required when installing Hermes-3. This will need to be updated when we update the BOUT++ version.