### PR TITLE
WIP: Add neutral pump

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1189,9 +1189,55 @@ Each returning atom has an energy of 3.5eV:
    sol_recycle_multiplier = 1 # Recycling fraction
    sol_recycle_energy = 3.5   # Energy of recycled particles [eV]
 
-   sol_recycle = true
-   sol_recycle_multiplier = 1 # Recycling fraction
-   sol_recycle_energy = 3.5   # Energy of recycled particles [eV]
+   pfr_recycle = true
+   pfr_recycle_multiplier = 1 # Recycling fraction
+   pfr_recycle_energy = 3.5   # Energy of recycled particles [eV]
+
+Neutral pump
+^^^^^^^^^^^^^^^
+
+The recycling component also features a neutral pump, which is currently implemented for 
+the SOL and PFR edges only, and so is not available in 1D. The pump is a region of the wall
+which facilitates particle loss by incomplete recycling and neutral absorption.
+
+The particle loss rate :math:`\Gamma_{N_{n}}` is the sum of the incident ions that are not recycled and the 
+incident neutrals which are not reflected, both of which are controlled by the pump multiplier :math:`M_{p}` 
+which is set by the `pump_multiplier` option in the input file. The unrecycled ion flux :math:`\Gamma_{N_{i}}^{unrecycled}` is calculated exactly the same
+as for edge recycling but with `pump_multiplier` replacing the `recycle_multiplier`.
+
+.. math::
+
+   \begin{aligned}
+   \Gamma_{N_{n}} &= \Gamma_{N_{i}}^{unrecycled} + M_{p} \times \Gamma_{N_{n}}^{incident} \\
+   \Gamma_{N_{n}}^{incident} &= N_{n} v_{th} = N_{n} \frac{1}{4} \sqrt{\frac{8 T_{n}}{\pi m_{n}}} \\
+   \end{aligned}
+
+Where the thermal velocity formulation is for a static maxwellian in 1D (see Stangeby p.64, eqns 2.21, 2.24) 
+and the temperature is in `eV`.
+
+The heat loss rate :math:`\Gamma_{E_{n}}` is calculated as:
+
+.. math::
+
+   \begin{aligned}
+   \Gamma_{E_{n}} &= \Gamma_{E_{i}}^{unrecycled}  + M_{p} \times \Gamma_{E_{n}}^{incident} \\
+   \Gamma_{E_{n}}^{incident} &= \gamma T_{n} N_{n} v_{th} = 2 T_{n} N_{n} \frac{1}{4} \sqrt{\frac{8 T_{n}}{\pi m_{n}}} \\
+   \end{aligned}
+
+Where the incident heat flux is for a static maxwellian in 1D (see Stangeby p.69, eqn 2.30).
+
+The pump will be placed in any cell that
+ 1. Is the final domain cell before the guard cells
+ 2. Is on the SOL or PFR edge
+ 3. Has a `is_pump` value of 1
+
+The field `is_pump` must be created by the user and added to the grid file as a `Field2D`.
+
+Diagnostic variables
+^^^^^^^^^^^^^^^
+Diagnostic variables for the recycled particle and energy fluxes are provided separately for the targets, the pump as well as the SOL and PFR which are grouped together as `wall`.
+as well as the pump. In addition, the field `is_pump` is saved to help in plotting the pump location.
+
 
 .. doxygenstruct:: Recycling
    :members:

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1196,9 +1196,11 @@ Each returning atom has an energy of 3.5eV:
 Neutral pump
 ^^^^^^^^^^^^^^^
 
-The recycling component also features a neutral pump, which is currently implemented for 
+The recycling component also features a neutral pump which is currently implemented for 
 the SOL and PFR edges only, and so is not available in 1D. The pump is a region of the wall
-which facilitates particle loss by incomplete recycling and neutral absorption.
+which facilitates particle loss by incomplete recycling and neutral absorption. 
+
+The pump requires wall recycling to be enabled on the relevant wall region.
 
 The particle loss rate :math:`\Gamma_{N_{n}}` is the sum of the incident ions that are not recycled and the 
 incident neutrals which are not reflected, both of which are controlled by the pump multiplier :math:`M_{p}` 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -56,7 +56,7 @@ private:
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
-  Field3D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR
+  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR
 
   // Recycling particle and energy sources for the different sources of recycling
   // Note that SOL, PFR and pump are not applicable to 1D

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -46,20 +46,24 @@ private:
 
     /// Flux multiplier (recycling fraction). 
     /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
-    BoutReal target_multiplier, sol_multiplier, pfr_multiplier; 
+    BoutReal target_multiplier, sol_multiplier, pfr_multiplier, pump_multiplier; 
     BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
 
-  bool target_recycle, sol_recycle, pfr_recycle;  ///< Flags for enabling recycling in different regions
+  bool target_recycle, sol_recycle, pfr_recycle, neutral_pump;  ///< Flags for enabling recycling in different regions
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
+  Field3D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR
 
-  Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
-  Field3D sol_recycle_density_source, sol_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
-  Field3D pfr_recycle_density_source, pfr_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  // Recycling particle and energy sources for the different sources of recycling
+  // Note that SOL, PFR and pump are not applicable to 1D
+  Field3D target_recycle_density_source, target_recycle_energy_source; 
+  Field3D sol_recycle_density_source, sol_recycle_energy_source; 
+  Field3D pfr_recycle_density_source, pfr_recycle_energy_source;
+  Field3D pump_recycle_density_source, pump_recycle_energy_source; 
 
   Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -99,7 +99,7 @@ void NeutralBoundary::transform(Options& state) {
         const BoutReal tnsheath = 0.5 * (Tn[im] + Tn[i]);
 
         // Thermal speed
-        const BoutReal v_th = sqrt(tnsheath / AA);
+        const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
 
         // Calculate effective gamma from particle and energy reflection coefficients
         BoutReal target_gamma_heat = 1 - target_energy_refl_factor * target_fast_refl_fraction 
@@ -142,7 +142,7 @@ void NeutralBoundary::transform(Options& state) {
         const BoutReal tnsheath = 0.5 * (Tn[ip] + Tn[i]);
 
         // Thermal speed
-        const BoutReal v_th = sqrt(tnsheath / AA);
+        const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
 
         // Calculate effective gamma from particle and energy reflection coefficients
         BoutReal target_gamma_heat = 1 - target_energy_refl_factor * target_fast_refl_fraction 
@@ -177,8 +177,8 @@ void NeutralBoundary::transform(Options& state) {
           const BoutReal nnsheath = 0.5 * (Nn[ig] + Nn[i]);
           const BoutReal tnsheath = 0.5 * (Tn[ig] + Tn[i]);
 
-          // Thermal speed in one direction only (?)
-          const BoutReal v_th = sqrt(tnsheath / AA);
+          // Thermal speed of static Maxwellian in one direction
+          const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
 
           // Calculate effective gamma from particle and energy reflection coefficients
           BoutReal sol_gamma_heat = 1 - sol_energy_refl_factor * sol_fast_refl_fraction 
@@ -224,8 +224,8 @@ void NeutralBoundary::transform(Options& state) {
           const BoutReal nnsheath = 0.5 * (Nn[ig] + Nn[i]);
           const BoutReal tnsheath = 0.5 * (Tn[ig] + Tn[i]);
 
-          // Thermal speed in one direction only (?)
-          const BoutReal v_th = sqrt(tnsheath / AA);
+          // Thermal speed of static Maxwellian in one direction
+          const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
 
           
           // Calculate effective gamma from particle and energy reflection coefficients

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -246,7 +246,7 @@ void Recycling::transform(Options& state) {
             // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
             BoutReal recycle_particle_flow = 0;
             if (radial_particle_outflow(mesh->xend+1, iy, iz) > 0) {
-              recycle_particle_flow = channel.sol_multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
+              recycle_particle_flow = multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
             } 
 
             // Divide by volume to get source

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -24,7 +24,7 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
 
 
   // Neutral pump
-  // Mark cells as having a pump by setting the Field3D is_pump to 1 in the grid file
+  // Mark cells as having a pump by setting the Field2D is_pump to 1 in the grid file
   // Works only on SOL and PFR edges, where it locally modifies the recycle multiplier to the pump albedo
   is_pump = 0.0;
   mesh->get(is_pump, std::string("is_pump"));
@@ -448,6 +448,11 @@ void Recycling::outputVars(Options& state) {
                           {"conversion", Pnorm * Omega_ci},
                           {"standard_name", "energy source"},
                           {"long_name", std::string("Pump recycling energy source of ") + channel.to},
+                          {"source", "recycling"}});
+
+          set_with_attrs(state[{std::string("is_pump")}], is_pump,
+                          {{"standard_name", "neutral pump location"},
+                          {"long_name", std::string("Neutral pump location")},
                           {"source", "recycling"}});
         }
       }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -280,7 +280,7 @@ void Recycling::transform(Options& state) {
               // Calculate wall conditions
               BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
               BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
-              BoutReal v_th = sqrt(tnsheath / AAn);
+              BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
 
               // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
               // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
@@ -296,8 +296,8 @@ void Recycling::transform(Options& state) {
               BoutReal pflow = v_th * nnsheath * dasheath;   // [s^-1]
               psink = pflow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
 
-              // Use gamma=3.5 as per Stangeby p.69, total energy of drifting Maxwellian
-              BoutReal eflow = 3.5 * tnsheath * v_th * nnsheath * dasheath;   // [W]
+              // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
+              BoutReal eflow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
               esink = eflow / dv * (1 - multiplier);   // heatsink [W m^-3]
 
               // Pump puts neutral particle and energy source in final domain cell
@@ -379,7 +379,7 @@ void Recycling::transform(Options& state) {
                 // Calculate wall conditions
                 BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
                 BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
-                BoutReal v_th = sqrt(tnsheath / AAn);
+                BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
 
                 // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
                 // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
@@ -395,8 +395,8 @@ void Recycling::transform(Options& state) {
                 BoutReal pflow = v_th * nnsheath * dasheath;   // [s^-1]
                 psink = pflow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
 
-                // Use gamma=3.5 as per Stangeby p.69, total energy of drifting Maxwellian
-                BoutReal eflow = 3.5 * tnsheath * v_th * nnsheath * dasheath;   // [W]
+                // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
+                BoutReal eflow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
                 esink = eflow / dv * (1 - multiplier);   // heatsink [W m^-3]
 
                 // Pump puts neutral particle and energy source in final domain cell

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -243,7 +243,7 @@ void Recycling::transform(Options& state) {
 
             // If cell is a pump, overwrite multiplier with pump multiplier
             BoutReal multiplier = channel.pfr_multiplier;
-            if ((is_pump(mesh->xend, iy, iz) == 1.0) and (neutral_pump)) {
+            if ((is_pump(mesh->xend, iy) == 1.0) and (neutral_pump)) {
               multiplier = channel.pump_multiplier;
             }
 
@@ -261,7 +261,7 @@ void Recycling::transform(Options& state) {
             // Compute the neutral loss sink and combine with the recycled source to compute overall neutral sources
             if ((is_pump(mesh->xend, iy) == 1.0) and (neutral_pump)) {
 
-              auto i = indexAt(Nn, mesh->lastX(), iy, iz);   // Final domain cell
+              auto i = indexAt(Nn, mesh->xend, iy, iz);   // Final domain cell
               auto is = i.xm();   // Second to final domain cell
               auto ig = i.xp();   // First guard cell
 
@@ -269,14 +269,14 @@ void Recycling::transform(Options& state) {
               // These are NOT communicated back into state and will exist only in this component
               // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
               // While enabling us to still calculate radial wall fluxes separately here
-              const BoutReal Nn_guard = SQ(Nn[i]) / Nn[is];
-              const BoutReal Pn_guard = SQ(Pn[i]) / Pn[is];
-              const BoutReal Tn_guard = SQ(Tn[i]) / Tn[is];
+              BoutReal nnguard = SQ(Nn[i]) / Nn[is];
+              BoutReal pnguard = SQ(Pn[i]) / Pn[is];
+              BoutReal tnguard = SQ(Tn[i]) / Tn[is];
 
               // Calculate wall conditions
-              const BoutReal nnsheath = 0.5 * (Nn[i] + Nn_guard);
-              const BoutReal tnsheath = 0.5 * (Tn[i] + Tn_guard);
-              const BoutReal v_th = sqrt(tnsheath / AAn);
+              BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
+              BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
+              BoutReal v_th = sqrt(tnsheath / AAn);
 
               // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
               // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
@@ -354,8 +354,49 @@ void Recycling::transform(Options& state) {
 
               // Add to appropriate diagnostic field depending if pump or not
               if ((is_pump(mesh->xstart, iy) == 1.0) and (neutral_pump))  {
-                pump_recycle_density_source(mesh->xstart, iy, iz) += recycle_source;
-                pump_recycle_energy_source(mesh->xstart, iy, iz) += recycle_source * channel.pfr_energy;
+                auto i = indexAt(Nn, mesh->xstart, iy, iz);   // Final domain cell
+                auto is = i.xp();   // Second to final domain cell
+                auto ig = i.xm();   // First guard cell
+
+                // Free boundary condition on Nn, Pn, Tn
+                // These are NOT communicated back into state and will exist only in this component
+                // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
+                // While enabling us to still calculate radial wall fluxes separately here
+                BoutReal nnguard = SQ(Nn[i]) / Nn[is];
+                BoutReal pnguard = SQ(Pn[i]) / Pn[is];
+                BoutReal tnguard = SQ(Tn[i]) / Tn[is];
+
+                // Calculate wall conditions
+                BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
+                BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
+                BoutReal v_th = sqrt(tnsheath / AAn);
+
+                // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
+                // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
+                // Calculate radial wall area in [m^2]
+                // Calculate final cell volume [m^3]
+                BoutReal dpolsheath = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
+                BoutReal dtorsheath = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+                BoutReal dasheath = dpolsheath * dtorsheath;  // [m^2]
+                BoutReal dv = coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i];
+
+                // Calculate particle and energy fluxes of neutrals hitting the pump
+                // Assume thermal velocity greater than perpendicular velocity and use it for flux calc
+                BoutReal pflow = v_th * nnsheath * dasheath;   // [s^-1]
+                BoutReal psink = pflow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
+
+                // Use gamma=3.5 as per Stangeby p.69, total energy of drifting Maxwellian
+                BoutReal eflow = 3.5 * tnsheath * v_th * nnsheath * dasheath;   // [W]
+                BoutReal esink = eflow / dv * (1 - multiplier);   // heatsink [W m^-3]
+
+                // Pump puts neutral particle and energy source in final domain cell
+                // Source accounts for recycled ions and the particle sink due to neutrals hitting the pump
+                // Note that the ions are explicitly transported out of the domain by anomalous_diffusion.cxx
+                // the pump picks this up and adds a recycling source based on this, but doesn't need an ion sink.
+                // Neutrals are not explicitly transported out by any component and must be taken out by the sink below.
+                // Pump multiplier controls both fraction of recycled ions and fraction of returned neutrals 
+                pump_recycle_density_source(mesh->xend, iy, iz) += recycle_source - psink;
+                pump_recycle_energy_source(mesh->xend, iy, iz) += recycle_source * channel.sol_energy - esink;
               } else {
                 wall_recycle_density_source(mesh->xstart, iy, iz) += recycle_source;
                 wall_recycle_energy_source(mesh->xstart, iy, iz) += recycle_source * channel.pfr_energy;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -475,7 +475,7 @@ void Recycling::outputVars(Options& state) {
 
         // Neutral pump
         if (neutral_pump) {
-          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump_recycle")}], pump_recycle_density_source,
+          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}], pump_recycle_density_source,
                           {{"time_dimension", "t"},
                           {"units", "m^-3 s^-1"},
                           {"conversion", Nnorm * Omega_ci},
@@ -483,7 +483,7 @@ void Recycling::outputVars(Options& state) {
                           {"long_name", std::string("Pump recycling particle source of ") + channel.to},
                           {"source", "recycling"}});
     
-          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump_recycle")}], pump_recycle_energy_source,
+          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}], pump_recycle_energy_source,
                           {{"time_dimension", "t"},
                           {"units", "W m^-3"},
                           {"conversion", Pnorm * Omega_ci},


### PR DESCRIPTION
Adds neutral pump for 2D/3D cases. This allows a more physically realistic setup: the target recycling is set to 1 (or almost 1) and the domain particle balance is then controlled by the pump recycle multiplier (i.e. the pump albedo). This means the particle outflow is no longer controlled by the amount of ions flowing into the target along the parallel, but instead by the amount of neutrals flowing to the pump in the perpendicular direction. This kind of condition is common in other codes such as UEDGE, SOLPS and SOLEDGE2D.

The pump location is specified in the grid file in line with what other codes do. You must pass a new Field3D called `is_pump` in the grid file and select pump cells by setting them to `1`. Only cells in the PFR and SOL edge will be picked up - careful not to set it in the guard cells.

The pump can be enabled or disabled by passing `neutral_pump` and its albedo controlled by `pump_recycle_multiplier` like the other recycling sources. You **must** have recycling enabled on the boundary edge where the pump resides.

~The code implementation is quite simple: the `recycling.cxx` component already iterates through the SOL and PFR boundaries if recycling is enabled there. If Hermes-3 finds a cell with `is_pump = 1`, it swaps the `recycle_multiplier` of the boundary with the `pump_recycle_multiplier`. The recycling sources from the pump are put into new diagnostic variables `Sx_pump_recycle` and `Ex_pump_recycle` and the diagnostic variables for sources from the host boundary will no longer count the pump flows.~

The implementation is tricky and needs discussion.

Tasks:

- [x] Implementation of pump taking out incident ions
- [x] Implementation of pump taking out incident atoms
- [x] Simple test
- [x] Complex test
- [x] Particle/energy balance test
- [x] Add documentation