### PR TITLE
vorticity: Remove 3/2 from ion diamagnetic energy exchange

### DIFF
--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -502,7 +502,7 @@ void Vorticity::transform(Options& state) {
 
     if (diamagnetic_polarisation) {
       // Calculate energy exchange term nonlinear in pressure
-      // ddt(Pi) += Pi * Div((Pe + Pi) * Curlb_B);
+      // (3 / 2) ddt(Pi) += Pi * Div((Pe + Pi) * Curlb_B);
       for (auto& kv : allspecies.getChildren()) {
         Options& species = allspecies[kv.first]; // Note: need non-const
 
@@ -522,7 +522,7 @@ void Vorticity::transform(Options& state) {
         const auto AA = get<BoutReal>(species["AA"]);
 
         add(species["energy_source"],
-            (3. / 2) * P * (AA / average_atomic_mass / charge) * DivJdia);
+            P * (AA / average_atomic_mass / charge) * DivJdia);
       }
     }
 


### PR DESCRIPTION
When ion diamagnetic drift is included in the polarisation drift there is an energy exchange between ion energy and perpendicular flow. That term doesn't have a 3/2 factor.