### PR TITLE
Robustness fixes

### DIFF
--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -16,7 +16,14 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   ASSERT1(get<BoutReal>(atom2["AA"]) == Aion); // Check that the mass is consistent
 
   // Calculate effective temperature in eV
-  const Field3D Teff = (Tatom / Aatom + Tion / Aion) * Tnorm;
+  Field3D Teff = (Tatom / Aatom + Tion / Aion) * Tnorm;
+  for (auto& i : Teff.getRegion("RGN_NOBNDRY")) {
+    if (Teff[i] < 0.01) {
+      Teff[i] = 0.01;
+    } else if (Teff[i] > 10000) {
+      Teff[i] = 10000;
+    }
+  }
   const Field3D lnT = log(Teff);
 
   Field3D ln_sigmav = -18.5028;

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -3,6 +3,7 @@
 #include <bout/fv_ops.hxx>
 #include <bout/derivs.hxx>
 #include <bout/difops.hxx>
+#include <bout/output_bout_types.hxx>
 
 #include "../include/div_ops.hxx"
 #include "../include/neutral_mixed.hxx"
@@ -391,6 +392,20 @@ void NeutralMixed::finally(const Options& state) {
     ddt(Pn) *= scale_timederivs;
     ddt(NVn) *= scale_timederivs;
   }
+
+#if CHECKLEVEL >= 1
+  for (auto& i : Nn.getRegion("RGN_NOBNDRY")) {
+    if (!std::isfinite(ddt(Nn)[i])) {
+      throw BoutException("ddt(N{}) non-finite at {}\n", name, i);
+    }
+    if (!std::isfinite(ddt(Pn)[i])) {
+      throw BoutException("ddt(P{}) non-finite at {}\n", name, i);
+    }
+    if (!std::isfinite(ddt(NVn)[i])) {
+      throw BoutException("ddt(NV{}) non-finite at {}\n", name, i);
+    }
+  }
+#endif
 }
 
 void NeutralMixed::outputVars(Options& state) {


### PR DESCRIPTION
In `hydrogen_charge_exchange`: Limit Teff to be between 0.01 and 1e4 eV. If Teff becomes too large then sigma_v can become Inf.

In `neutral_mixed`, add checks for finite time-derivatives if `CHECKLEVEL >= 1`.