### PR TITLE
Implement fast recycling

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1214,11 +1214,11 @@ The recycled heat flux is:
 .. math::
 
    \begin{aligned}
-   \Gamma_{E_{n}} &= R \times (R_{f} \alpha_{E} \Gamma_{E_{i}}^{sheath}  + (1 - R_{f} T_{R} \Gamma_{N_{i}})) \\
+   \Gamma_{E_{n}} &= R \times (R_{f} \alpha_{E} \Gamma_{E_{i}}^{sheath}  + (1 - R_{f}) T_{R} \Gamma_{N_{i}})) \\
    \end{aligned}
 
 Where :math:`R` is the recycle multiplier, :math:`R_{f}` is the fast reflection fraction, :math:`\alpha_{E}` is the energy reflection factor,
-:math:`\Gamma_{E_{i}}^{sheath}` is the incident heat flux from the sheath boundary condition, :math:`T_{R}` is the recycle energy.
+:math:`\Gamma_{E_{i}}^{sheath}` is the incident heat flux from the sheath boundary condition, :math:`T_{R}` is the recycle energy and :math:`\Gamma_{N_{i}}` is the incident ion flux.
 
 :math:`R_{f}` and :math:`\alpha_{E}` can be set as in the below example. They can also be set to different values for the SOL and PFR by replacing
 the word "target" with either "sol" or "pfr".

--- a/examples/1D-hydrogen-equalT/BOUT.inp
+++ b/examples/1D-hydrogen-equalT/BOUT.inp
@@ -95,6 +95,8 @@ density_controller_p = 5e2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-hydrogen/BOUT.inp
+++ b/examples/1D-hydrogen/BOUT.inp
@@ -98,6 +98,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-hydrogen/qn/BOUT.inp
+++ b/examples/1D-hydrogen/qn/BOUT.inp
@@ -100,6 +100,7 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-neon-source/BOUT.inp
+++ b/examples/1D-neon-source/BOUT.inp
@@ -103,6 +103,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1.0  # Recycling fraction
 
 [Nd+]
@@ -169,6 +171,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]
@@ -189,6 +193,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+2]
@@ -209,6 +215,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+3]
@@ -229,6 +237,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -251,8 +261,9 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
-
 diagnose = true
 
 [Nne+5]
@@ -273,6 +284,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -295,6 +308,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -317,6 +332,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -339,6 +356,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true
@@ -361,6 +380,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true   # Target recycling on
+target_recycle_energy = 0   # Simple assumption
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/examples/1D-neon/BOUT.inp
+++ b/examples/1D-neon/BOUT.inp
@@ -104,7 +104,9 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 
@@ -168,6 +170,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+]
@@ -188,6 +192,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+2]
@@ -208,6 +214,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nne+3]
@@ -228,6 +236,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -250,6 +260,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -272,6 +284,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -294,6 +308,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -316,6 +332,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -338,6 +356,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true
@@ -360,6 +380,8 @@ noflow_lower_y = true
 noflow_upper_y = false  # Sheath boundary at upper y
 
 recycle_as = ne
+target_recycle = true  # Target recycling on
+target_recycle_energy = 0  # Simple assumption
 target_recycle_multiplier = 1  # Recycling fraction
 
 diagnose = true

--- a/examples/1D-recycling/BOUT.inp
+++ b/examples/1D-recycling/BOUT.inp
@@ -101,6 +101,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]

--- a/examples/1D-recycling/cvode/BOUT.inp
+++ b/examples/1D-recycling/cvode/BOUT.inp
@@ -92,6 +92,8 @@ thermal_conduction = true  # in evolve_pressure
 diagnose = true
 
 recycle_as = d
+target_recycle = true
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
 target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]

--- a/examples/solkit-comparison/single-temperature/BOUT.inp
+++ b/examples/solkit-comparison/single-temperature/BOUT.inp
@@ -100,7 +100,9 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 

--- a/examples/solkit-comparison/two-temperatures/BOUT.inp
+++ b/examples/solkit-comparison/two-temperatures/BOUT.inp
@@ -100,7 +100,9 @@ AA = 2
 diagnose = true   # Output diagnostics for these components?
 
 recycle_as = d
-target_recycle_multiplier = 1.0  # Recycling fraction
+target_recycle = true  # Target recycling on
+target_recycle_energy = 3.5  # Franck-Condon dissociation energy
+target_recycle_multiplier = 1  # Recycling fraction
 
 [Nd+]
 

--- a/examples/tokamak/recycling-dthe-drifts/BOUT.inp
+++ b/examples/tokamak/recycling-dthe-drifts/BOUT.inp
@@ -53,6 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -89,6 +90,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -125,6 +127,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]

--- a/examples/tokamak/recycling-dthe/BOUT.inp
+++ b/examples/tokamak/recycling-dthe/BOUT.inp
@@ -53,6 +53,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -89,6 +90,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -125,6 +127,7 @@ anomalous_chi = 1.0
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/examples/tokamak/recycling-dthene/BOUT.inp
+++ b/examples/tokamak/recycling-dthene/BOUT.inp
@@ -36,6 +36,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nd+]
@@ -76,6 +77,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = t
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nt+]
@@ -116,6 +118,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = he
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nhe+]
@@ -156,6 +159,7 @@ anomalous_chi = 1
 thermal_conduction = true
 
 recycle_as = ne
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 [Nne+]

--- a/examples/tokamak/recycling/BOUT.inp
+++ b/examples/tokamak/recycling/BOUT.inp
@@ -59,6 +59,7 @@ anomalous_chi = 4
 thermal_conduction = true
 
 recycle_as = d
+target_recycle = true
 target_recycle_multiplier = 0.99  # Recycling fraction
 
 diagnose = true

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -65,7 +65,7 @@ private:
 
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
-  Field3D pump_recycle_density_source, pump_recycle_energy_source;  ///< Recycling particle and energy sources for pump recycling
+  Field3D pump_density_source, pump_energy_source;  ///< Recycling particle and energy sources for pump recycling
 
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -58,6 +58,7 @@ private:
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
+  Field3D heatflow_ylow, heatflow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
 
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -64,8 +64,6 @@ private:
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
 
-  // Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
-  
 
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -48,6 +48,8 @@ private:
     /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
     BoutReal target_multiplier, sol_multiplier, pfr_multiplier; 
     BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
+    BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction;   ///< Fraction of ions undergoing fast reflection
+    BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor;   ///< Fraction of energy retained by fast recycled neutrals
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
@@ -62,6 +64,7 @@ private:
 
   Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   
+
 };
 
 namespace {

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -46,7 +46,7 @@ private:
 
     /// Flux multiplier (recycling fraction). 
     /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
-    BoutReal target_multiplier, sol_multiplier, pfr_multiplier; 
+    BoutReal target_multiplier, sol_multiplier, pfr_multiplier, pump_multiplier; 
     BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
     BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction;   ///< Fraction of ions undergoing fast reflection
     BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor;   ///< Fraction of energy retained by fast recycled neutrals
@@ -54,16 +54,18 @@ private:
 
   std::vector<RecycleChannel> channels; // Recycling channels
 
-  bool target_recycle, sol_recycle, pfr_recycle;  ///< Flags for enabling recycling in different regions
+  bool target_recycle, sol_recycle, pfr_recycle, neutral_pump;  ///< Flags for enabling recycling in different regions
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
   Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
   Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity
 
+  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR. Provided by user in grid file.
+
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
-
+  Field3D pump_recycle_density_source, pump_recycle_energy_source;  ///< Recycling particle and energy sources for pump recycling
 
 };
 

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -58,12 +58,13 @@ private:
   bool diagnose; ///< Save additional post-processing variables?
 
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
-  Field3D heatflow_ylow, heatflow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
+  Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
+  Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity
 
   Field3D target_recycle_density_source, target_recycle_energy_source;  ///< Recycling particle and energy sources for target recycling only
   Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
 
-  Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
+  // Field3D radial_particle_outflow, radial_energy_outflow;  ///< Radial fluxes coming from evolve_density and evolve_pressure used in recycling calc
   
 
 };

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -67,6 +67,36 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
                                   .withDefault<BoutReal>(3.0)
                               / Tnorm; // Normalise from eV
 
+    BoutReal target_fast_recycle_fraction =
+        from_options["target_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at target")
+            .withDefault<BoutReal>(0);
+
+    BoutReal pfr_fast_recycle_fraction =
+        from_options["pfr_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at pfr")
+            .withDefault<BoutReal>(0);
+
+    BoutReal sol_fast_recycle_fraction =
+        from_options["sol_fast_recycle_fraction"]
+            .doc("Fraction of ions undergoing fast reflection at sol")
+            .withDefault<BoutReal>(0);
+
+    BoutReal target_fast_recycle_energy_factor =
+        from_options["target_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at target")
+            .withDefault<BoutReal>(0);
+
+    BoutReal sol_fast_recycle_energy_factor =
+        from_options["sol_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at sol")
+            .withDefault<BoutReal>(0);
+
+    BoutReal pfr_fast_recycle_energy_factor =
+        from_options["pfr_fast_recycle_energy_factor"]
+            .doc("Fraction of energy retained by fast recycled neutrals at pfr")
+            .withDefault<BoutReal>(0);
+
     if ((target_recycle_multiplier < 0.0) or (target_recycle_multiplier > 1.0)
     or (sol_recycle_multiplier < 0.0) or (sol_recycle_multiplier > 1.0)
     or (pfr_recycle_multiplier < 0.0) or (pfr_recycle_multiplier > 1.0)) {
@@ -77,7 +107,9 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*) {
     channels.push_back({
       from, to, 
       target_recycle_multiplier, sol_recycle_multiplier, pfr_recycle_multiplier,
-      target_recycle_energy, sol_recycle_energy, pfr_recycle_energy});
+      target_recycle_energy, sol_recycle_energy, pfr_recycle_energy,
+      target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction,
+      target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor});
 
     // Boolean flags for enabling recycling in different regions
     target_recycle = from_options["target_recycle"]
@@ -111,6 +143,7 @@ void Recycling::transform(Options& state) {
 
     const Field3D N = get<Field3D>(species_from["density"]);
     const Field3D V = get<Field3D>(species_from["velocity"]); // Parallel flow velocity
+    const Field3D T = get<Field3D>(species_from["temperature"]); // Ion temperature
 
     Options& species_to = state["species"][channel.to];
 
@@ -122,6 +155,8 @@ void Recycling::transform(Options& state) {
     energy_source = species_to.isSet("energy_source")
                                 ? getNonFinal<Field3D>(species_to["energy_source"])
                                 : 0.0;
+
+    
 
     // Recycling at the divertor target plates
     if (target_recycle) {
@@ -156,7 +191,14 @@ void Recycling::transform(Options& state) {
               / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
 
           // energy of recycled particles
-          target_recycle_energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
+          // VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          // TODO: Is the energy here 3eV * NV or 3/2 * 3eV * NV? It was just 3eV * NV before but it's adding to energy source
+          BoutReal tisheath = (T(r.ind, mesh->ystart, jz) + T(r.ind, mesh->ystart-1, jz)) * 0.5;   // Ion temp at wall
+          BoutReal neutral_energy = flow * (
+            channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction * tisheath  // Fast recycling part
+            + (1 - channel.target_fast_recycle_fraction) * channel.target_energy);   // Thermal recycling part
+
+          target_recycle_energy_source(r.ind, mesh->ystart, jz) += neutral_energy
               / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
           energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
               / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
@@ -190,7 +232,15 @@ void Recycling::transform(Options& state) {
           density_source(r.ind, mesh->yend, jz) += flow 
               / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
 
-          target_recycle_energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
+          // energy of recycled particles
+          // VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          // TODO: Is the energy here 3eV * NV or 3/2 * 3eV * NV? It was just 3eV * NV before but it's adding to energy source
+          BoutReal tisheath = (T(r.ind, mesh->yend, jz) + T(r.ind, mesh->yend+1, jz)) * 0.5;   // Ion temp at wall
+          BoutReal neutral_energy = flow * (
+            channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction * tisheath  // Fast recycling part
+            + (1 - channel.target_fast_recycle_fraction) * channel.target_energy);   // Thermal recycling part
+
+          target_recycle_energy_source(r.ind, mesh->yend, jz) += neutral_energy
               / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
           energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
               / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -202,7 +202,7 @@ void Recycling::transform(Options& state) {
           // Blend fast (ion energy) and thermal (constant energy) recycling 
           // Calculate returning neutral heat flow in [W]
           BoutReal neutral_heatflow = 
-            ion_heatflow * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
+            ion_heatflow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
             + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
 
           // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
@@ -245,7 +245,7 @@ void Recycling::transform(Options& state) {
           // Blend fast (ion energy) and thermal (constant energy) recycling 
           // Calculate returning neutral heat flow in [W]
           BoutReal neutral_heatflow = 
-            ion_heatflow * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
+            ion_heatflow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
             + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
 
 
@@ -310,7 +310,7 @@ void Recycling::transform(Options& state) {
             // Blend fast (ion energy) and thermal (constant energy) recycling 
             // Calculate returning neutral heat flow in [W]
             BoutReal neutral_heatflow = 
-              ion_heatflow * channel.sol_fast_recycle_energy_factor * channel.sol_fast_recycle_fraction   // Fast recycling part
+              ion_heatflow * channel.sol_multiplier * channel.sol_fast_recycle_energy_factor * channel.sol_fast_recycle_fraction   // Fast recycling part
               + recycle_particle_flow * (1 - channel.sol_fast_recycle_fraction) * channel.sol_energy;   // Thermal recycling part
 
             // Divide heat flow in [W] by cell volume to get energy source in [m^-3 s^-1]
@@ -358,7 +358,7 @@ void Recycling::transform(Options& state) {
               // Blend fast (ion energy) and thermal (constant energy) recycling 
               // Calculate returning neutral heat flow in [W]
               BoutReal neutral_heatflow = 
-                ion_heatflow * channel.pfr_fast_recycle_energy_factor * channel.pfr_fast_recycle_fraction   // Fast recycling part
+                ion_heatflow * channel.pfr_multiplier * channel.pfr_fast_recycle_energy_factor * channel.pfr_fast_recycle_fraction   // Fast recycling part
                 + recycle_particle_flow * (1 - channel.pfr_fast_recycle_fraction) * channel.pfr_energy;   // Thermal recycling part
 
               // Divide heat flow in [W] by cell volume to get energy source in [m^-3 s^-1]

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -187,14 +187,14 @@ void Recycling::transform(Options& state) {
           // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
               channel.target_multiplier * flux
-              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1))
-              / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1))); // Omitting *dx*dz because it cancels out when calculating source
+              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1)) / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)))
+              * 0.5*(dx(r.ind, mesh->ystart) + dx(r.ind, mesh->ystart - 1)) * 0.5*(dz(r.ind, mesh->ystart) + dz(r.ind, mesh->ystart - 1));  
+
+          BoutReal volume  = J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart);
 
           // Calculate sources in the final cell [m^-3 s^-1]
-          target_recycle_density_source(r.ind, mesh->ystart, jz) += flow    // For diagnostic 
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          density_source(r.ind, mesh->ystart, jz) += flow         // For use in solver
-              / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
+          target_recycle_density_source(r.ind, mesh->ystart, jz) += flow / volume;    // For diagnostic 
+          density_source(r.ind, mesh->ystart, jz) += flow / volume;         // For use in solver
 
           // Energy of recycled particles
           BoutReal ion_heatflow = energy_flow_ylow(r.ind, mesh->ystart, jz);   // Ion heat flux to wall. This is ylow end so take first domain cell
@@ -206,10 +206,8 @@ void Recycling::transform(Options& state) {
             + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
 
           // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
-          target_recycle_energy_source(r.ind, mesh->ystart, jz) += neutral_heatflow
-              / (J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart));
-          energy_source(r.ind, mesh->ystart, jz) += neutral_heatflow
-              / (J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart));
+          target_recycle_energy_source(r.ind, mesh->ystart, jz) += neutral_heatflow / volume;
+          energy_source(r.ind, mesh->ystart, jz) += neutral_heatflow / volume;
         }
       }
 
@@ -231,15 +229,16 @@ void Recycling::transform(Options& state) {
           // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
               channel.target_multiplier * flux 
-              * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1))
-              / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1)));  // Omitting *dx*dz because it cancels out when calculating source
+              * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1)) / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1)))
+              * 0.5*(dx(r.ind, mesh->yend) + dx(r.ind, mesh->yend + 1)) * 0.5*(dz(r.ind, mesh->yend) + dz(r.ind, mesh->yend + 1)); 
+
+          BoutReal volume  = J(r.ind, mesh->yend) * dx(r.ind, mesh->yend) * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend);
 
           // Calculate sources in the final cell [m^-3 s^-1]
-          target_recycle_density_source(r.ind, mesh->yend, jz) += flow    // For diagnostic 
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          density_source(r.ind, mesh->yend, jz) += flow         // For use in solver
-              / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend)); 
+          target_recycle_density_source(r.ind, mesh->yend, jz) += flow / volume;    // For diagnostic 
+          density_source(r.ind, mesh->yend, jz) += flow / volume;         // For use in solver
 
+          // Energy of recycled particles
           BoutReal ion_heatflow = energy_flow_ylow(r.ind, mesh->yend + 1, jz);   // Ion heat flow to wall in [W]. This is yup end so take guard cell
 
           // Blend fast (ion energy) and thermal (constant energy) recycling 
@@ -250,10 +249,8 @@ void Recycling::transform(Options& state) {
 
 
           // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
-          target_recycle_energy_source(r.ind, mesh->yend, jz) += neutral_heatflow
-              / (J(r.ind, mesh->yend) * dx(r.ind, mesh->yend) * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend));
-          energy_source(r.ind, mesh->yend, jz) += neutral_heatflow
-              / (J(r.ind, mesh->yend) * dx(r.ind, mesh->yend) * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend));
+          target_recycle_energy_source(r.ind, mesh->yend, jz) += neutral_heatflow / volume;
+          energy_source(r.ind, mesh->yend, jz) += neutral_heatflow / volume;
         }
       }
     }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -200,7 +200,7 @@ void Recycling::transform(Options& state) {
 
           target_recycle_energy_source(r.ind, mesh->ystart, jz) += neutral_energy
               / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
-          energy_source(r.ind, mesh->ystart, jz) += channel.target_energy * flow 
+          energy_source(r.ind, mesh->ystart, jz) += neutral_energy
               / (J(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart));
         }
       }
@@ -242,7 +242,7 @@ void Recycling::transform(Options& state) {
 
           target_recycle_energy_source(r.ind, mesh->yend, jz) += neutral_energy
               / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
-          energy_source(r.ind, mesh->yend, jz) += channel.target_energy * flow 
+          energy_source(r.ind, mesh->yend, jz) += neutral_energy
               / (J(r.ind, mesh->yend) * dy(r.ind, mesh->yend));
         }
       }

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -185,9 +185,12 @@ void Recycling::transform(Options& state) {
       // Fast recycling needs to know how much energy the "from" species is losing to the boundary
       if (species_from.isSet("energy_flow_ylow")) {
         energy_flow_ylow = get<Field3D>(species_from["energy_flow_ylow"]);
-      } else if (channel.target_fast_recycle_fraction > 0) {
-        throw BoutException("Target fast recycle enabled but no sheath heat flow available, check compatibility with sheath component");
-      };
+      } else {
+        energy_flow_ylow = 0;
+        if (channel.target_fast_recycle_fraction > 0) {
+          throw BoutException("Target fast recycle enabled but no sheath heat flow available in energy_flow_ylow! \nCurrently only sheath_boundary_simple is supported for fast recycling.");
+        }
+      }
 
       target_recycle_density_source = 0;
       target_recycle_energy_source = 0;

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -197,7 +197,7 @@ void Recycling::transform(Options& state) {
           density_source(r.ind, mesh->ystart, jz) += flow / volume;         // For use in solver
 
           // Energy of recycled particles
-          BoutReal ion_heatflow = energy_flow_ylow(r.ind, mesh->ystart, jz);   // Ion heat flux to wall. This is ylow end so take first domain cell
+          BoutReal ion_heatflow = energy_flow_ylow(r.ind, mesh->ystart, jz) * -1;   // This is ylow end so take first domain cell and flip sign
 
           // Blend fast (ion energy) and thermal (constant energy) recycling 
           // Calculate returning neutral heat flow in [W]

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -282,8 +282,8 @@ void Recycling::transform(Options& state) {
     if (sol_recycle) {
 
       // Flow out of domain is positive in the positive coordinate direction
-      Field3D radial_particle_outflow = energy_flow_xlow;
-      Field3D radial_energy_outflow = particle_flow_xlow;
+      Field3D radial_particle_outflow = particle_flow_xlow;
+      Field3D radial_energy_outflow = energy_flow_xlow;
 
       if(mesh->lastX()){  // Only do this for the processor which has the edge region
         for(int iy=0; iy < mesh->LocalNy ; iy++){

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -278,8 +278,6 @@ void Recycling::transform(Options& state) {
     }
 
     // Initialise counters of pump recycling fluxes
-    pump_recycle_density_source = 0;
-    pump_recycle_energy_source = 0;
     wall_recycle_density_source = 0;
     wall_recycle_energy_source = 0;
     pump_density_source = 0;

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -418,7 +418,7 @@ void SheathBoundarySimple::transform(Options& state) {
   set(electrons["energy_source"], fromFieldAligned(electron_energy_source));
 
   // Add the total sheath power flux to the tracker of y power flows
-  add(electrons["energy_flow_ylow"], electron_sheath_power_ylow);
+  add(electrons["energy_flow_ylow"], fromFieldAligned(electron_sheath_power_ylow));
 
   if (IS_SET_NOBOUNDARY(electrons["velocity"])) {
     setBoundary(electrons["velocity"], fromFieldAligned(Ve));
@@ -622,6 +622,6 @@ void SheathBoundarySimple::transform(Options& state) {
     set(species["energy_source"], fromFieldAligned(energy_source));
 
     // Add the total sheath power flux to the tracker of y power flows
-    add(species["energy_flow_ylow"], ion_sheath_power_ylow);
+    add(species["energy_flow_ylow"], fromFieldAligned(ion_sheath_power_ylow));
   }
 }

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -330,20 +330,20 @@ void SheathBoundarySimple::transform(Options& state) {
                      * nesheath * vesheath;
 
         // Multiply by cell area to get power
-        BoutReal flux = q * (coord->J[i] + coord->J[im])
-                        / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
+        BoutReal heatflow = q * (coord->J[i] + coord->J[im])
+                        / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));  // This omits dx*dz because we divide by dx*dz next
 
         // Divide by volume of cell to get energy loss rate (< 0)
-        BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+        BoutReal power = heatflow / (coord->dy[i] * coord->J[i]);
 
         electron_energy_source[i] += power;
 
         // Total heat flux for diagnostic purposes
-        q = (gamma_e * tesheath + 0.5 * Me * SQ(vesheath)) * nesheath * vesheath;
-        flux = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
-        power = flux / (coord->dy[i] * coord->J[i]);
+        q = gamma_e * tesheath  * nesheath * vesheath;   // Wm-2
+        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
+                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
 
-        electron_sheath_power_ylow[i] += power;       // lower Y, so power placed in final domain cell 
+        electron_sheath_power_ylow[i] += heatflow;       // lower Y, so power placed in final domain cell 
                       
       }
     }
@@ -390,20 +390,20 @@ void SheathBoundarySimple::transform(Options& state) {
                      * nesheath * vesheath;
 
         // Multiply by cell area to get power
-        BoutReal flux = q * (coord->J[i] + coord->J[ip])
-                        / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));
+        BoutReal heatflow = q * (coord->J[i] + coord->J[ip])
+                        / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));  // This omits dx*dz because we divide by dx*dz next
 
         // Divide by volume of cell to get energy loss rate (> 0)
-        BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+        BoutReal power = heatflow / (coord->dy[i] * coord->J[i]);
 
         electron_energy_source[i] -= power;
 
         // Total heat flux for diagnostic purposes
-        q = (gamma_e * tesheath + 0.5 * Me * SQ(vesheath)) * nesheath * vesheath;
-        flux = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
-        power = flux / (coord->dy[i] * coord->J[i]);
+        q = gamma_e * tesheath * nesheath * vesheath;  // Wm-2
+        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
+                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
         
-        electron_sheath_power_ylow[ip] -= power;    // upper Y, so power placed in first guard cell
+        electron_sheath_power_ylow[ip] -= heatflow;    // upper Y, so power placed in first guard cell
       }
     }
   }
@@ -520,20 +520,20 @@ void SheathBoundarySimple::transform(Options& state) {
               * nisheath * visheath;
 
           // Multiply by cell area to get power
-          BoutReal flux = q * (coord->J[i] + coord->J[im])
-                          / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
+          BoutReal heatflow = q * (coord->J[i] + coord->J[im])
+                          / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));  // This omits dx*dz because we divide by dx*dz next
 
           // Divide by volume of cell to get energy loss rate (< 0)
-          BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+          BoutReal power = heatflow / (coord->dy[i] * coord->J[i]);
 
           energy_source[i] += power;
 
           // Calculation of total heat flux for diagnostic purposes
-          q = (gamma_i * tisheath + 0.5 * Mi * C_i_sq) * nisheath * visheath;
-          flux = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
-          power = flux / (coord->dy[i] * coord->J[i]);
+          q = gamma_i * tisheath * nisheath * visheath;   // Wm-2
+          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
+                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
 
-          ion_sheath_power_ylow[i] += power;      // lower Y, so power placed in final domain cell
+          ion_sheath_power_ylow[i] += heatflow;      // lower Y, so power placed in final domain cell
         }
       }
     }
@@ -584,21 +584,21 @@ void SheathBoundarySimple::transform(Options& state) {
               * nisheath * visheath;
 
           // Multiply by cell area to get power
-          BoutReal flux = q * (coord->J[i] + coord->J[ip])
-                          / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));
+          BoutReal heatflow = q * (coord->J[i] + coord->J[ip])
+                          / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));  // This omits dx*dz because we divide by dx*dz next
 
           // Divide by volume of cell to get energy loss rate (> 0)
-          BoutReal power = flux / (coord->dy[i] * coord->J[i]);
+          BoutReal power = heatflow / (coord->dy[i] * coord->J[i]);
           ASSERT2(std::isfinite(power));
 
           energy_source[i] -= power; // Note: Sign negative because power > 0
 
           // Calculation of total heat flux for diagnostic purposes
-          q = (gamma_i * tisheath + 0.5 * Mi * C_i_sq) * nisheath * visheath;
-          flux = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]));
-          power = flux / (coord->dy[i] * coord->J[i]);
+          q = gamma_i * tisheath * nisheath * visheath;
+          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
+                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
 
-          ion_sheath_power_ylow[ip] += power;       // Upper Y, so power placed in first guard cell
+          ion_sheath_power_ylow[ip] += heatflow;       // Upper Y, so power placed in first guard cell
         }
       }
       


### PR DESCRIPTION
Turns out fast recycling has a big impact. This PR does a simple implementation of this:

$$\Gamma_{E_{n}} = R \times (R_{f} \alpha_{E} \Gamma_{E_{i}}^{sheath}  + (1 - R_{f}) T_{R} \Gamma_{N_{i}})) $$

Where $R$ is the recycle multiplier, $R_{f}$ is the fast reflection fraction, $\alpha_{E}$ is the energy reflection factor,
$\Gamma_{E_{i}}^{sheath}$ is the incident heat flux from the sheath boundary condition, $T_{R}$ is the recycle energy and $\Gamma_{N_{i}}$ is the incident ion particle flux.

This is implemented for the SOL and the PFR and is fully compatible with the neutral pump.

In addition, the example cases haven't been corrected to reflect the new recycling flags - this is now done in this PR for all examples.

Tasks:

- [x] Implement for ylow and yup targets
- [x] Test
- [x] Run case for complex test
- [x] Make compatible with neutral pump
- [x] Add documentation