### PR TITLE
Add collision diagnostics

### DIFF
--- a/include/collisions.hxx
+++ b/include/collisions.hxx
@@ -41,6 +41,9 @@ struct Collisions : public Component {
 
   void transform(Options &state) override;
 
+  /// Add extra fields for output, or set attributes e.g docstrings
+  void outputVars(Options &state) override;
+
 private:
   BoutReal Tnorm; // Temperature normalisation [eV]
   BoutReal Nnorm; // Density normalisation [m^-3]
@@ -53,6 +56,13 @@ private:
 
   /// Include frictional heating term?
   bool frictional_heating;
+
+  /// Calculated collision rates saved for post-processing and use by other components
+  /// Saved in options, the BOUT++ dictionary-like object
+  Options collision_rates; 
+
+  /// Save more diagnostics?
+  bool diagnose;
 
   /// Update collision frequencies, momentum and energy exchange
   /// nu_12    normalised frequency

--- a/include/collisions.hxx
+++ b/include/collisions.hxx
@@ -59,7 +59,7 @@ private:
 
   /// Calculated collision rates saved for post-processing and use by other components
   /// Saved in options, the BOUT++ dictionary-like object
-  Options collision_rates; 
+  Options collision_rates;
 
   /// Save more diagnostics?
   bool diagnose;

--- a/include/collisions.hxx
+++ b/include/collisions.hxx
@@ -60,6 +60,7 @@ private:
   /// Calculated collision rates saved for post-processing and use by other components
   /// Saved in options, the BOUT++ dictionary-like object
   Options collision_rates; 
+  Options frictional_heating_sources;   // Also save frictional heating which is per species not per collision basis
 
   /// Save more diagnostics?
   bool diagnose;

--- a/include/collisions.hxx
+++ b/include/collisions.hxx
@@ -60,7 +60,6 @@ private:
   /// Calculated collision rates saved for post-processing and use by other components
   /// Saved in options, the BOUT++ dictionary-like object
   Options collision_rates; 
-  Options frictional_heating_sources;   // Also save frictional heating which is per species not per collision basis
 
   /// Save more diagnostics?
   bool diagnose;

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -47,6 +47,9 @@ Collisions::Collisions(std::string name, Options& alloptions, Solver*) {
   frictional_heating = options["frictional_heating"]
     .doc("Include R dot v heating term as energy source?")
     .withDefault<bool>(true);
+
+  diagnose =
+      options["diagnose"].doc("Output additional diagnostics?").withDefault<bool>(false);
 }
 
 /// Calculate transfer of momentum and energy between species1 and species2
@@ -65,6 +68,7 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
   AUTO_TRACE();
 
   add(species1["collision_frequency"], nu_12);
+  set(collision_rates[species1.name()][species2.name()], nu_12);
 
   if (&species1 != &species2) {
     // For collisions between different species
@@ -81,6 +85,7 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
     });
 
     add(species2["collision_frequency"], nu);
+    set(collision_rates[species2.name()][species1.name()], nu);
 
     // Momentum exchange
     if (isSetFinalNoBoundary(species1["velocity"]) or
@@ -140,7 +145,6 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
       subtract(species2["energy_source"], Q12);
     }
   }
-  set(collision_rates[species1.name()][species2.name()], nu_12);
 }
 
 void Collisions::transform(Options& state) {
@@ -475,22 +479,27 @@ void Collisions::transform(Options& state) {
 
 void Collisions::outputVars(Options& state) {
   AUTO_TRACE();
+
+  if (!diagnose) {
+    return; // Don't save diagnostics
+  }
+
   // Normalisations
   auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
 
   /// Iterate through the first species in each collision pair
   const std::map<std::string, Options>& level1 = collision_rates.getChildren();
   for (auto s1 = std::begin(level1); s1 != std::end(level1); ++s1) {
+    const Options& section = collision_rates[s1->first];
 
     /// Iterate through the second species in each collision pair
-    const std::map<std::string, Options>& level2 = collision_rates[s1->first].getChildren();
+    const std::map<std::string, Options>& level2 = section.getChildren();
     for (auto s2 = std::begin(level2); s2 != std::end(level2); ++s2) {
 
       std::string name = s1->first + s2->first;
 
-      if (diagnose) {
-
-        set_with_attrs(state[std::string("K") + name + std::string("_coll")], get<Field3D>(collision_rates[s1->first][s2->first]),
+      set_with_attrs(state[std::string("K") + name + std::string("_coll")],
+                     getNonFinal<Field3D>(section[s2->first]),
                      {{"time_dimension", "t"},
                       {"units", "s-1"},
                       {"conversion", Omega_ci},
@@ -498,7 +507,6 @@ void Collisions::outputVars(Options& state) {
                       {"long_name", name + " collision frequency"},
                       {"species", name},
                       {"source", "collisions"}});
-      }
     }
   }
 }

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -140,7 +140,7 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
       subtract(species2["energy_source"], Q12);
     }
   }
-  collision_rates[species1.name()][species2.name()] = nu_12;
+  set(collision_rates[species1.name()][species2.name()], nu_12);
 }
 
 void Collisions::transform(Options& state) {
@@ -490,7 +490,7 @@ void Collisions::outputVars(Options& state) {
 
       if (diagnose) {
 
-        set_with_attrs(state[std::string("K") + name + std::string("_coll")], collision_rates[s1->first][s2->first],
+        set_with_attrs(state[std::string("K") + name + std::string("_coll")], get<Field3D>(collision_rates[s1->first][s2->first]),
                      {{"time_dimension", "t"},
                       {"units", "s-1"},
                       {"conversion", Omega_ci},

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -66,15 +66,6 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
 
   add(species1["collision_frequency"], nu_12);
 
-  /// Record the frequency and initialise energy and momentum sources to 0
-  collision_rates[species1.name()][species2.name()]["frequency"] = nu_12;
-  collision_rates[species1.name()][species2.name()]["energy_source"] = 0;
-  collision_rates[species1.name()][species2.name()]["momentum_source"] = 0;
-
-  /// This is treated separately because both species in the collision get heated
-  /// Otherwise, since we save only one source per pair, the source for species1 would no longer equal -1*source for species2
-  collision_rates[species1.name()][species2.name()]["frictional_heating_energy_source"] = 0;
-
   if (&species1 != &species2) {
     // For collisions between different species
     // m_a n_a \nu_{ab} = m_b n_b \nu_{ba}
@@ -107,7 +98,6 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
 
       add(species1["momentum_source"], F12);
       subtract(species2["momentum_source"], F12);
-      add(collision_rates[species1.name()][species2.name()]["momentum_source"], F12);
 
       if (frictional_heating) {
         // Heating due to friction and energy transfer
@@ -131,13 +121,8 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
         //  1) This term is always positive: Collisions don't lead to cooling
         //  2) In the limit that m_2 << m_1 (e.g. electron-ion collisions),
         //     the lighter species is heated more than the heavy species.
-        Field3D species1_source = (A2 / (A1 + A2)) * (velocity2 - velocity1) * F12;
-        Field3D species2_source = (A1 / (A1 + A2)) * (velocity2 - velocity1) * F12;
-
-        add(species1["energy_source"], species1_source);
-        add(species2["energy_source"], species2_source);
-        frictional_heating_sources[species1.name()][species1.name()+species2.name()] = species1_source;
-        frictional_heating_sources[species2.name()][species1.name()+species2.name()] = species2_source;
+        add(species1["energy_source"], (A2 / (A1 + A2)) * (velocity2 - velocity1) * F12);
+        add(species2["energy_source"], (A1 / (A1 + A2)) * (velocity2 - velocity1) * F12);
       }
     }
 
@@ -153,16 +138,9 @@ void Collisions::collide(Options& species1, Options& species2, const Field3D& nu
 
       add(species1["energy_source"], Q12);
       subtract(species2["energy_source"], Q12);
-      add(collision_rates[species1.name()][species2.name()]["energy_source"], Q12);
     }
-
-    
   }
-
-  
-  
-  
-  // collision_rates[species1.name()][species2.name()] = nu_12;
+  collision_rates[species1.name()][species2.name()] = nu_12;
 }
 
 void Collisions::transform(Options& state) {
@@ -498,11 +476,7 @@ void Collisions::transform(Options& state) {
 void Collisions::outputVars(Options& state) {
   AUTO_TRACE();
   // Normalisations
-  auto Nnorm = get<BoutReal>(state["Nnorm"]);
-  auto Tnorm = get<BoutReal>(state["Tnorm"]);
-  BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
   auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
-  auto Cs0 = get<BoutReal>(state["Cs0"]);
 
   /// Iterate through the first species in each collision pair
   const std::map<std::string, Options>& level1 = collision_rates.getChildren();
@@ -513,13 +487,10 @@ void Collisions::outputVars(Options& state) {
     for (auto s2 = std::begin(level2); s2 != std::end(level2); ++s2) {
 
       std::string name = s1->first + s2->first;
-      Field3D frequency = collision_rates[s1->first][s2->first]["frequency"];
-      Field3D energy = collision_rates[s1->first][s2->first]["energy_source"];
-      Field3D momentum = collision_rates[s1->first][s2->first]["momentum_source"];
 
       if (diagnose) {
 
-        set_with_attrs(state[std::string("K") + name + std::string("_coll")], frequency,
+        set_with_attrs(state[std::string("K") + name + std::string("_coll")], collision_rates[s1->first][s2->first],
                      {{"time_dimension", "t"},
                       {"units", "s-1"},
                       {"conversion", Omega_ci},
@@ -527,25 +498,6 @@ void Collisions::outputVars(Options& state) {
                       {"long_name", name + " collision frequency"},
                       {"species", name},
                       {"source", "collisions"}});
-
-        set_with_attrs(state[std::string("E") + name + std::string("_coll")], energy,
-                     {{"time_dimension", "t"},
-                      {"units", "s-1"},
-                      {"conversion", Pnorm * Omega_ci},
-                      {"standard_name", "energy transfer"},
-                      {"long_name", name + " Energy transfer"},
-                      {"species", name},
-                      {"source", "collisions"}});
-
-        set_with_attrs(state[std::string("F") + name + std::string("_coll")], momentum,
-                     {{"time_dimension", "t"},
-                      {"units", "s-1"},
-                      {"conversion", SI::Mp * Nnorm * Cs0 * Omega_ci},
-                      {"standard_name", "momentum transfer"},
-                      {"long_name", name + " Momentum transfer"},
-                      {"species", name},
-                      {"source", "collisions"}});
-
       }
     }
   }


### PR DESCRIPTION
This PR is now scaled back to just the collision frequencies due to a change in priorities. The other objectives will be picked up by a separate PR.
Tasks:

- [x] Implement diagnostic variables for collision rates
- [x] Test them against reproduction in Python

**Original objectives:**
_This PR adds new diagnostic variables for the energy and momentum transfer channels due to all the collisions in `collisions`. This should finally allow us to perform energy and momentum balances on a species basis. The collision frequencies are also saved with the new code `K`, e.g. `Kdd+_coll`. The rates for the various atomic processes are also going to be saved in the same format.
The frictional heating energy sources are saved separately due to the fact that both collision species end up with an energy gain. This prevents us from working out the energy source of species 2 from the inverse of the energy source of species 1, which is important as only the species 1 sources are saved.

In addition, the collision frequencies will be visible to other components and allow user choice in which collisions are used in the calculation of the neutral diffusion of particles, momentum and heat.

Tasks:

- [ ] Implement diagnostic variables for collision rates
- [ ] Implement diagnostic variables for collision energy and momentum transfer rates
- [ ] Allow the above to be grouped by default (i.e. source on one species due to ALL collisions)
- [ ] Implement diagnostic variables for frictional heating due to collisions
- [ ] Implement diagnostic variables for atomic rate frequencies
- [ ] Pass rates into the state and allow the neutral model to pick them up
- [ ] Test
- [ ] Add documentation_
