### PR TITLE
Allow solving in 2D/3D without neutral momentum equation

### DIFF
--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -52,6 +52,7 @@ private:
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
 
   bool neutral_viscosity; ///< include viscosity?
+  bool evolve_momentum; ///< Evolve parallel momentum?
 
   bool precondition {true}; ///< Enable preconditioner?
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning


### PR DESCRIPTION
In 1D neutral momentum is controlled by the `evolve_momentum` which can be easily disabled. In 2D, it is controlled by `neutral_mixed` which has the entire neutral transport model inside it and no option to disable it. This PR adds a new flag called `evolve_momentum` which is `True` by default. 

- [x] Implement flag
- [x] Test