### PR TITLE
Allow neutral cooling due to wall reflection

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -787,8 +787,15 @@ is set on parallel velocity and momentum. It is a species-specific
 component and so goes in the list of components for the species
 that the boundary condition should be applied to.
 
-An energy sink is added to the flux of heat to the wall, with
-heat flux `q`:
+A source of neutral cooling is added in accordance with the approach in the thesis of D.Power 2023.
+The source represents two kinds of neutral reflection:
+
+- Fast reflection, where a neutral atom hits the wall and reflects having lost some energy,
+- Thermal reflection, where a neutral atom hits the wall, recombines into a molecule, and then
+  is assumed to immediately dissociate at the Franck Condon dissociation temperature of 3eV.
+
+The energy sink has a heat flux `q` calculated from thermal velocity at the wall and a 
+heat transmission coefficient:
 
 .. math::
 
@@ -796,7 +803,19 @@ heat flux `q`:
 
    v_{th} = \sqrt{eT / m}
 
-The factor `gamma_heat`
+   \gamma_{heat} = 1 - \alpha_{n} R_{r} - (1 - R_{r}) (\frac{T_{FC}}{2 T})
+
+Where :math:`\alpha_{n}` is the energy retained by the neutral particle after reflection,
+:math:`R_{r}` is the fraction of neutral particles that undergo fast reflection and 
+:math:`T_{FC}` is the Franck-Condon dissociation temperature, currently hardcoded to 3eV.
+Since different regions of the tokamak feature different incidence angles and may feature 
+different materials, the energy reflection coefficient and the fast reflection fraction 
+can be set individually for the target, PFR and SOL walls. The default values are 0.75
+for :math:`\alpha_{n}` and 0.8 for :math:`R_{r}` and correspond to approximate values for 
+tungsten for incidence angles seen at the target. (Power, 2023)
+
+Here are the options set to their defaults. Note that the SOL and PFR are set to have no
+reflection by default so that it is compatible with a model of any dimensionality which has a target.
 
 .. code-block:: ini
 
@@ -806,9 +825,18 @@ The factor `gamma_heat`
    [d]
    type = ... , neutral_boundary
 
-   gamma_heat = 3  # Neutral boundary heat transmission coefficient
-   neutral_lower_y = true  # Boundary on lower y?
-   neutral_upper_y = true  # Boundary on upper y?
+   neutral_boundary_sol = true
+   neutral_boundary_pfr = true
+   neutral_boundary_upper_y = true
+   neutral_boundary_lower_y = true 
+
+   target_energy_refl_factor = 0.75
+   sol_energy_refl_factor = 0.75
+   pfr_energy_refl_factor = 0.75
+
+   target_fast_refl_fraction = 0.80
+   sol_fast_refl_fraction = 0.80
+   pfr_fast_refl_fraction = 0.80
 
 .. doxygenstruct:: NeutralBoundary
    :members:

--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -55,6 +55,8 @@ private:
 
   bool lower_y; ///< Boundary condition at lower y?
   bool upper_y; ///< Boundary condition at upper y?
+  bool sol; ///< Boundary condition at sol?
+  bool pfr; ///< Boundary condition at pfr?
 };
 
 namespace {

--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -48,7 +48,7 @@ struct NeutralBoundary : public Component {
 private:
   std::string name; ///< Short name of species e.g "d"
 
-  BoutReal gamma_heat; ///< Heat flux coefficient
+  BoutReal target_gamma_heat, sol_gamma_heat, pfr_gamma_heat; ///< Heat flux coefficient
   Field3D energy_source_diagnostic; ///< Diagnostic for power lost to wall
 
   bool diagnose; ///> Save diagnostic variables?

--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -48,7 +48,11 @@ struct NeutralBoundary : public Component {
 private:
   std::string name; ///< Short name of species e.g "d"
 
-  BoutReal target_gamma_heat, sol_gamma_heat, pfr_gamma_heat; ///< Heat flux coefficient
+  BoutReal Tnorm; // Temperature normalisation [eV]
+
+  BoutReal target_energy_refl_factor, sol_energy_refl_factor, pfr_energy_refl_factor; ///< Fraction of energy retained after reflection
+  BoutReal target_fast_refl_fraction, sol_fast_refl_fraction, pfr_fast_refl_fraction; ///< Fraction of neutrals undergoing fast reflection
+
   Field3D target_energy_source, wall_energy_source; ///< Diagnostic for power loss
 
   bool diagnose; ///> Save diagnostic variables?

--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -43,11 +43,15 @@ struct NeutralBoundary : public Component {
   ///      - energy_source  Adds wall losses
   ///
   void transform(Options& state) override;
+  void outputVars(Options &state) override;
 
 private:
   std::string name; ///< Short name of species e.g "d"
 
   BoutReal gamma_heat; ///< Heat flux coefficient
+  Field3D energy_source_diagnostic; ///< Diagnostic for power lost to wall
+
+  bool diagnose; ///> Save diagnostic variables?
 
   bool lower_y; ///< Boundary condition at lower y?
   bool upper_y; ///< Boundary condition at upper y?

--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -49,7 +49,7 @@ private:
   std::string name; ///< Short name of species e.g "d"
 
   BoutReal target_gamma_heat, sol_gamma_heat, pfr_gamma_heat; ///< Heat flux coefficient
-  Field3D energy_source_diagnostic; ///< Diagnostic for power lost to wall
+  Field3D target_energy_source, wall_energy_source; ///< Diagnostic for power loss
 
   bool diagnose; ///> Save diagnostic variables?
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -58,8 +58,7 @@ private:
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
 
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
-  Field3D sol_recycle_density_source, sol_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
-  Field3D pfr_recycle_density_source, pfr_recycle_energy_source;  ///< Recycling particle and energy sources for edge recycling only
+  Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
 
   Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -55,7 +55,8 @@ void NeutralBoundary::transform(Options& state) {
           : zeroFrom(Nn);
 
   Coordinates* coord = mesh->getCoordinates();
-  energy_source_diagnostic = 0;
+  target_energy_source = 0;
+  wall_energy_source = 0;
 
   // Targets
   if (lower_y) {
@@ -92,7 +93,7 @@ void NeutralBoundary::transform(Options& state) {
 
         // Subtract from cell next to boundary
         energy_source[i] -= power;
-        energy_source_diagnostic[i] -= power;
+        target_energy_source[i] -= power;
       }
     }
   }
@@ -131,7 +132,7 @@ void NeutralBoundary::transform(Options& state) {
 
         // Subtract from cell next to boundary
         energy_source[i] -= power;
-        energy_source_diagnostic[i] -= power;
+        target_energy_source[i] -= power;
       }
     }
   }
@@ -165,7 +166,7 @@ void NeutralBoundary::transform(Options& state) {
 
           // Subtract from cell next to boundary
           energy_source[i] -= power;
-          energy_source_diagnostic[i] -= power;
+          wall_energy_source[i] -= power;
 
         }
       }
@@ -200,7 +201,7 @@ void NeutralBoundary::transform(Options& state) {
 
           // Subtract from cell next to boundary
           energy_source[i] -= power;
-          energy_source_diagnostic[i] -= power;
+          wall_energy_source[i] -= power;
 
         }
       }
@@ -239,13 +240,24 @@ void NeutralBoundary::outputVars(Options& state) {
       // Save particle and energy source for the species created during recycling
 
       // Target recycling
-        set_with_attrs(state[{std::string("E") + name + std::string("_wall_refl")}], energy_source_diagnostic,
+
+      if ((sol) or (pfr)) {
+        set_with_attrs(state[{std::string("E") + name + std::string("_wall_refl")}], wall_energy_source,
                         {{"time_dimension", "t"},
                         {"units", "W m^-3"},
                         {"conversion", Pnorm * Omega_ci},
                         {"standard_name", "energy source"},
                         {"long_name", std::string("Wall reflection energy source of ") + name},
                         {"source", "neutral_boundary"}});
+      }
+
+      set_with_attrs(state[{std::string("E") + name + std::string("_target_refl")}], target_energy_source,
+                      {{"time_dimension", "t"},
+                      {"units", "W m^-3"},
+                      {"conversion", Pnorm * Omega_ci},
+                      {"standard_name", "energy source"},
+                      {"long_name", std::string("Wall reflection energy source of ") + name},
+                      {"source", "neutral_boundary"}});
   }
 }
 

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -10,16 +10,24 @@ NeutralBoundary::NeutralBoundary(std::string name, Options& alloptions, Solver* 
 
   auto& options = alloptions[name];
 
-  gamma_heat = options["gamma_heat"]
-                   .doc("Neutral boundary heat transmission coefficient")
+  target_gamma_heat = options["target_gamma_heat"]
+                   .doc("Neutral boundary heat transmission coefficient on target")
+                   .withDefault(0.0);
+
+  sol_gamma_heat = options["sol_gamma_heat"]
+                   .doc("Neutral boundary heat transmission coefficient in SOL")
+                   .withDefault(0.0);
+
+  pfr_gamma_heat = options["pfr_gamma_heat"]
+                   .doc("Neutral boundary heat transmission coefficient in PFR")
                    .withDefault(0.0);
 
   diagnose = options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
 
-  lower_y = options["neutral_lower_y"].doc("Boundary on lower y?").withDefault<bool>(true);
-  upper_y = options["neutral_upper_y"].doc("Boundary on upper y?").withDefault<bool>(true);
-  sol = options["neutral_sol"].doc("Boundary on SOL?").withDefault<bool>(false);
-  pfr = options["neutral_pfr"].doc("Boundary on PFR?").withDefault<bool>(false);
+  lower_y = options["neutral_boundary_lower_y"].doc("Boundary on lower y?").withDefault<bool>(true);
+  upper_y = options["neutral_boundary_upper_y"].doc("Boundary on upper y?").withDefault<bool>(true);
+  sol = options["neutral_boundary_sol"].doc("Boundary on SOL?").withDefault<bool>(false);
+  pfr = options["neutral_boundary_pfr"].doc("Boundary on PFR?").withDefault<bool>(false);
 }
 
 void NeutralBoundary::transform(Options& state) {
@@ -74,7 +82,7 @@ void NeutralBoundary::transform(Options& state) {
         const BoutReal v_th = sqrt(tnsheath / AA);
 
         // Heat flux (> 0)
-        const BoutReal q = gamma_heat * nnsheath * tnsheath * v_th;
+        const BoutReal q = target_gamma_heat * nnsheath * tnsheath * v_th;
         // Multiply by cell area to get power
         BoutReal flux = q * (coord->J[i] + coord->J[im])
                         / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
@@ -113,7 +121,7 @@ void NeutralBoundary::transform(Options& state) {
         const BoutReal v_th = sqrt(tnsheath / AA);
 
         // Heat flux (> 0)
-        const BoutReal q = gamma_heat * nnsheath * tnsheath * v_th;
+        const BoutReal q = target_gamma_heat * nnsheath * tnsheath * v_th;
         // Multiply by cell area to get power
         BoutReal flux = q * (coord->J[i] + coord->J[ip])
                         / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));
@@ -145,7 +153,7 @@ void NeutralBoundary::transform(Options& state) {
           const BoutReal v_th = sqrt(tnsheath / AA);
 
           // Heat flux (> 0)
-          const BoutReal q = gamma_heat * nnsheath * tnsheath * v_th;
+          const BoutReal q = sol_gamma_heat * nnsheath * tnsheath * v_th;
 
           // Multiply by cell area to get power
           BoutReal flux = q * (coord->dy[i] + coord->dy[ig]) * (coord->dz[i] + coord->dz[ig])
@@ -180,7 +188,7 @@ void NeutralBoundary::transform(Options& state) {
           const BoutReal v_th = sqrt(tnsheath / AA);
 
           // Heat flux (> 0)
-          const BoutReal q = gamma_heat * nnsheath * tnsheath * v_th;
+          const BoutReal q = pfr_gamma_heat * nnsheath * tnsheath * v_th;
 
           // Multiply by cell area to get power
           BoutReal flux = q * (coord->dy[i] + coord->dy[ig]) * (coord->dz[i] + coord->dz[ig])

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -155,9 +155,10 @@ void NeutralBoundary::transform(Options& state) {
           // Heat flux (> 0)
           const BoutReal q = sol_gamma_heat * nnsheath * tnsheath * v_th;
 
-          // Multiply by cell area to get power
+          // Multiply by radial cell area to get power
           BoutReal flux = q * (coord->dy[i] + coord->dy[ig]) * (coord->dz[i] + coord->dz[ig])
-                          / (sqrt(coord->g22[i]) + sqrt(coord->g22[ig]));
+                          *  1/(sqrt(coord->g22[i]) + sqrt(coord->g22[ig]))   // Converts dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
+                          * sqrt(coord->g_33[i] + coord->g_33[ig]);   // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
 
           // Divide by volume of cell to get energy loss rate (> 0)
           BoutReal power = flux / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -137,7 +137,7 @@ void NeutralBoundary::transform(Options& state) {
     }
   }
 
-  // SOL edge
+    // SOL edge
   if (sol) {
     if(mesh->lastX()){  // Only do this for the processor which has the edge region
       for(int iy=0; iy < mesh->LocalNy ; iy++){
@@ -157,12 +157,19 @@ void NeutralBoundary::transform(Options& state) {
           const BoutReal q = sol_gamma_heat * nnsheath * tnsheath * v_th;
 
           // Multiply by radial cell area to get power
-          BoutReal flux = q * (coord->dy[i] + coord->dy[ig]) * (coord->dz[i] + coord->dz[ig])
-                          *  1/(sqrt(coord->g22[i]) + sqrt(coord->g22[ig]))   // Converts dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
-                          * sqrt(coord->g_33[i] + coord->g_33[ig]);   // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
+          // Expanded form of the calculation for clarity
+
+          // Converts dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
+          BoutReal dpolsheath = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
+
+          // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
+          BoutReal dtorsheath = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+
+          BoutReal dasheath = dpolsheath * dtorsheath;  // [m^2]
+          BoutReal flux = q * dasheath;  // [W]
 
           // Divide by volume of cell to get energy loss rate (> 0)
-          BoutReal power = flux / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);
+          BoutReal power = flux / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);   // [W m^-3]
 
           // Subtract from cell next to boundary
           energy_source[i] -= power;
@@ -192,12 +199,20 @@ void NeutralBoundary::transform(Options& state) {
           // Heat flux (> 0)
           const BoutReal q = pfr_gamma_heat * nnsheath * tnsheath * v_th;
 
-          // Multiply by cell area to get power
-          BoutReal flux = q * (coord->dy[i] + coord->dy[ig]) * (coord->dz[i] + coord->dz[ig])
-                          / (sqrt(coord->g22[i]) + sqrt(coord->g22[ig]));
+          // Multiply by radial cell area to get power
+          // Expanded form of the calculation for clarity
+
+          // Converts dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
+          BoutReal dpolsheath = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
+
+          // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
+          BoutReal dtorsheath = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+
+          BoutReal dasheath = dpolsheath * dtorsheath;  // [m^2]
+          BoutReal flux = q * dasheath;  // [W]
 
           // Divide by volume of cell to get energy loss rate (> 0)
-          BoutReal power = flux / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);
+          BoutReal power = flux / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);   // [W m^-3]
 
           // Subtract from cell next to boundary
           energy_source[i] -= power;

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -9,30 +9,49 @@ NeutralBoundary::NeutralBoundary(std::string name, Options& alloptions, Solver* 
   AUTO_TRACE();
 
   auto& options = alloptions[name];
-
-  target_gamma_heat = options["target_gamma_heat"]
-                   .doc("Neutral boundary heat transmission coefficient on target")
-                   .withDefault(0.0);
-
-  sol_gamma_heat = options["sol_gamma_heat"]
-                   .doc("Neutral boundary heat transmission coefficient in SOL")
-                   .withDefault(0.0);
-
-  pfr_gamma_heat = options["pfr_gamma_heat"]
-                   .doc("Neutral boundary heat transmission coefficient in PFR")
-                   .withDefault(0.0);
+  const Options& units = alloptions["units"];
+  Tnorm = units["eV"];
 
   diagnose = options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
-
   lower_y = options["neutral_boundary_lower_y"].doc("Boundary on lower y?").withDefault<bool>(true);
   upper_y = options["neutral_boundary_upper_y"].doc("Boundary on upper y?").withDefault<bool>(true);
   sol = options["neutral_boundary_sol"].doc("Boundary on SOL?").withDefault<bool>(false);
   pfr = options["neutral_boundary_pfr"].doc("Boundary on PFR?").withDefault<bool>(false);
+
+  target_energy_refl_factor =
+        options["target_energy_refl_factor"]
+            .doc("Fraction of energy retained by neutral particles after wall reflection at target")
+            .withDefault<BoutReal>(0.75);
+
+  sol_energy_refl_factor =
+        options["sol_energy_refl_factor"]
+            .doc("Fraction of energy retained by neutral particles after wall reflection at SOL")
+            .withDefault<BoutReal>(0.75);
+
+  pfr_energy_refl_factor =
+        options["pfr_energy_refl_factor"]
+            .doc("Fraction of energy retained by neutral particles after wall reflection at PFR")
+            .withDefault<BoutReal>(0.75);
+
+  target_fast_refl_fraction =
+        options["target_fast_refl_fraction"]
+            .doc("Fraction of neutrals that are undergoing fast reflection at the target")
+            .withDefault<BoutReal>(0.8);
+
+  sol_fast_refl_fraction =
+        options["sol_fast_refl_fraction"]
+            .doc("Fraction of neutrals that are undergoing fast reflection at the sol")
+            .withDefault<BoutReal>(0.8);
+  
+  pfr_fast_refl_fraction =
+        options["pfr_fast_refl_fraction"]
+            .doc("Fraction of neutrals that are undergoing fast reflection at the pfr")
+            .withDefault<BoutReal>(0.8);
+
 }
 
 void NeutralBoundary::transform(Options& state) {
   AUTO_TRACE();
-
   auto& species = state["species"][name];
   const BoutReal AA = get<BoutReal>(species["AA"]);
 
@@ -82,6 +101,10 @@ void NeutralBoundary::transform(Options& state) {
         // Thermal speed
         const BoutReal v_th = sqrt(tnsheath / AA);
 
+        // Calculate effective gamma from particle and energy reflection coefficients
+        BoutReal target_gamma_heat = 1 - target_energy_refl_factor * target_fast_refl_fraction 
+                                  -(1-target_fast_refl_fraction) * (3/Tnorm) / (2*tnsheath);  // D. Power thesis 2023
+
         // Heat flux (> 0)
         const BoutReal q = target_gamma_heat * nnsheath * tnsheath * v_th;
         // Multiply by cell area to get power
@@ -121,6 +144,10 @@ void NeutralBoundary::transform(Options& state) {
         // Thermal speed
         const BoutReal v_th = sqrt(tnsheath / AA);
 
+        // Calculate effective gamma from particle and energy reflection coefficients
+        BoutReal target_gamma_heat = 1 - target_energy_refl_factor * target_fast_refl_fraction 
+                                  -(1-target_fast_refl_fraction) * (3/Tnorm) / (2*tnsheath);  // D. Power thesis 2023
+
         // Heat flux (> 0)
         const BoutReal q = target_gamma_heat * nnsheath * tnsheath * v_th;
         // Multiply by cell area to get power
@@ -152,6 +179,10 @@ void NeutralBoundary::transform(Options& state) {
 
           // Thermal speed in one direction only (?)
           const BoutReal v_th = sqrt(tnsheath / AA);
+
+          // Calculate effective gamma from particle and energy reflection coefficients
+          BoutReal sol_gamma_heat = 1 - sol_energy_refl_factor * sol_fast_refl_fraction 
+                                    -(1-sol_fast_refl_fraction) * (3/Tnorm) / (2*tnsheath);  // D. Power thesis 2023
 
           // Heat flux (> 0)
           const BoutReal q = sol_gamma_heat * nnsheath * tnsheath * v_th;
@@ -195,6 +226,11 @@ void NeutralBoundary::transform(Options& state) {
 
           // Thermal speed in one direction only (?)
           const BoutReal v_th = sqrt(tnsheath / AA);
+
+          
+          // Calculate effective gamma from particle and energy reflection coefficients
+          BoutReal pfr_gamma_heat = 1 - pfr_energy_refl_factor * pfr_fast_refl_fraction 
+                                    -(1-pfr_fast_refl_fraction) * (3/Tnorm) / (2*tnsheath);  // D. Power thesis 2023
 
           // Heat flux (> 0)
           const BoutReal q = pfr_gamma_heat * nnsheath * tnsheath * v_th;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -198,14 +198,14 @@ void Recycling::transform(Options& state) {
       }
     }
 
+    wall_recycle_density_source = 0;
+    wall_recycle_energy_source = 0;
+
     // Recycling at the SOL edge (2D/3D only)
     if (sol_recycle) {
 
       // Flow out of domain is positive in the positive coordinate direction
       radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]);
-
-      sol_recycle_density_source = 0;
-      sol_recycle_energy_source = 0;
 
       if(mesh->lastX()){  // Only do this for the processor which has the edge region
         for(int iy=0; iy < mesh->LocalNy ; iy++){
@@ -224,12 +224,12 @@ void Recycling::transform(Options& state) {
             } 
 
             // Divide by volume to get source
-            sol_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
-            density_source(mesh->xend, iy, iz) += sol_recycle_density_source(mesh->xend, iy, iz);
+            wall_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
+            density_source(mesh->xend, iy, iz) += recycle_particle_flow / volume;
 
             // For now, this is a fixed temperature
-            sol_recycle_energy_source(mesh->xend, iy, iz) += channel.sol_energy * recycle_particle_flow / volume;
-            energy_source(mesh->xend, iy, iz) += sol_recycle_energy_source(mesh->xend, iy, iz);
+            wall_recycle_energy_source(mesh->xend, iy, iz) += channel.sol_energy * recycle_particle_flow / volume;
+            energy_source(mesh->xend, iy, iz) += channel.sol_energy * recycle_particle_flow / volume;
 
           
 
@@ -243,9 +243,6 @@ void Recycling::transform(Options& state) {
 
       // PFR is flipped compared to edge: x=0 is at the PFR edge. Therefore outflow is in the negative coordinate direction.
       radial_particle_outflow = get<Field3D>(species_from["particle_flow_xlow"]) * -1;
-
-      pfr_recycle_density_source = 0;
-      pfr_recycle_energy_source = 0;
 
       if(mesh->firstX()){   // Only do this for the processor which has the core region
         if (!mesh->periodicY(mesh->xstart)) {   // Only do this for the processor with a periodic Y, i.e. the PFR
@@ -266,12 +263,12 @@ void Recycling::transform(Options& state) {
               }
 
               // Divide by volume to get source
-              pfr_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;
-              density_source(mesh->xstart, iy, iz) += pfr_recycle_density_source(mesh->xstart, iy, iz);
+              wall_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;
+              density_source(mesh->xstart, iy, iz) += recycle_particle_flow / volume;
 
               // For now, this is a fixed temperature
-              pfr_recycle_energy_source(mesh->xstart, iy, iz) += channel.pfr_energy * recycle_particle_flow / volume;
-              energy_source(mesh->xstart, iy, iz) += pfr_recycle_energy_source(mesh->xstart, iy, iz);
+              wall_recycle_energy_source(mesh->xstart, iy, iz) += channel.pfr_energy * recycle_particle_flow / volume;
+              energy_source(mesh->xstart, iy, iz) += channel.pfr_energy * recycle_particle_flow / volume;
 
             }
           }
@@ -320,41 +317,22 @@ void Recycling::outputVars(Options& state) {
                           {"source", "recycling"}});
           }
 
-        // SOL recycling
-        if (sol_recycle) {
-          set_with_attrs(state[{std::string("S") + channel.to + std::string("_sol_recycle")}], sol_recycle_density_source,
+        // Wall recycling
+        if ((sol_recycle) or (pfr_recycle)) {
+          set_with_attrs(state[{std::string("S") + channel.to + std::string("_wall_recycle")}], wall_recycle_density_source,
                           {{"time_dimension", "t"},
                           {"units", "m^-3 s^-1"},
                           {"conversion", Nnorm * Omega_ci},
                           {"standard_name", "particle source"},
-                          {"long_name", std::string("SOL recycling particle source of ") + channel.to},
+                          {"long_name", std::string("Wall recycling particle source of ") + channel.to},
                           {"source", "recycling"}});
     
-          set_with_attrs(state[{std::string("E") + channel.to + std::string("_sol_recycle")}], sol_recycle_energy_source,
+          set_with_attrs(state[{std::string("E") + channel.to + std::string("_wall_recycle")}], wall_recycle_energy_source,
                           {{"time_dimension", "t"},
                           {"units", "W m^-3"},
                           {"conversion", Pnorm * Omega_ci},
                           {"standard_name", "energy source"},
-                          {"long_name", std::string("SOL recycling energy source of ") + channel.to},
-                          {"source", "recycling"}});
-          }
-
-        // PFR recycling
-        if (pfr_recycle) {
-          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pfr_recycle")}], pfr_recycle_density_source,
-                          {{"time_dimension", "t"},
-                          {"units", "m^-3 s^-1"},
-                          {"conversion", Nnorm * Omega_ci},
-                          {"standard_name", "particle source"},
-                          {"long_name", std::string("PFR recycling particle source of ") + channel.to},
-                          {"source", "recycling"}});
-    
-          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pfr_recycle")}], pfr_recycle_energy_source,
-                          {{"time_dimension", "t"},
-                          {"units", "W m^-3"},
-                          {"conversion", Pnorm * Omega_ci},
-                          {"standard_name", "energy source"},
-                          {"long_name", std::string("PFR recycling energy source of ") + channel.to},
+                          {"long_name", std::string("Wall recycling energy source of ") + channel.to},
                           {"source", "recycling"}});
           }
       }


### PR DESCRIPTION
When hitting a wall, a neutral atom can either undergo thermal reflection (recombine, thermalise with the wall and come off as a molecule) or fast reflection (the atom does not recombine and bounces off, possibly losing some energy in the process). In EIRENE the fate of the particle is determined from the TRIM database.

The only thing we have on this right now is the `neutral_boundary` component which is currently only implemented for the sheath. It uses a sheath heat transmission style expression to allow for neutral energy to be imparted on the wall given a `gamma` parameter. The velocity used for this is the thermal velocity.

This PR adds a diagnostic variable for the heat loss due to this process and extends it to the SOL and PFR edges.

The expression will be following that from D. Power's 2023 thesis, and which was based on Horsten's work.
A sheath-style expression with a thermal velocity in one direction ( sqrt(Tn/Mn) ).
The gamma is calculated as:

gamma_n = 1 - alpha*R_r - (1-R_r)(T_fc / 2*Tn)

Where:

- Alpha is the fraction of energy particles retain after reflection
- R_r is the fraction of particles undergoing fast reflection as opposed to thermal reflection
- T_fc is the Franck-Condon dissociation temperature (about 3eV)
- Tn is the neutral temperature

Solving the above with alpha = 0.75 and R_r 0.8 results in a gamma of 0.3 for Tn = T_fc.
The gamma increases to 0.4 when Tn >> T_fc. The alpha and R_r coefficients were obtained by D. Power for typical conditions in deuterium-tungsten reflection.

Currently gamma is an input, but it has a dependency on Tn and should therefore be a calculation.
The inputs will be alpha and R_r now, with defaults of 1 and 1 (fully reflective with no energy loss)

Tasks:
- [x] Add diagnostic variable for the reflection energy loss: Ed_wall_refl (opinions on name?)
- [x] Extend to SOL and PFR edges
- [x] Modify to have energy and particle reflection coefficient as inputs
- [x] Test
- [x] Add documentation
- [x] Final check: full scale model