### PR TITLE
Adding a decay length boundary condition

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -597,11 +597,75 @@ agreement with kinetic neutral models [Discussion, T.Rognlien].
 
 Boundary conditions
 -------------------
+Simple boundary conditions
+~~~~~~~~~~~~~~~
+BOUT++ simple boundary conditions
+^^^^^^^^^^^^^^^
+
+BOUT++ provides a number of fundamental boundary conditions including:
+- dirichlet(x): boundary set to constant value of `x`
+- neumann: boundary set to zero gradient
+- free_o2: boundary set by linear extrapolation (using 2 points)
+- free_o3: boundary set by quadratic extrapolation (using 3 points)
+
+These can be set on different parts of the domain using the keywords
+`core`, `sol`, `pf`, `lower_target`, `upper_target`, `xin`, `xout`, `yup`, `ydown` and `bndry_all`.
+
+The boundary conditions can also be applied over a finite width as well as relaxed over a specified timescale.
+
+These boundary conditions are implemented in BOUT++, and therefore have no access to
+the normalisations within Hermes-3 and so must be used in normalised units.
+Please see the `BOUT++ documentation
+<https://bout-dev.readthedocs.io/en/latest/user_docs/boundary_options.html>`_ for more detail, 
+including the full list of boundary conditions and more guidance on their use.
+In case the documentation is incomplete or insufficient, please refer to the 
+`BOUT++ boundary condition code
+<https://github.com/boutproject/BOUT-dev/blob/cbd197e78f7d52721188badfd7c38a0a540a82bd/src/mesh/boundary_standard.cxx>`_
+.
+
+Hermes-3 simple boundary conditions
+^^^^^^^^^^^^^^^
+Currently, there is only one additional simple boundary condition implemented in Hermes-3.
+`decaylength(x)` sets the boundary according to a user-set radial decay length. 
+This is a commonly used setting for plasma density and pressure in the tokamak SOL boundary in 2D and 3D but is not applicable in 1D.
+Note that this must be provided in normalised units just like the BOUT++ simple boundary conditions.
+
+
+Simple boundary condition examples
+^^^^^^^^^^^^^^^
+The below example for a 2D tokamak simulation sets the electron density to a constant value of 1e20 m:sup:`-3` in the core and
+sets a decay length of 3mm in the SOL and PFR regions, while setting the remaining boundaries to `neumann`.
+Example settings of the fundamental normalisation factors and the calculation of the derived ones is provided
+in the `hermes` component which can be accessed by using the `hermes:` prefix in any other component in the input file.
+
+.. code-block:: ini
+
+   [hermes]
+   Nnorm = 1e17  # Reference density [m^-3]
+   Bnorm = 1   # Reference magnetic field [T]
+   Tnorm = 100   # Reference temperature [eV]
+   qe = 1.60218e-19   # Electron charge
+   Mp = 1.67262e-27   # Proton mass
+   Cs0 = sqrt(qe * Tnorm / Mp)   # Reference speed [m/s]
+   Omega_ci = qe * Bnorm / Mp   # Reference frequency [1/s]
+   rho_s0 = Cs0 / Omega_ci   # Refence length [m]
+
+   [Ne]
+   bndry_core = dirichlet(1e20 / hermes:Nnorm)
+   bndry_sol = decaylength(0.003 / hermes:rho_s0)
+   bndry_pf = decaylength(0.003 / hermes:rho_s0)
+   bndry_all = neumann()
+
+
+Component boundary conditions
+~~~~~~~~~~~~~~~
+Hermes-3 includes additional boundary conditions whose complexity requires their implementation
+as components. They may overwrite simple boundary conditions and must be set in the same way as other components.
 
 .. _noflow_boundary:
 
 noflow_boundary
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 This is a species component which imposes a no-flow boundary condition
 on y (parallel) boundaries.
@@ -645,7 +709,7 @@ The implementation is in `NoFlowBoundary`:
 .. _neutral_boundary:
 
 neutral_boundary
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 Sets Y (sheath/target) boundary conditions on neutral particle
 density, temperature and pressure. A no-flow boundary condition
@@ -678,6 +742,10 @@ The factor `gamma_heat`
 
 .. doxygenstruct:: NeutralBoundary
    :members:
+
+Others
+^^^^^^^^^^^^^^^
+See `sheath_boundary` and `simple_sheath_boundary`.
 
 Collective quantities
 ---------------------

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -102,6 +102,10 @@ public:
     // Ensure that field and boundary are on the same mesh
     Mesh* mesh = bndry->localmesh;
     ASSERT1(mesh == f.getMesh());
+    Coordinates *coord = mesh->getCoordinates();
+    Field2D dx = coord->dx;
+    Field2D g11 = coord->g11;
+    Field2D dr = dx / sqrt(g11) // cell radial length. dr = dx/(Bpol * R) and g11 = (Bpol*R)**2 
 
     // Only implemented for cell centre quantities
     ASSERT1(f.getLocation() == CELL_CENTRE);

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -115,20 +115,21 @@ public:
       for (int zk = 0; zk < mesh->LocalNz; zk++) { // Loop over Z points
         BoutReal val = 0.0; // Boundary value
         if (gen) {
-          // Generate the boundary value
+          // Pick up the boundary condition setting from the input file
           val = gen->generate(bout::generator::Context(bndry, zk, CELL_CENTRE, 0.0, mesh));
         }
-        // Set value in boundary cell f(bndry->x, bndry->y, zk)
-        // using value inside the domain f(bndry->x - bndry->bx, bndry->y - bndry->by, zk)
+        // Set value in inner guard cell f(bndry->x, bndry->y, zk)
+        // using the final domain cell value f(bndry->x - bndry->bx, bndry->y - bndry->by, zk)
         // Note: (bx, by) is the direction into the boundary, so
         //    (1, 0)  X outer boundary (SOL)
         //    (-1, 0) X inner boundary (Core or PF)
         //    (0, 1)  Y upper boundary (outer lower target)
         //    (0, -1) Y lower boundary (inner lower target)
+        output << val;
         f(bndry->x, bndry->y, zk) =
           2 * val - f(bndry->x - bndry->bx, bndry->y - bndry->by, zk);
 
-        // Set remainder of boundary cells to the same value
+        // Set any remaining guard cells (i.e. the outer guards) to the same value
         for (int i = 1; i < bndry->width; i++) {
           f(bndry->x + i * bndry->bx, bndry->y + i * bndry->by, zk) = f(bndry->x, bndry->y, zk);
         }

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -79,10 +79,10 @@
 
 #include "include/loadmetric.hxx"
 
-class CustomBoundary : public BoundaryOp {
+class DecayLengthBoundary : public BoundaryOp {
 public:
-  CustomBoundary() : gen(nullptr) {}
-  CustomBoundary(BoundaryRegion* region,  std::shared_ptr<FieldGenerator> g)
+  DecayLengthBoundary() : gen(nullptr) {}
+  DecayLengthBoundary(BoundaryRegion* region,  std::shared_ptr<FieldGenerator> g)
     : BoundaryOp(region), gen(std::move(g)) {}
 
   using BoundaryOp::clone;
@@ -94,7 +94,7 @@ public:
       // First argument should be an expression
       newgen = FieldFactory::get()->parse(args.front());
     }
-    return new CustomBoundary(region, newgen);
+    return new DecayLengthBoundary(region, newgen);
   }
 
   // Only implementing for Field3D, no time dependence
@@ -102,10 +102,12 @@ public:
     // Ensure that field and boundary are on the same mesh
     Mesh* mesh = bndry->localmesh;
     ASSERT1(mesh == f.getMesh());
+
+    // Get cell radial length
     Coordinates *coord = mesh->getCoordinates();
     Field2D dx = coord->dx;
     Field2D g11 = coord->g11;
-    Field2D dr = dx / sqrt(g11) // cell radial length. dr = dx/(Bpol * R) and g11 = (Bpol*R)**2 
+    Field2D dr = dx / sqrt(g11); // cell radial length. dr = dx/(Bpol * R) and g11 = (Bpol*R)**2 
 
     // Only implemented for cell centre quantities
     ASSERT1(f.getLocation() == CELL_CENTRE);
@@ -113,10 +115,11 @@ public:
     // This loop goes over the first row of boundary cells (in X and Y)
     for (bndry->first(); !bndry->isDone(); bndry->next1d()) {
       for (int zk = 0; zk < mesh->LocalNz; zk++) { // Loop over Z points
-        BoutReal val = 0.0; // Boundary value
+        BoutReal decay_length = 3; // Default decay length is 3 normalised units (usually ~3mm)
         if (gen) {
           // Pick up the boundary condition setting from the input file
-          val = gen->generate(bout::generator::Context(bndry, zk, CELL_CENTRE, 0.0, mesh));
+          // Must be specified in normalised units like the other BCs inputs
+          decay_length = gen->generate(bout::generator::Context(bndry, zk, CELL_CENTRE, 0.0, mesh));
         }
         // Set value in inner guard cell f(bndry->x, bndry->y, zk)
         // using the final domain cell value f(bndry->x - bndry->bx, bndry->y - bndry->by, zk)
@@ -125,11 +128,17 @@ public:
         //    (-1, 0) X inner boundary (Core or PF)
         //    (0, 1)  Y upper boundary (outer lower target)
         //    (0, -1) Y lower boundary (inner lower target)
-        output << val;
+        
+        // Distance between final cell centre and inner guard cell centre in normalised units
+        BoutReal distance = 0.5 * (dr(bndry->x, bndry->y) + 
+          dr(bndry->x - bndry->bx, bndry->y - bndry->by));
+
+        // Exponential decay 
         f(bndry->x, bndry->y, zk) =
-          2 * val - f(bndry->x - bndry->bx, bndry->y - bndry->by, zk);
+          f(bndry->x - bndry->bx, bndry->y - bndry->by, zk) * exp(-1 * distance / decay_length);
 
         // Set any remaining guard cells (i.e. the outer guards) to the same value
+        // Should the outer guards have the decay continue, or just copy what the inners have?
         for (int i = 1; i < bndry->width; i++) {
           f(bndry->x + i * bndry->bx, bndry->y + i * bndry->by, zk) = f(bndry->x, bndry->y, zk);
         }
@@ -138,7 +147,7 @@ public:
   }
 
   void apply(Field2D& f) override {
-    throw BoutException("CustomBoundary not implemented for Field2D");
+    throw BoutException("DecayLengthBoundary not implemented for Field2D");
   }
 private:
   std::shared_ptr<FieldGenerator> gen; // Generator
@@ -173,10 +182,10 @@ int Hermes::init(bool restarting) {
   Options::root()["units"] = units;
   Options::root()["units"].setConditionallyUsed();
 
-  // Add a custom boundary condition to the boundary factory
+  // Add the decay length boundary condition to the boundary factory
   // This will make it available as an input option
-  // e.g. bndry_all = custom(0.1)
-  BoundaryFactory::getInstance()->add(new CustomBoundary(), "custom");
+  // e.g. bndry_sol = decaylength(0.003 / rho_s0) sets up a decay length of 3mm
+  BoundaryFactory::getInstance()->add(new DecayLengthBoundary(), "decaylength");
 
   /////////////////////////////////////////////////////////
   // Load metric tensor from the mesh, passing length and B


### PR DESCRIPTION
Original post from Ben:
_Implements Dirichlet boundary condition, labelled "custom" for now. Registered with the BOUT++ boundary factory, so can be used as an option in BOUT.inp_

Mike comments:
- Ben set this up with a dummy clone of a Dirichlet boundary condition for me to work with
- This is the implementation of the radial decay length BC seen in SOLPS/SOLEDGE2D/UEDGE (see BCCON=9 in SOLPS)
- It's often used for plasma density and pressure on the SOL and PFR edges

The new boundary condition can be used in the same way as the other boundary conditions such as `neumann` or `dirichlet`.
For example,
```
[Nd+]
bndry_sol = decaylength(0.003 / hermes:rho_s0)
```
sets up the ion density to decay according to a decay length of 3mm. Note that you need to calculate rho_s0 in the input file to provide the normalisation. This should be done in the `hermes` component as below:
```
[hermes]
qe = 1.60218e-19   # Electron charge
Mp = 1.67262e-27   # Proton mass
Cs0 = sqrt(qe * Tnorm / Mp)   # Reference speed [m/s]
Omega_ci = qe * Bnorm / Mp   # Reference frequency [1/s]
rho_s0 = Cs0 / Omega_ci   # Refence length [m]
```

Tasks:
- [x] Change the dummy Dirichlet BC into decay length
- [x] Simple test
- [x] Complex test
- [x] Add documentation