### PR TITLE
Add edge recycling

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -978,17 +978,17 @@ The boundary fluxes might be set by sheath boundary conditions,
 which potentially depend on the density and temperature of all species.
 Recycling therefore can't be calculated until all species boundary conditions
 have been set. It is therefore expected that this component is a top-level
-component which comes after boundary conditions are set.
+component (i.e. in the `Hermes` section) which comes after boundary conditions are set.
 
 Recycling has been implemented at the target, the SOL edge and the PFR edge.
-Each is off by default and must activated with a separate flag. Each can be 
+Each is off by default and must be activated with a separate flag. Each can be 
 assigned a separate recycle multiplier and recycle energy. 
 
 The chosen species must feature an outflow through the boundary - any cells
 with an inflow have their recycling source set to zero. If a sheath boundary condition
 is enabled, then this is automatically satisfied at the target through the Bohm condition.
-If it is not enabled, then the target boundary must be set to `free` or `decay_length` to 
-allow an outflow. If SOL or PFR recycling is enabled, a `free` or `decay_length` on
+If it is not enabled, then the target boundary must be set to `free_o2`, `free_o3` or `decaylength` to 
+allow an outflow. If SOL or PFR recycling is enabled, a `free_o2`, `free_o3` or `decaylength`on
 their respective boundaries is required at all times.
 
 The recycling component has a `species` option, that is a list of species

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -971,7 +971,7 @@ The implementation is in the `ThermalForce` class:
 recycling
 ~~~~~~~~~
 
-This component calculates the flux of a species into a Y boundary,
+This component calculates the flux of a species into a boundary
 due to recycling of flow out of the boundary of another species.
 
 The boundary fluxes might be set by sheath boundary conditions,
@@ -980,13 +980,29 @@ Recycling therefore can't be calculated until all species boundary conditions
 have been set. It is therefore expected that this component is a top-level
 component which comes after boundary conditions are set.
 
+Recycling has been implemented at the target, the SOL edge and the PFR edge.
+Each is off by default and must activated with a separate flag. Each can be 
+assigned a separate recycle multiplier and recycle energy. 
+
+The chosen species must feature an outflow through the boundary - any cells
+with an inflow have their recycling source set to zero. If a sheath boundary condition
+is enabled, then this is automatically satisfied at the target through the Bohm condition.
+If it is not enabled, then the target boundary must be set to `free` or `decay_length` to 
+allow an outflow. If SOL or PFR recycling is enabled, a `free` or `decay_length` on
+their respective boundaries is required at all times.
+
 The recycling component has a `species` option, that is a list of species
 to recycle. For each of the species in that list, `recycling` will look in
 the corresponding section for the options `recycle_as`, `recycle_multiplier`
-and `recycle_energy`.
+and `recycle_energy` for each of the three implemented boundaries. Note that 
+the resulting recycling source is a simple
+multiplication of the outgoing species flow and the multiplier factor.
+This means that recycling `d+` ions into `d2` molecules would require a multiplier 
+of 0.5 to maintain a particle balance in the simulation.
 
 For example, recycling `d+` ions into `d` atoms with a recycling fraction
-of 1. Each returning atom has an energy of 3.5eV:
+of 0.95 at the target and 1.0 at the SOL and PFR edges. 
+Each returning atom has an energy of 3.5eV:
 
 .. code-block:: ini
 
@@ -998,8 +1014,18 @@ of 1. Each returning atom has an energy of 3.5eV:
 
    [d+]
    recycle_as = d         # Species to recycle as
-   recycle_multiplier = 1 # Recycling fraction
-   recycle_energy = 3.5   # Energy of recycled particles [eV]
+
+   target_recycle = true  
+   target_recycle_multiplier = 0.95 # Recycling fraction
+   target_recycle_energy = 3.5   # Energy of recycled particles [eV]
+
+   sol_recycle = true
+   sol_recycle_multiplier = 1 # Recycling fraction
+   sol_recycle_energy = 3.5   # Energy of recycled particles [eV]
+
+   sol_recycle = true
+   sol_recycle_multiplier = 1 # Recycling fraction
+   sol_recycle_energy = 3.5   # Energy of recycled particles [eV]
 
 .. doxygenstruct:: Recycling
    :members:

--- a/examples/1D-hydrogen-equalT/BOUT.inp
+++ b/examples/1D-hydrogen-equalT/BOUT.inp
@@ -95,7 +95,7 @@ density_controller_p = 5e2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 

--- a/examples/1D-hydrogen/BOUT.inp
+++ b/examples/1D-hydrogen/BOUT.inp
@@ -98,7 +98,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 

--- a/examples/1D-hydrogen/qn/BOUT.inp
+++ b/examples/1D-hydrogen/qn/BOUT.inp
@@ -100,7 +100,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 

--- a/examples/1D-neon-source/BOUT.inp
+++ b/examples/1D-neon-source/BOUT.inp
@@ -103,7 +103,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 
@@ -169,7 +169,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]
 function = 1e-5
@@ -189,7 +189,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+2]
 function = 1e-5
@@ -209,7 +209,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+3]
 function = 1e-5
@@ -229,7 +229,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -251,7 +251,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -273,7 +273,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -295,7 +295,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -317,7 +317,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -339,7 +339,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 
@@ -361,7 +361,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -104,7 +104,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 
@@ -168,7 +168,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+]
 function = 1e-5
@@ -188,7 +188,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+2]
 function = 1e-5
@@ -208,7 +208,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+3]
 function = 1e-5
@@ -228,7 +228,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -250,7 +250,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -272,7 +272,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -294,7 +294,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -316,7 +316,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -338,7 +338,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 
@@ -360,7 +360,7 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
 

--- a/examples/1D-recycling/BOUT.inp
+++ b/examples/1D-recycling/BOUT.inp
@@ -101,7 +101,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 # Initial condition for ion density.

--- a/examples/1D-recycling/cvode/BOUT.inp
+++ b/examples/1D-recycling/cvode/BOUT.inp
@@ -92,7 +92,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
-recycle_multiplier = 1  # Recycling fraction
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 

--- a/examples/solkit-comparison/single-temperature/BOUT.inp
+++ b/examples/solkit-comparison/single-temperature/BOUT.inp
@@ -100,7 +100,7 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 

--- a/examples/solkit-comparison/two-temperatures/BOUT.inp
+++ b/examples/solkit-comparison/two-temperatures/BOUT.inp
@@ -100,7 +100,7 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
 

--- a/examples/tokamak/recycling-dthe-drifts/BOUT.inp
+++ b/examples/tokamak/recycling-dthe-drifts/BOUT.inp
@@ -53,7 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
 
@@ -89,7 +89,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
 
@@ -125,7 +125,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]
 

--- a/examples/tokamak/recycling-dthe/BOUT.inp
+++ b/examples/tokamak/recycling-dthe/BOUT.inp
@@ -53,7 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
 
@@ -89,7 +89,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = t
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
 
@@ -125,7 +125,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = he
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 

--- a/examples/tokamak/recycling-dthene/BOUT.inp
+++ b/examples/tokamak/recycling-dthene/BOUT.inp
@@ -36,7 +36,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
 
@@ -76,7 +76,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
 
@@ -116,7 +116,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]
 
@@ -156,7 +156,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = ne
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]
 

--- a/examples/tokamak/recycling/BOUT.inp
+++ b/examples/tokamak/recycling/BOUT.inp
@@ -59,7 +59,7 @@ anomalous_chi = 4
 thermal_conduction = true
 
 recycle_as = d
-recycle_multiplier = 0.99  # Recycling fraction
+target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -61,7 +61,7 @@ private:
   Field3D sol_recycle_density_source, sol_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
   Field3D pfr_recycle_density_source, pfr_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
 
-  Field3D radial_particle_flow, radial_energy_flow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
+  Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -51,15 +51,15 @@ private:
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
-  
-  bool target_recycling, sol_recycling, pfr_recycling;  ///< Flags for enabling recycling in different regions
+
+  bool target_recycle, sol_recycle, pfr_recycle;  ///< Flags for enabling recycling in different regions
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
 
-  Field3D target_recycling_density_source, target_recycling_energy_source;  ///< Recycling particle and energy sources for target recycling only
-  Field3D sol_recycling_density_source, sol_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
-  Field3D pfr_recycling_density_source, pfr_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
+  Field3D sol_recycle_density_source, sol_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  Field3D pfr_recycle_density_source, pfr_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
 
   Field3D radial_particle_flow, radial_energy_flow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -36,6 +36,7 @@ struct Recycling : public Component {
   ///   - density_source
   ///
   void transform(Options &state) override;
+  void outputVars(Options &state) override;
 
 private:
 
@@ -49,6 +50,8 @@ private:
 
   std::vector<RecycleChannel> channels; // Recycling channels
   bool sol_recycling;  ///< Flag for reycling in the edge
+  bool diagnose; ///< Outputting diagnostics?
+  Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
   
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -46,8 +46,8 @@ private:
 
     /// Flux multiplier (recycling fraction). 
     /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
-    BoutReal target_multiplier, sol_multiplier, edge_multiplier; 
-    BoutReal target_energy, sol_energy, edge_energy; ///< Energy of recycled particle (normalised to Tnorm)
+    BoutReal target_multiplier, sol_multiplier, pfr_multiplier; 
+    BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -48,6 +48,7 @@ private:
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
+  bool sol_recycling;  ///< Flag for reycling in the edge
   
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -52,6 +52,9 @@ private:
   bool sol_recycling;  ///< Flag for reycling in the edge
   bool diagnose; ///< Outputting diagnostics?
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
+  Field3D sol_recycling_density_source, sol_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  Field3D target_recycling_density_source, target_recycling_energy_source;  ///< Recycling particle and energy sources for target recycling only
+  Field3D radial_particle_flow, radial_energy_flow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -43,17 +43,24 @@ private:
   struct RecycleChannel {
     std::string from; ///< The species name to recycle
     std::string to;   ///< Species to recycle to
-    BoutReal multiplier; ///< Flux multiplier. Combination of recycling fraction and species
-                         ///< change e.g h+ -> h2 results in 0.5 multiplier
-    BoutReal energy; ///< Energy of recycled particle (normalised to Tnorm)
+
+    /// Flux multiplier (recycling fraction). 
+    /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
+    BoutReal target_multiplier, sol_multiplier, edge_multiplier; 
+    BoutReal target_energy, sol_energy, edge_energy; ///< Energy of recycled particle (normalised to Tnorm)
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
-  bool sol_recycling;  ///< Flag for reycling in the edge
-  bool diagnose; ///< Outputting diagnostics?
+  
+  bool target_recycling, sol_recycling, pfr_recycling;  ///< Flags for enabling recycling in different regions
+  bool diagnose; ///< Save additional post-processing variables?
+
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
-  Field3D sol_recycling_density_source, sol_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+
   Field3D target_recycling_density_source, target_recycling_energy_source;  ///< Recycling particle and energy sources for target recycling only
+  Field3D sol_recycling_density_source, sol_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  Field3D pfr_recycling_density_source, pfr_recycling_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+
   Field3D radial_particle_flow, radial_energy_flow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   
 };

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -203,7 +203,7 @@ void Recycling::outputVars(Options& state) {
 
         // Save particle and energy source for the species created during recycling
 
-        set_with_attrs(state[{std::string("S") + channel.to + std::string("_target_recycle")}], density_source,
+        set_with_attrs(state[{std::string("S") + channel.to + std::string("_recycle")}], density_source,
                         {{"time_dimension", "t"},
                         {"units", "m^-3 s^-1"},
                         {"conversion", Nnorm * Omega_ci},
@@ -228,14 +228,6 @@ void Recycling::outputVars(Options& state) {
                           {"long_name", std::string("SOL recycling energy source of ") + channel.to},
                           {"source", "recycling"}});
           }
-
-        set_with_attrs(state["debug_particle_flow"], radial_particle_flow,
-                        {{"time_dimension", "t"},
-                        {"units", "m^-3 s^-1"},
-                        {"conversion", Nnorm * Omega_ci},
-                        {"standard_name", "particle source"},
-                        {"long_name", std::string("Particle flow of ")},
-                        {"source", "recycling"}});
       }
 
   }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -217,9 +217,11 @@ void Recycling::transform(Options& state) {
 
             // Flow of recycled species back from the edge
             // SOL edge = LHS flow of inner guard cells on the high X side (mesh->xend+1)
-            
-            // TODO: Handle cases when flow is going into domain from edge
-            BoutReal recycle_particle_flow = channel.sol_multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
+            // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
+            BoutReal recycle_particle_flow = 0;
+            if (radial_particle_outflow(mesh->xend+1, iy, iz) > 0) {
+              recycle_particle_flow = channel.sol_multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
+            } 
 
             // Divide by volume to get source
             sol_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
@@ -241,7 +243,7 @@ void Recycling::transform(Options& state) {
 
       // PFR is flipped compared to edge: flow out of domain is positive
       radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
-      
+
       pfr_recycle_density_source = 0;
       pfr_recycle_energy_source = 0;
 
@@ -257,8 +259,11 @@ void Recycling::transform(Options& state) {
 
               // Flow of recycled species back from the edge
               // PFR edge = LHS flow of the first domain cell on the low X side (mesh->xstart)
-              // TODO: Handle cases when flow is going into domain from edge
-              BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_outflow(mesh->xstart, iy, iz); 
+              // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
+              BoutReal recycle_particle_flow = 0;
+              if (radial_particle_outflow(mesh->xstart, iy, iz) > 0) { 
+                recycle_particle_flow = channel.pfr_multiplier * radial_particle_outflow(mesh->xstart, iy, iz); 
+              }
 
               // Divide by volume to get source
               pfr_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -150,12 +150,16 @@ void Recycling::transform(Options& state) {
               / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)));
 
           // Add to density source
-          target_recycle_density_source += flow / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          density_source(r.ind, mesh->ystart, jz) += flow / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          target_recycle_density_source(r.ind, mesh->ystart, jz) += flow 
+              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          density_source(r.ind, mesh->ystart, jz) += flow 
+              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
 
           // energy of recycled particles
-          target_recycle_energy_source += channel.target_energy * flow / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          target_recycle_energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
+              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
+              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
         }
       }
 
@@ -181,11 +185,15 @@ void Recycling::transform(Options& state) {
 
           // Rate of change of neutrals in final cell
           // Add to density source
-          target_recycle_density_source += flow / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          density_source(r.ind, mesh->yend, jz) += flow / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          target_recycle_density_source(r.ind, mesh->yend, jz) += flow 
+              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          density_source(r.ind, mesh->yend, jz) += flow 
+              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
 
-          target_recycle_energy_source += channel.target_energy * flow / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          target_recycle_energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
+              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
+          energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
+              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
         }
       }
     }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -202,7 +202,6 @@ void Recycling::transform(Options& state) {
     if (sol_recycle) {
 
       radial_particle_flow = get<Field3D>(species_from["particle_flow_xlow"]);
-      radial_energy_flow = get<Field3D>(species_from["energy_flow_xlow"]);
       sol_recycle_density_source = 0;
       sol_recycle_energy_source = 0;
 
@@ -218,7 +217,6 @@ void Recycling::transform(Options& state) {
             // Edge = LHS flow of inner guard cells (mesh->xend-1)
             // TODO: Handle cases when flow is going into domain from edge
             BoutReal recycle_particle_flow = channel.sol_multiplier * radial_particle_flow(mesh->xend+1, iy, iz) * -1; 
-            BoutReal recycle_energy_flow = channel.sol_multiplier * radial_energy_flow(mesh->xend, iy, iz) * -1 ;
 
             // Divide by volume to get source
             sol_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
@@ -239,7 +237,6 @@ void Recycling::transform(Options& state) {
     if (pfr_recycle) {
 
       radial_particle_flow = get<Field3D>(species_from["particle_flow_xlow"]);
-      radial_energy_flow = get<Field3D>(species_from["energy_flow_xlow"]);
       pfr_recycle_density_source = 0;
       pfr_recycle_energy_source = 0;
 
@@ -257,7 +254,6 @@ void Recycling::transform(Options& state) {
               // Edge = LHS flow of inner guard cells (mesh->xend-1)
               // TODO: Handle cases when flow is going into domain from edge
               BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_flow(mesh->xstart+1, iy, iz) * -1; 
-              BoutReal recycle_energy_flow = channel.pfr_multiplier * radial_energy_flow(mesh->xstart, iy, iz) * -1 ;
 
               // Divide by volume to get source
               pfr_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -54,17 +54,17 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
 
     BoutReal target_recycle_energy = from_options["target_recycle_energy"]
                                   .doc("Fixed energy of the recycled particles at target [eV]")
-                                  .withDefault<BoutReal>(0.0)
+                                  .withDefault<BoutReal>(3.0)
                               / Tnorm; // Normalise from eV
 
     BoutReal sol_recycle_energy = from_options["sol_recycle_energy"]
                                   .doc("Fixed energy of the recycled particles at sol [eV]")
-                                  .withDefault<BoutReal>(0.0)
+                                  .withDefault<BoutReal>(3.0)
                               / Tnorm; // Normalise from eV
 
     BoutReal pfr_recycle_energy = from_options["pfr_recycle_energy"]
                                   .doc("Fixed energy of the recycled particles at pfr [eV]")
-                                  .withDefault<BoutReal>(0.0)
+                                  .withDefault<BoutReal>(3.0)
                               / Tnorm; // Normalise from eV
 
     if ((target_recycle_multiplier < 0.0) or (target_recycle_multiplier > 1.0)

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -201,7 +201,9 @@ void Recycling::transform(Options& state) {
     // Recycling at the SOL edge (2D/3D only)
     if (sol_recycle) {
 
-      radial_particle_flow = get<Field3D>(species_from["particle_flow_xlow"]);
+      // Flow out of domain is negative, so outflow is *-1
+      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]) * -1;
+
       sol_recycle_density_source = 0;
       sol_recycle_energy_source = 0;
 
@@ -215,9 +217,9 @@ void Recycling::transform(Options& state) {
 
             // Flow of recycled species back from the edge
             // SOL edge = LHS flow of inner guard cells on the high X side (mesh->xend+1)
-            // Flow out of domain is negative
+            
             // TODO: Handle cases when flow is going into domain from edge
-            BoutReal recycle_particle_flow = channel.sol_multiplier * radial_particle_flow(mesh->xend+1, iy, iz) * -1; 
+            BoutReal recycle_particle_flow = channel.sol_multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
 
             // Divide by volume to get source
             sol_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
@@ -237,7 +239,9 @@ void Recycling::transform(Options& state) {
     // Recycling at the PFR edge (2D/3D only)
     if (pfr_recycle) {
 
-      radial_particle_flow = get<Field3D>(species_from["particle_flow_xlow"]);
+      // PFR is flipped compared to edge: flow out of domain is positive
+      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
+      
       pfr_recycle_density_source = 0;
       pfr_recycle_energy_source = 0;
 
@@ -253,9 +257,8 @@ void Recycling::transform(Options& state) {
 
               // Flow of recycled species back from the edge
               // PFR edge = LHS flow of the first domain cell on the low X side (mesh->xstart)
-              // PFR is flipped compared to edge: flow out of domain is positive
               // TODO: Handle cases when flow is going into domain from edge
-              BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_flow(mesh->xstart, iy, iz); 
+              BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_outflow(mesh->xstart, iy, iz); 
 
               // Divide by volume to get source
               pfr_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -214,7 +214,8 @@ void Recycling::transform(Options& state) {
                  * dy(mesh->xend, iy) * dz(mesh->xend, iy);
 
             // Flow of recycled species back from the edge
-            // Edge = LHS flow of inner guard cells (mesh->xend-1)
+            // SOL edge = LHS flow of inner guard cells on the high X side (mesh->xend+1)
+            // Flow out of domain is negative
             // TODO: Handle cases when flow is going into domain from edge
             BoutReal recycle_particle_flow = channel.sol_multiplier * radial_particle_flow(mesh->xend+1, iy, iz) * -1; 
 
@@ -251,9 +252,10 @@ void Recycling::transform(Options& state) {
                   * dy(mesh->xstart, iy) * dz(mesh->xstart, iy);
 
               // Flow of recycled species back from the edge
-              // Edge = LHS flow of inner guard cells (mesh->xend-1)
+              // PFR edge = LHS flow of the first domain cell on the low X side (mesh->xstart)
+              // PFR is flipped compared to edge: flow out of domain is positive
               // TODO: Handle cases when flow is going into domain from edge
-              BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_flow(mesh->xstart+1, iy, iz) * -1; 
+              BoutReal recycle_particle_flow = channel.pfr_multiplier * radial_particle_flow(mesh->xstart, iy, iz); 
 
               // Divide by volume to get source
               pfr_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -20,8 +20,6 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
                                    .as<std::string>(),
                                ',');
 
-  diagnose =
-      options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
       
   for (const auto& species : species_list) {
     std::string from = trim(species, " \t\r()"); // The species name in the list
@@ -34,6 +32,9 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
     std::string to = from_options["recycle_as"]
                          .doc("Name of the species to recycle into")
                          .as<std::string>();
+
+    diagnose =
+      from_options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
 
     BoutReal recycle_multiplier =
         from_options["recycle_multiplier"]
@@ -50,7 +51,7 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
     }
     channels.push_back({from, to, recycle_multiplier, recycle_energy});
 
-    sol_recycling = alloptions[name]["sol_recycling"]
+    sol_recycling = from_options["sol_recycling"]
                    .doc("Recycling in the SOL edge?")
                    .withDefault<bool>(false);
   }
@@ -168,11 +169,11 @@ void Recycling::transform(Options& state) {
             BoutReal particle_flow = channel.multiplier * particle_flux * area;
             BoutReal energy_flow = channel.multiplier * energy_flux * area;
 
-            // // Not sure why the other calcs above aren't dividing the flow by the cell volume..
-            // density_source(mesh->lastX(), iy, iz) += particle_flow / volume;
+            // Not sure why the other calcs above aren't dividing the flow by the cell volume..
+            density_source(mesh->lastX(), iy, iz) += particle_flow / volume;
 
-            // // For now, this is a fixed temperature
-            // energy_source(mesh->lastX(), iy, iz) += channel.energy * particle_flow / volume;
+            // For now, this is a fixed temperature
+            energy_source(mesh->lastX(), iy, iz) += channel.energy * particle_flow / volume;
 
           }
         }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -201,8 +201,8 @@ void Recycling::transform(Options& state) {
     // Recycling at the SOL edge (2D/3D only)
     if (sol_recycle) {
 
-      // Flow out of domain is negative, so outflow is *-1
-      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]) * -1;
+      // Flow out of domain is positive in the positive coordinate direction
+      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
 
       sol_recycle_density_source = 0;
       sol_recycle_energy_source = 0;
@@ -241,8 +241,8 @@ void Recycling::transform(Options& state) {
     // Recycling at the PFR edge (2D/3D only)
     if (pfr_recycle) {
 
-      // PFR is flipped compared to edge: flow out of domain is positive
-      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
+      // PFR is flipped compared to edge: x=0 is at the PFR edge. Therefore outflow is in the negative coordinate direction.
+      radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]) * -1;
 
       pfr_recycle_density_source = 0;
       pfr_recycle_energy_source = 0;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -40,17 +40,17 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
     BoutReal target_recycle_multiplier =
         from_options["target_recycle_multiplier"]
             .doc("Multiply the target recycled flux by this factor. Should be >=0 and <= 1")
-            .as<BoutReal>();
+            .withDefault<BoutReal>(1.0);
 
     BoutReal sol_recycle_multiplier =
         from_options["sol_recycle_multiplier"]
             .doc("Multiply the sol recycled flux by this factor. Should be >=0 and <= 1")
-            .as<BoutReal>();
+            .withDefault<BoutReal>(1.0);
 
     BoutReal pfr_recycle_multiplier =
         from_options["pfr_recycle_multiplier"]
             .doc("Multiply the pfr recycled flux by this factor. Should be >=0 and <= 1")
-            .as<BoutReal>();
+            .withDefault<BoutReal>(1.0);
 
     BoutReal target_recycle_energy = from_options["target_recycle_energy"]
                                   .doc("Fixed energy of the recycled particles at target [eV]")

--- a/tests/integrated/1D-recycling/data/BOUT.inp
+++ b/tests/integrated/1D-recycling/data/BOUT.inp
@@ -91,7 +91,9 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
-recycle_multiplier = 1  # Recycling fraction
+target_recycling = true
+target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle_energy = 0.0  # Realistic number is 3eV, but here 0 for consistency with older tests
 
 [Nd+]
 

--- a/tests/integrated/1D-recycling/data/BOUT.inp
+++ b/tests/integrated/1D-recycling/data/BOUT.inp
@@ -91,7 +91,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
-target_recycling = true
+target_recycle = true
 target_recycle_multiplier = 1.0  # Recycling fraction
 target_recycle_energy = 0.0  # Realistic number is 3eV, but here 0 for consistency with older tests
 


### PR DESCRIPTION
First of several BCs required to bring Hermes-3 in line with UEDGE/SOLPS/SOLEDGE2D/etc in terms of boundary conditions.
This requires the PR which enables cell face flows to be saved in the state: https://github.com/bendudson/hermes-3/pull/152
It's required because the perpendicular fluxes are currently calculated in `anomalous_diffusion` and not saved; the operators only output the change in source to the next cell as a result of the flux. At the moment, just the radial and poloidal components of the three anomalous transport channels are saved. These are sufficient to calculate the plasma flux leaving the SOL edge.

Note that for plasma flux to leave the edge you need a free boundary condition on both density (to allow a density gradient and therefore perpendicular diffusion) as well as pressure (to avoid violating P=NT) but a neumann condition on temperature (to prevent conduction). This requirement will need documentation and maybe a warning if the user only set a neumann condition. 

One of the other things I will be implementing is a decay length boundary condition which will be an alternative to the free BC in the above scenario.


Tasks:
- [x] Add recycling in the SOL edge
- [x] Add recycling in the PFR edge
- [x] Add diagnostic variables for particle and energy sources from recycling
- [ ] ~Implement console warning if user sets edge recycling but fails to set free boundary condition~
- [x] Make BC requirements clear in the documentation
- [x] Add individual controls for SOL/PFR/target recycling fraction and recycling species energy
- [x] Simple tests
- [x] Complex test
- [x] Mass balance test
- [x] Update examples
- [x] Add documentation