### PR TITLE
Allow reactions to be arbitrarily scaled up and down

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1461,42 +1461,47 @@ rates calculation. The following might therefore be used
           t + e -> t+ + 2e,  # Tritium ionisation
          )
 
-+------------------+---------------------------------------+
-| Reaction         | Description                           |
-+==================+=======================================+
-| h + e -> h+ + 2e | Hydrogen ionisation (Amjuel 2.1.5)    |
-+------------------+---------------------------------------+
-| d + e -> d+ + 2e | Deuterium ionisation (Amjuel 2.1.5)   |
-+------------------+---------------------------------------+
-| t + e -> t+ + 2e | Tritium ionisation (Amjuel 2.1.5)     |
-+------------------+---------------------------------------+
-| h + h+ -> h+ + h | Hydrogen charge exchange              |
-+------------------+---------------------------------------+
-| d + d+ -> d+ + d | Deuterium charge exchange             |
-+------------------+---------------------------------------+
-| t + t+ -> t+ + t | Tritium charge exchange               |
-+------------------+---------------------------------------+
-| h + d+ -> h+ + d | Mixed hydrogen isotope CX             |
-+------------------+---------------------------------------+
-| d + h+ -> d+ + h |                                       |
-+------------------+---------------------------------------+
-| h + t+ -> h+ + t |                                       |
-+------------------+---------------------------------------+
-| t + h+ -> t+ + h |                                       |
-+------------------+---------------------------------------+
-| d + t+ -> d+ + t |                                       |
-+------------------+---------------------------------------+
-| t + d+ -> t+ + d |                                       |
-+------------------+---------------------------------------+
-| h+ + e -> h      | Hydrogen recombination (Amjuel 2.1.8) |
-+------------------+---------------------------------------+
-| d+ + e -> d      | Deuterium recombination (Amjuel 2.1.8)|
-+------------------+---------------------------------------+
-| t+ + e -> t      | Tritium recombination (Amjuel 2.1.8)  |
-+------------------+---------------------------------------+
++------------------+----------------------------------------------+
+| Reaction         | Description                                  |
++==================+==============================================+
+| h + e -> h+ + 2e | Hydrogen ionisation (Amjuel H.4 2.1.5)       |
++------------------+----------------------------------------------+
+| d + e -> d+ + 2e | Deuterium ionisation (Amjuel H.4 2.1.5)      |
++------------------+----------------------------------------------+
+| t + e -> t+ + 2e | Tritium ionisation (Amjuel H.4 2.1.5)        |
++------------------+----------------------------------------------+
+| h + h+ -> h+ + h | Hydrogen charge exchange (Amjuel H.3 3.1.8)  |
++------------------+----------------------------------------------+
+| d + d+ -> d+ + d | Deuterium charge exchange (Amjuel H.3 3.1.8) |
++------------------+----------------------------------------------+
+| t + t+ -> t+ + t | Tritium charge exchange (Amjuel H.3 3.1.8)   |
++------------------+----------------------------------------------+
+| h + d+ -> h+ + d | Mixed hydrogen isotope CX (Amjuel H.3 3.1.8) |
++------------------+----------------------------------------------+
+| d + h+ -> d+ + h |                                              |
++------------------+----------------------------------------------+
+| h + t+ -> h+ + t |                                              |
++------------------+----------------------------------------------+
+| t + h+ -> t+ + h |                                              |
++------------------+----------------------------------------------+
+| d + t+ -> d+ + t |                                              |
++------------------+----------------------------------------------+
+| t + d+ -> t+ + d |                                              |
++------------------+----------------------------------------------+
+| h+ + e -> h      | Hydrogen recombination (Amjuel H.4 2.1.8)    |
++------------------+----------------------------------------------+
+| d+ + e -> d      | Deuterium recombination (Amjuel H.4 2.1.8)   |
++------------------+----------------------------------------------+
+| t+ + e -> t      | Tritium recombination (Amjuel H.4 2.1.8)     |
++------------------+----------------------------------------------+
+
+In addition, the energy loss associated with the ionisation potential energy cost
+as well as the photon emission during excitation and de-excitation during multi-step 
+ionisation is calculated using the AMJUEL rate H.10 2.1.5. The equivalent rate
+for recombination is H.10 2.1.8.
 
 The code to calculate the charge exchange rates is in
-`hydrogen_charge_exchange.[ch]xx`. This implements reaction 3.1.8 from
+`hydrogen_charge_exchange.[ch]xx`. This implements reaction H.3 3.1.8 from
 Amjuel (p43), scaled to different isotope masses and finite neutral
 particle temperatures by using the effective temperature (Amjuel p43):
 
@@ -1506,9 +1511,9 @@ particle temperatures by using the effective temperature (Amjuel p43):
 
 
 The effective hydrogenic ionisation rates are calculated using Amjuel
-reaction 2.1.5, by D.Reiter, K.Sawada and T.Fujimoto (2016).
+reaction H.4 2.1.5, by D.Reiter, K.Sawada and T.Fujimoto (2016).
 Effective recombination rates, which combine radiative and 3-body contributions,
-are calculated using Amjuel reaction 2.1.8.
+are calculated using Amjuel reaction 2.1.8. 
 
 .. doxygenstruct:: HydrogenChargeExchange
    :members:

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1355,6 +1355,27 @@ twice.
 When reactions are added, all the species involved must be included, or an exception
 should be thrown.
 
+Diagnostic variables
+~~~~~~~~
+
+Diagnostic variables are provided for each reaction channel of density, momentum and energy transfer. Additionally, charge exchange
+features a diagnostic for the reaction rate (in ionisation and recombination, the reaction rate K is simply the density transfer rate S divided by the ion density).
+The sign convention is always in terms of a plasma source, so that a source of plasma density, energy or momentum is positive, and a sink is negative.
+Radiative energy transfer is provided separately as E is a transfer of energy between two species, while R is a net loss of energy from the system due to the plasma being transparent.
+
++------------------+---------------------------+-------------------------+
+| Variable prefix  |   Units                   | Description             |
++==================+===========================+=========================+
+| K                |   :math:`s^{-1}`          | Reaction rate           |
++------------------+---------------------------+-------------------------+
+| S                |   :math:`m^{-3}s^{-1}`    | Density transfer rate   |
++------------------+---------------------------+-------------------------+
+| E                |   :math:`Wm^{-3}`         | Energy transfer rate    |
++------------------+---------------------------+-------------------------+
+| R                |   :math:`Wm^{-3}`         | Radiation               |
++------------------+---------------------------+-------------------------+
+
+
 Notes:
 
 1. Charge exchange channel diagnostics: For two species `a` and `b`,
@@ -1419,6 +1440,8 @@ Notes:
   This has the property that the change in pressure of both species is
   Galilean invariant. This transfer term is included in the Amjuel reactions
   and hydrogen charge exchange.
+
+
      
 Hydrogen
 ~~~~~~~~
@@ -1689,6 +1712,33 @@ collisional-radiative model has been set to :math:`1\times 10^{20} \times 0.5ms`
 
 Each rate has an upper and lower bound beyond which the rate remains constant. 
 Please refer to the source code in `fixed_fraction_radiation.hxx` for the coefficients and bounds used for each rate.
+
+
+Adjusting reactions
+~~~~~~~~
+
+The reaction rates can be adjusted by a user-specified arbitrary multiplier. This can be useful for 
+the analysis of the impact of individual reactions. The multiplier setting must be placed under the 
+neutral species corresponding to the reaction, e.g. under `[d]` when adjusting deuterium ionisation, recombination or charge exchange.
+The multiplier for the fixed fraction impurity radiation must be placed under the impurity species header, e.g. under `[ar]` for argon.
+This functionality is not yet currently implemented for helium or neon reactions.
+
++-----------------------+------------------+---------------------------------------+
+| Setting               | Specified under  |  Reaction                             |
++=======================+==================+=======================================+
+| K_iz_multiplier       | Neutral species  | Ionisation rate                       |
++-----------------------+------------------+---------------------------------------+
+| R_ex_multiplier       | Neutral species  | Ionisation (excitation) radiation rate|
++-----------------------+------------------+---------------------------------------+
+| K_rec_multiplier      | Neutral species  | Recombination rate                    |
++-----------------------+------------------+---------------------------------------+
+| R_rec_multiplier      | Neutral species  | Recombination radiation rate          |
++-----------------------+------------------+---------------------------------------+
+| K_cx_multiplier       | Neutral species  | Charge exchange rate                  |
++-----------------------+------------------+---------------------------------------+
+| R_multiplier          | Impurity species | Fixed frac. impurity radiation rate   |
++-----------------------+------------------+---------------------------------------+
+
 
 Electromagnetic fields
 ----------------------

--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -12,22 +12,26 @@ struct AmjuelHeIonisation01 : public AmjuelReaction {
   AmjuelHeIonisation01(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {
 
-        multiplier = alloptions[name]["scale_ionisation"]
+        rate_multiplier = alloptions[std::string("he")]["ionisation_rate_multiplier"]
+                           .doc("Scale the ionisation rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+
+        radiation_multiplier = alloptions[std::string("he")]["ionisation_radiation_rate_multiplier"]
                            .doc("Scale the ionisation rate by this factor")
                            .withDefault<BoutReal>(1.0);
       }
 
   void calculate_rates(Options& state, 
                         Field3D &reaction_rate, Field3D &momentum_exchange,
-                        Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier);
+                        Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier);
 
   void transform(Options& state) override{
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
-    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier);
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier);
   };
 
   private:
-  BoutReal multiplier; ///< Scaling factor on reaction rate
+  BoutReal rate_multiplier, radiation_multiplier; ///< Scaling factor on reaction rate
 
 };
 
@@ -40,23 +44,27 @@ struct AmjuelHeRecombination10 : public AmjuelReaction {
   AmjuelHeRecombination10(std::string name, Options& alloptions, Solver* solver)
       : AmjuelReaction(name, alloptions, solver) {
 
-        multiplier = alloptions[name]["scale_recombination"]
+        rate_multiplier = alloptions[name]["recombination_rate_multiplier"]
                            .doc("Scale the recombination rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+
+        radiation_multiplier = alloptions[name]["recombination_radiation_multiplier"]
+                           .doc("Scale the recombination radiation rate by this factor")
                            .withDefault<BoutReal>(1.0);
 
       }
 
   void calculate_rates(Options& state, 
                       Field3D &reaction_rate, Field3D &momentum_exchange,
-                      Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier);
+                      Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier);
 
   void transform(Options& state) override{
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
-    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier);
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier);
   };
 
   private:
-  BoutReal multiplier; ///< Scaling factor on reaction rate
+  BoutReal rate_multiplier, radiation_multiplier; ///< Scaling factor on reaction rate
 
 };
 

--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -10,16 +10,25 @@
 /// Not resolving metastables, only transporting ground state
 struct AmjuelHeIonisation01 : public AmjuelReaction {
   AmjuelHeIonisation01(std::string name, Options& alloptions, Solver* solver)
-      : AmjuelReaction(name, alloptions, solver) {}
+      : AmjuelReaction(name, alloptions, solver) {
+
+        multiplier = alloptions[name]["scale_ionisation"]
+                           .doc("Scale the ionisation rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+      }
 
   void calculate_rates(Options& state, 
                         Field3D &reaction_rate, Field3D &momentum_exchange,
-                        Field3D &energy_exchange, Field3D &energy_loss);
+                        Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier);
 
   void transform(Options& state) override{
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
-    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier);
   };
+
+  private:
+  BoutReal multiplier; ///< Scaling factor on reaction rate
+
 };
 
 
@@ -29,16 +38,26 @@ struct AmjuelHeIonisation01 : public AmjuelReaction {
 /// Fujimoto Formulation II
 struct AmjuelHeRecombination10 : public AmjuelReaction {
   AmjuelHeRecombination10(std::string name, Options& alloptions, Solver* solver)
-      : AmjuelReaction(name, alloptions, solver) {}
+      : AmjuelReaction(name, alloptions, solver) {
+
+        multiplier = alloptions[name]["scale_recombination"]
+                           .doc("Scale the recombination rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+
+      }
 
   void calculate_rates(Options& state, 
                       Field3D &reaction_rate, Field3D &momentum_exchange,
-                      Field3D &energy_exchange, Field3D &energy_loss);
+                      Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier);
 
   void transform(Options& state) override{
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
-    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss);
+    calculate_rates(state, reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier);
   };
+
+  private:
+  BoutReal multiplier; ///< Scaling factor on reaction rate
+
 };
 
 

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -13,7 +13,7 @@ struct AmjuelHydIonisation : public AmjuelReaction {
 
   void calculate_rates(Options& electron, Options& atom, Options& ion,
                        Field3D& reaction_rate, Field3D& momentum_exchange,
-                       Field3D& energy_exchange, Field3D& energy_loss);
+                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& multiplier);
 };
 
 /// Hydrogen ionisation
@@ -26,6 +26,10 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     diagnose = alloptions[name]["diagnose"]
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
+
+    multiplier = alloptions[name]["scale_ionisation"]
+                           .doc("Scale the ionisation rate by this factor")
+                           .withDefault<BoutReal>(1.0);
   }
 
   void transform(Options& state) override {
@@ -35,7 +39,7 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
     calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange,
-                    energy_exchange, energy_loss);
+                    energy_exchange, energy_loss, multiplier);
 
     if (diagnose) {
       S = reaction_rate;
@@ -100,6 +104,7 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
 
 private:
   bool diagnose; ///< Outputting diagnostics?
+  BoutReal multiplier; ///< Scaling factor on reaction rate
   Field3D S;     ///< Particle exchange
   Field3D F;     ///< Momentum exchange
   Field3D E;     ///< Energy exchange

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -13,7 +13,7 @@ struct AmjuelHydIonisation : public AmjuelReaction {
 
   void calculate_rates(Options& electron, Options& atom, Options& ion,
                        Field3D& reaction_rate, Field3D& momentum_exchange,
-                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& multiplier);
+                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& rate_multiplier, BoutReal& radiation_multiplier);
 };
 
 /// Hydrogen ionisation
@@ -27,8 +27,12 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
 
-    multiplier = alloptions[name]["scale_ionisation"]
+    rate_multiplier = alloptions[{Isotope}]["ionisation_rate_multiplier"]
                            .doc("Scale the ionisation rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+
+    radiation_multiplier = alloptions[{Isotope}]["ionisation_radiation_multiplier"]
+                           .doc("Scale the ionisation excitation/de-excitation radiation rate by this factor")
                            .withDefault<BoutReal>(1.0);
   }
 
@@ -39,7 +43,7 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
     calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange,
-                    energy_exchange, energy_loss, multiplier);
+                    energy_exchange, energy_loss, rate_multiplier, radiation_multiplier);
 
     if (diagnose) {
       S = reaction_rate;
@@ -104,7 +108,7 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
 
 private:
   bool diagnose; ///< Outputting diagnostics?
-  BoutReal multiplier; ///< Scaling factor on reaction rate
+  BoutReal rate_multiplier, radiation_multiplier; ///< Scaling factor on reaction rate
   Field3D S;     ///< Particle exchange
   Field3D F;     ///< Momentum exchange
   Field3D E;     ///< Energy exchange

--- a/include/amjuel_hyd_ionisation.hxx
+++ b/include/amjuel_hyd_ionisation.hxx
@@ -27,11 +27,11 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIonisation {
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
 
-    rate_multiplier = alloptions[{Isotope}]["ionisation_rate_multiplier"]
+    rate_multiplier = alloptions[{Isotope}]["K_iz_multiplier"]
                            .doc("Scale the ionisation rate by this factor")
                            .withDefault<BoutReal>(1.0);
 
-    radiation_multiplier = alloptions[{Isotope}]["ionisation_radiation_multiplier"]
+    radiation_multiplier = alloptions[{Isotope}]["R_ex_multiplier"]
                            .doc("Scale the ionisation excitation/de-excitation radiation rate by this factor")
                            .withDefault<BoutReal>(1.0);
   }

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -29,11 +29,11 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
 
-    rate_multiplier = alloptions[{Isotope}]["recombination_rate_multiplier"]
+    rate_multiplier = alloptions[{Isotope}]["K_rec_multiplier"]
                            .doc("Scale the recombination rate by this factor")
                            .withDefault<BoutReal>(1.0);
 
-    radiation_multiplier = alloptions[{Isotope}]["recombination_radiation_multiplier"]
+    radiation_multiplier = alloptions[{Isotope}]["R_rec_multiplier"]
                            .doc("Scale the recombination radiation (incl. 3 body) rate by this factor")
                            .withDefault<BoutReal>(1.0);
   }

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -15,7 +15,7 @@ struct AmjuelHydRecombination : public AmjuelReaction {
 
   void calculate_rates(Options& electron, Options& atom, Options& ion,
                        Field3D& reaction_rate, Field3D& momentum_exchange,
-                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& multiplier);
+                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& rate_multiplier, BoutReal& radiation_multiplier);
 };
 
 /// Hydrogen recombination
@@ -29,8 +29,12 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
 
-    multiplier = alloptions[name]["scale_recombination"]
+    rate_multiplier = alloptions[{Isotope}]["recombination_rate_multiplier"]
                            .doc("Scale the recombination rate by this factor")
+                           .withDefault<BoutReal>(1.0);
+
+    radiation_multiplier = alloptions[{Isotope}]["recombination_radiation_multiplier"]
+                           .doc("Scale the recombination radiation (incl. 3 body) rate by this factor")
                            .withDefault<BoutReal>(1.0);
   }
 
@@ -41,7 +45,7 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
     calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange,
-                    energy_exchange, energy_loss, multiplier);
+                    energy_exchange, energy_loss, rate_multiplier, radiation_multiplier);
 
     if (diagnose) {
       S = -reaction_rate;
@@ -109,7 +113,7 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
 
 private:
   bool diagnose; ///< Outputting diagnostics?
-  BoutReal multiplier; ///< Scaling factor on reaction rate
+  BoutReal rate_multiplier, radiation_multiplier; ///< Scaling factor on reaction rate
   Field3D S;     ///< Particle exchange
   Field3D F;     ///< Momentum exchange
   Field3D E;     ///< Energy exchange

--- a/include/amjuel_hyd_recombination.hxx
+++ b/include/amjuel_hyd_recombination.hxx
@@ -15,7 +15,7 @@ struct AmjuelHydRecombination : public AmjuelReaction {
 
   void calculate_rates(Options& electron, Options& atom, Options& ion,
                        Field3D& reaction_rate, Field3D& momentum_exchange,
-                       Field3D& energy_exchange, Field3D& energy_loss);
+                       Field3D& energy_exchange, Field3D& energy_loss, BoutReal& multiplier);
 };
 
 /// Hydrogen recombination
@@ -28,6 +28,10 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     diagnose = alloptions[name]["diagnose"]
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
+
+    multiplier = alloptions[name]["scale_recombination"]
+                           .doc("Scale the recombination rate by this factor")
+                           .withDefault<BoutReal>(1.0);
   }
 
   void transform(Options& state) override {
@@ -37,7 +41,7 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
     Field3D reaction_rate, momentum_exchange, energy_exchange, energy_loss;
 
     calculate_rates(electron, atom, ion, reaction_rate, momentum_exchange,
-                    energy_exchange, energy_loss);
+                    energy_exchange, energy_loss, multiplier);
 
     if (diagnose) {
       S = -reaction_rate;
@@ -105,6 +109,7 @@ struct AmjuelHydRecombinationIsotope : public AmjuelHydRecombination {
 
 private:
   bool diagnose; ///< Outputting diagnostics?
+  BoutReal multiplier; ///< Scaling factor on reaction rate
   Field3D S;     ///< Particle exchange
   Field3D F;     ///< Momentum exchange
   Field3D E;     ///< Energy exchange

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -97,9 +97,9 @@ protected:
     reaction_rate = cellAverage(
         [&](BoutReal ne, BoutReal n1, BoutReal te) {
           return ne * n1 * evaluate(rate_coefs, te * Tnorm, ne * Nnorm) * Nnorm
-                 / FreqNorm;
+                 / FreqNorm * rate_multiplier;
         },
-        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * rate_multiplier;
+        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te);
 
     // Particles
     // For ionisation, "from_ion" is the neutral and "to_ion" is the ion
@@ -159,9 +159,9 @@ protected:
     energy_loss = cellAverage(
         [&](BoutReal ne, BoutReal n1, BoutReal te) {
           return ne * n1 * evaluate(radiation_coefs, te * Tnorm, ne * Nnorm) * Nnorm
-                 / (Tnorm * FreqNorm);
+                 / (Tnorm * FreqNorm) * radiation_multiplier;
         },
-        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * radiation_multiplier;
+        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te);
 
     // Loss is reduced by heating
     energy_loss -= (electron_heating / Tnorm) * reaction_rate;

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -72,7 +72,9 @@ protected:
                          Field3D &reaction_rate,
                          Field3D &momentum_exchange,
                          Field3D &energy_exchange,
-                         Field3D &energy_loss) {
+                         Field3D &energy_loss,
+                         BoutReal multiplier) {
+
     Field3D Ne = get<Field3D>(electron["density"]);
     Field3D Te = get<Field3D>(electron["temperature"]);
 
@@ -90,12 +92,13 @@ protected:
     const BoutReal to_charge =
         to_ion.isSet("charge") ? get<BoutReal>(to_ion["charge"]) : 0.0;
 
+    // Calculate reaction rate using cell averaging. Optionally scale by multiplier
     reaction_rate = cellAverage(
         [&](BoutReal ne, BoutReal n1, BoutReal te) {
           return ne * n1 * evaluate(rate_coefs, te * Tnorm, ne * Nnorm) * Nnorm
                  / FreqNorm;
         },
-        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te);
+        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * multiplier;
 
     // Particles
     // For ionisation, "from_ion" is the neutral and "to_ion" is the ion

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -73,7 +73,8 @@ protected:
                          Field3D &momentum_exchange,
                          Field3D &energy_exchange,
                          Field3D &energy_loss,
-                         BoutReal multiplier) {
+                         BoutReal rate_multiplier,
+                         BoutReal radiation_multiplier) {
 
     Field3D Ne = get<Field3D>(electron["density"]);
     Field3D Te = get<Field3D>(electron["temperature"]);
@@ -98,7 +99,7 @@ protected:
           return ne * n1 * evaluate(rate_coefs, te * Tnorm, ne * Nnorm) * Nnorm
                  / FreqNorm;
         },
-        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * multiplier;
+        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * rate_multiplier;
 
     // Particles
     // For ionisation, "from_ion" is the neutral and "to_ion" is the ion
@@ -160,7 +161,7 @@ protected:
           return ne * n1 * evaluate(radiation_coefs, te * Tnorm, ne * Nnorm) * Nnorm
                  / (Tnorm * FreqNorm);
         },
-        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te);
+        Ne.getRegion("RGN_NOBNDRY"))(Ne, N1, Te) * radiation_multiplier;
 
     // Loss is reduced by heating
     energy_loss -= (electron_heating / Tnorm) * reaction_rate;

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -168,6 +168,10 @@ struct FixedFractionRadiation : public Component {
       .doc("Scale the radiation rate by this factor")
       .withDefault<BoutReal>(1.0);
 
+    output<<std::string("\n\n****************************************************\n");
+    output << name << radiation_multiplier;
+    output<<std::string("\n****************************************************\n\n");
+
     // Get the units
     auto& units = alloptions["units"];
     Tnorm = get<BoutReal>(units["eV"]);
@@ -193,7 +197,7 @@ struct FixedFractionRadiation : public Component {
     // Don't need boundary cells
     const Field3D Ne = GET_NOBOUNDARY(Field3D, electrons["density"]);
     const Field3D Te = GET_NOBOUNDARY(Field3D, electrons["temperature"]);
-
+    
     radiation = cellAverage(
                             [&](BoutReal ne, BoutReal te) {
                               if (ne < 0.0 or te < 0.0) {
@@ -231,7 +235,7 @@ struct FixedFractionRadiation : public Component {
   BoutReal fraction; ///< Fixed fraction
 
   bool diagnose; ///< Output radiation diagnostic?
-  bool radiation_multiplier; ///< Scale the radiation rate by this factor
+  BoutReal radiation_multiplier; ///< Scale the radiation rate by this factor
   Field3D radiation; ///< For output diagnostic
 
   // Normalisations

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -164,6 +164,10 @@ struct FixedFractionRadiation : public Component {
       .doc("Output radiation diagnostic?")
       .withDefault<bool>(false);
 
+    radiation_multiplier = options["radiation_multiplier"]
+      .doc("Scale the radiation rate by this factor")
+      .withDefault<BoutReal>(1.0);
+
     // Get the units
     auto& units = alloptions["units"];
     Tnorm = get<BoutReal>(units["eV"]);
@@ -199,8 +203,8 @@ struct FixedFractionRadiation : public Component {
                               const BoutReal ni = fraction * ne;
                               // cooling in Wm^3 so normalise.
                               // Note factor of qe due to Watts rather than eV
-                              return ne * ni * cooling.curve(te * Tnorm) * Nnorm /
-                                (SI::qe * Tnorm * FreqNorm);
+                              return ne * ni * cooling.curve(te * Tnorm) * radiation_multiplier * 
+                              Nnorm / (SI::qe * Tnorm * FreqNorm);
                             },
                             Ne.getRegion("RGN_NOBNDRY"))(Ne, Te);
 
@@ -227,6 +231,7 @@ struct FixedFractionRadiation : public Component {
   BoutReal fraction; ///< Fixed fraction
 
   bool diagnose; ///< Output radiation diagnostic?
+  bool radiation_multiplier; ///< Scale the radiation rate by this factor
   Field3D radiation; ///< For output diagnostic
 
   // Normalisations

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -164,7 +164,7 @@ struct FixedFractionRadiation : public Component {
       .doc("Output radiation diagnostic?")
       .withDefault<bool>(false);
 
-    radiation_multiplier = options["radiation_multiplier"]
+    radiation_multiplier = options["R_multiplier"]
       .doc("Scale the radiation rate by this factor")
       .withDefault<BoutReal>(1.0);
 

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -123,7 +123,7 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
 
-    rate_multiplier = alloptions[{Isotope1}]["cx_rate_multiplier"]
+    rate_multiplier = alloptions[{Isotope1}]["K_cx_multiplier"]
                            .doc("Scale the charge exchange rate by this factor")
                            .withDefault<BoutReal>(1.0);
   }

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -70,7 +70,9 @@ protected:
   ///
   void calculate_rates(Options& atom1, Options& ion1, Options& atom2, Options& ion2,
                        Field3D& R, Field3D& atom_mom, Field3D& ion_mom,
-                       Field3D& atom_energy, Field3D& ion_energy, BoutReal& rate_multiplier);
+                       Field3D& atom_energy, Field3D& ion_energy, 
+                       Field3D& atom_rate, Field3D& ion_rate,
+                       BoutReal& rate_multiplier);
 };
 
 /// Hydrogen charge exchange
@@ -134,6 +136,7 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
                     state["species"][{Isotope2}],                   // e.g. "d"
                     state["species"][{Isotope1, '+'}],              // e.g. "h+"
                     R, atom_mom, ion_mom, atom_energy, ion_energy,  // Transfer channels
+                    atom_rate, ion_rate,                            // Collision rates in s^-1
                     rate_multiplier);                               // Arbitrary user set multiplier
 
     if (diagnose) {
@@ -193,6 +196,16 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
                                      + ion1 + " due to CX with " + ion2)},
                       {"source", "hydrogen_charge_exchange"}});
 
+      set_with_attrs(state[{'K', Isotope1, Isotope2, '+', '_', 'c', 'x'}], // e.g Kdt+_cx
+                     atom_rate,
+                     {{"time_dimension", "t"},
+                      {"units", "s^-1"},
+                      {"conversion", Omega_ci},
+                      {"standard_name", "collision frequency"},
+                      {"long_name", (std::string("CX collision frequency between") + atom1 + " and "
+                                     + ion1 + " producing" + ion2 + " and" + atom2 + ". Note Kab != Kba")},
+                      {"source", "hydrogen_charge_exchange"}});
+
       if (Isotope1 != Isotope2) {
         // Different isotope => particle source, second momentum & energy channel
         set_with_attrs(
@@ -238,6 +251,7 @@ private:
   Field3D S;     ///< Particle exchange, used if Isotope1 != Isotope2
   Field3D F, F2; ///< Momentum exchange
   Field3D E, E2; ///< Energy exchange
+  Field3D atom_rate, ion_rate; ///< Collision rates in s^-1
 };
 
 namespace {

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -70,7 +70,7 @@ protected:
   ///
   void calculate_rates(Options& atom1, Options& ion1, Options& atom2, Options& ion2,
                        Field3D& R, Field3D& atom_mom, Field3D& ion_mom,
-                       Field3D& atom_energy, Field3D& ion_energy);
+                       Field3D& atom_energy, Field3D& ion_energy, BoutReal& rate_multiplier);
 };
 
 /// Hydrogen charge exchange
@@ -120,6 +120,10 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
     diagnose = alloptions[name]["diagnose"]
                    .doc("Output additional diagnostics?")
                    .withDefault<bool>(false);
+
+    rate_multiplier = alloptions[{Isotope1}]["cx_rate_multiplier"]
+                           .doc("Scale the charge exchange rate by this factor")
+                           .withDefault<BoutReal>(1.0);
   }
 
   void transform(Options& state) override {
@@ -129,7 +133,8 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
                     state["species"][{Isotope2, '+'}],              // e.g. "d+"
                     state["species"][{Isotope2}],                   // e.g. "d"
                     state["species"][{Isotope1, '+'}],              // e.g. "h+"
-                    R, atom_mom, ion_mom, atom_energy, ion_energy); // Transfer channels
+                    R, atom_mom, ion_mom, atom_energy, ion_energy,  // Transfer channels
+                    rate_multiplier);                               // Arbitrary user set multiplier
 
     if (diagnose) {
       // Calculate diagnostics to be written to dump file
@@ -229,6 +234,7 @@ struct HydrogenChargeExchangeIsotope : public HydrogenChargeExchange {
 
 private:
   bool diagnose; ///< Outputting diagnostics?
+  BoutReal rate_multiplier; ///< Multiply rate by arbitrary user set factor
   Field3D S;     ///< Particle exchange, used if Isotope1 != Isotope2
   Field3D F, F2; ///< Momentum exchange
   Field3D E, E2; ///< Energy exchange

--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -68,13 +68,13 @@ static constexpr const BoutReal he01_radiation_coefs[9][9] = {
 
 void AmjuelHeIonisation01::calculate_rates(Options& state, 
                                           Field3D &reaction_rate, Field3D &momentum_exchange,
-                                          Field3D &energy_exchange, Field3D &energy_loss) {
+                                          Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he"],  // From helium atoms
                     state["species"]["he+"], // To helium ions
                     he01_rate_coefs, he01_radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs,
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
 
   );
 }
@@ -147,12 +147,12 @@ static constexpr const BoutReal he10_radiation_coefs[9][9] = {
 
 void AmjuelHeRecombination10::calculate_rates(Options& state, 
                                               Field3D &reaction_rate, Field3D &momentum_exchange,
-                                              Field3D &energy_exchange, Field3D &energy_loss) {
+                                              Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms
                     he10_rate_coefs, he10_radiation_coefs,
                     24.586, // Ionisation potential heating of electrons
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
   );
 }

--- a/src/amjuel_helium.cxx
+++ b/src/amjuel_helium.cxx
@@ -68,13 +68,13 @@ static constexpr const BoutReal he01_radiation_coefs[9][9] = {
 
 void AmjuelHeIonisation01::calculate_rates(Options& state, 
                                           Field3D &reaction_rate, Field3D &momentum_exchange,
-                                          Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
+                                          Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he"],  // From helium atoms
                     state["species"]["he+"], // To helium ions
                     he01_rate_coefs, he01_radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs,
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier
 
   );
 }
@@ -147,12 +147,12 @@ static constexpr const BoutReal he10_radiation_coefs[9][9] = {
 
 void AmjuelHeRecombination10::calculate_rates(Options& state, 
                                               Field3D &reaction_rate, Field3D &momentum_exchange,
-                                              Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
+                                              Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier) {
   electron_reaction(state["species"]["e"],
                     state["species"]["he+"], // From helium ions
                     state["species"]["he"],  // To helium atoms
                     he10_rate_coefs, he10_radiation_coefs,
                     24.586, // Ionisation potential heating of electrons
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier
   );
 }

--- a/src/amjuel_hyd_ionisation.cxx
+++ b/src/amjuel_hyd_ionisation.cxx
@@ -67,9 +67,9 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
 void AmjuelHydIonisation::calculate_rates(
   Options& electron, Options& atom, Options& ion, 
   Field3D &reaction_rate, Field3D &momentum_exchange,
-  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
+  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier) {
   electron_reaction(electron, atom, ion, rate_coefs, radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier
   );
 }

--- a/src/amjuel_hyd_ionisation.cxx
+++ b/src/amjuel_hyd_ionisation.cxx
@@ -67,9 +67,9 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
 void AmjuelHydIonisation::calculate_rates(
   Options& electron, Options& atom, Options& ion, 
   Field3D &reaction_rate, Field3D &momentum_exchange,
-  Field3D &energy_exchange, Field3D &energy_loss) {
+  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
   electron_reaction(electron, atom, ion, rate_coefs, radiation_coefs,
                     0.0, // Note: Ionisation potential included in radiation_coefs
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
   );
 }

--- a/src/amjuel_hyd_recombination.cxx
+++ b/src/amjuel_hyd_recombination.cxx
@@ -67,9 +67,9 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
 void AmjuelHydRecombination::calculate_rates(
   Options& electron, Options& atom, Options& ion, 
   Field3D &reaction_rate, Field3D &momentum_exchange,
-  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
+  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &rate_multiplier, BoutReal &radiation_multiplier) {
   electron_reaction(electron, ion, atom, rate_coefs, radiation_coefs,
                     13.6, // Potential energy loss [eV] heats electrons
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, rate_multiplier, radiation_multiplier
   );
 }

--- a/src/amjuel_hyd_recombination.cxx
+++ b/src/amjuel_hyd_recombination.cxx
@@ -67,9 +67,9 @@ static constexpr const BoutReal radiation_coefs[9][9] = {
 void AmjuelHydRecombination::calculate_rates(
   Options& electron, Options& atom, Options& ion, 
   Field3D &reaction_rate, Field3D &momentum_exchange,
-  Field3D &energy_exchange, Field3D &energy_loss) {
+  Field3D &energy_exchange, Field3D &energy_loss, BoutReal &multiplier) {
   electron_reaction(electron, ion, atom, rate_coefs, radiation_coefs,
                     13.6, // Potential energy loss [eV] heats electrons
-                    reaction_rate, momentum_exchange, energy_exchange, energy_loss
+                    reaction_rate, momentum_exchange, energy_exchange, energy_loss, multiplier
   );
 }

--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -5,6 +5,7 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
                                              Field3D &R,
                                              Field3D &atom_mom, Field3D &ion_mom,
                                              Field3D &atom_energy, Field3D &ion_energy,
+                                             Field3D &atom_rate, Field3D &ion_rate,
                                              BoutReal &rate_multiplier) {
 
   // Temperatures and masses of initial atom and ion
@@ -90,7 +91,9 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   subtract(ion1["energy_source"], ion_energy);
   add(atom2["energy_source"], ion_energy);
 
-  // Update collision frequency for the two colliding species
-  add(atom1["collision_frequency"], Nion * sigmav);
-  add(ion1["collision_frequency"], Natom * sigmav);
+  // Update collision frequency for the two colliding species in s^-1
+  atom_rate = Nion * sigmav;
+  ion_rate = Natom * sigmav;
+  add(atom1["collision_frequency"], atom_rate);
+  add(ion1["collision_frequency"], ion_rate);
 }

--- a/src/hydrogen_charge_exchange.cxx
+++ b/src/hydrogen_charge_exchange.cxx
@@ -4,7 +4,8 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
                                              Options& atom2, Options& ion2,
                                              Field3D &R,
                                              Field3D &atom_mom, Field3D &ion_mom,
-                                             Field3D &atom_energy, Field3D &ion_energy) {
+                                             Field3D &atom_energy, Field3D &ion_energy,
+                                             BoutReal &rate_multiplier) {
 
   // Temperatures and masses of initial atom and ion
   const Field3D Tatom = get<Field3D>(atom1["temperature"]);
@@ -38,7 +39,8 @@ void HydrogenChargeExchange::calculate_rates(Options& atom1, Options& ion1,
   }
 
   // Get rate coefficient, convert cm^3/s to m^3/s then normalise
-  const Field3D sigmav = exp(ln_sigmav) * (1e-6 * Nnorm / FreqNorm);
+  // Optionally multiply by arbitrary multiplier
+  const Field3D sigmav = exp(ln_sigmav) * (1e-6 * Nnorm / FreqNorm) * rate_multiplier;
 
   const Field3D Natom = floor(get<Field3D>(atom1["density"]), 1e-5);
   const Field3D Nion = floor(get<Field3D>(ion1["density"]), 1e-5);


### PR DESCRIPTION
This PR allows the reaction rate for each reaction to be scaled according to a user-set `multiplier`. This will make it easier to determine the impact of a particular reaction. Impurity rates are excluded and left to future work, apart from fixed fraction.

Todo:
- [x] Implement in ionisation and recombination for hydrogenic and helium reactions
- [x] Implement in ionisation and recombination related radiation
- [x] Implement in charge exchange
- [x] Implement in fixed fraction radiation
- [x] Test
- [x] Add documentation