### PR TITLE
Fixes for electron-neutral and ion-neutral collisions

### DIFF
--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -265,7 +265,7 @@ void Collisions::transform(Options& state) {
 
         const Field3D nu_en = filledFrom(Ne, [&](auto& i) {
           // Electron thermal speed (normalised)
-          const BoutReal vth_e = sqrt((SI::Mp / SI::Me) * Te[i]);
+          const BoutReal vth_e = sqrt((SI::Mp / SI::Me) * Te[i] / Tnorm);
 
           // Electron-neutral collision rate
           return vth_e * Nnorm * Nn[i] * a0 * rho_s0;

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -411,7 +411,7 @@ void Collisions::transform(Options& state) {
         // If temperature isn't set, assume zero
         const Field3D temperature2 =
             species2.isSet("temperature")
-                ? GET_NOBOUNDARY(Field3D, species2["temperature"])
+                ? GET_NOBOUNDARY(Field3D, species2["temperature"]) * Tnorm
                 : 0.0;
         const BoutReal AA2 = get<BoutReal>(species2["AA"]);
         const Field3D density2 = GET_NOBOUNDARY(Field3D, species2["density"]) * Nnorm;


### PR DESCRIPTION
Confusion over normalised vs non-normalised (eV) units, found by @mikekryjak.

Affects ion-neutral and electron-neutral elastic collision rates.