### PR TITLE
ExB drift

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -59,7 +59,7 @@ The equation solved is:
 
 .. math::
 
-   \frac{\partial n}{\partial t} = \nabla\cdot\left[n \left(\frac{1}{B}\mathbf{b}\times\nabla\phi + v_{||}\mathbf{b}\right)\right] + S_n
+   \frac{\partial n}{\partial t} = -\nabla\cdot\left[n \left(\frac{1}{B}\mathbf{b}\times\nabla\phi + v_{||}\mathbf{b}\right)\right] + S_n
 
 where the source :math:`S_n` is a combination of external source, and
 other processes that nay be included, including drift terms

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -176,8 +176,8 @@ void EvolveDensity::finally(const Options& state) {
   // but retain densities which fall below zero
   N.setBoundaryTo(get<Field3D>(species["density"]));
 
-  if (state.isSection("fields") and state["fields"].isSet("phi")) {
-    // Electrostatic potential set -> include ExB flow
+  if ((fabs(charge) > 1e-5) and state.isSection("fields") and state["fields"].isSet("phi")) {
+    // Electrostatic potential set and species is charged -> include ExB flow
 
     Field3D phi = get<Field3D>(state["fields"]["phi"]);
 

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -203,7 +203,8 @@ void EvolveEnergy::finally(const Options& state) {
 
   Field3D Pfloor = P;
 
-  if (state.isSection("fields") and state["fields"].isSet("phi")) {
+  if (species.isSet("charge") and (fabs(get<BoutReal>(species["charge"])) > 1e-5) and
+      state.isSection("fields") and state["fields"].isSet("phi")) {
     // Electrostatic potential set -> include ExB flow
 
     Field3D phi = get<Field3D>(state["fields"]["phi"]);

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -190,8 +190,9 @@ void EvolvePressure::finally(const Options& state) {
   T = get<Field3D>(species["temperature"]);
   N = get<Field3D>(species["density"]);
 
-  if (state.isSection("fields") and state["fields"].isSet("phi")) {
-    // Electrostatic potential set -> include ExB flow
+  if (species.isSet("charge") and (fabs(get<BoutReal>(species["charge"])) > 1e-5) and
+      state.isSection("fields") and state["fields"].isSet("phi")) {
+    // Electrostatic potential set and species is charged -> include ExB flow
 
     Field3D phi = get<Field3D>(state["fields"]["phi"]);
 


### PR DESCRIPTION
Ensure that ExB drift is only added for charged species.

Though the magnitude of the drift doesn't depend on charge, but charge must be non-zero.

A better solution might be to create a new top-level component `exb_drift` to go with the `diamagnetic_drift` and `polarisation_drift` components.