### PR TITLE
Add user-set multiplier on e-i collision rate

### DIFF
--- a/include/collisions.hxx
+++ b/include/collisions.hxx
@@ -57,6 +57,8 @@ private:
   /// Include frictional heating term?
   bool frictional_heating;
 
+  BoutReal ei_multiplier;  // Arbitrary user-set multiplier on electron-ion collisions
+
   /// Calculated collision rates saved for post-processing and use by other components
   /// Saved in options, the BOUT++ dictionary-like object
   Options collision_rates;

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -48,6 +48,10 @@ Collisions::Collisions(std::string name, Options& alloptions, Solver*) {
     .doc("Include R dot v heating term as energy source?")
     .withDefault<bool>(true);
 
+  ei_multiplier = options["ei_multiplier"]
+                      .doc("User-set arbitrary multiplier on electron-ion collision rate")
+                      .withDefault<BoutReal>(1.0);
+
   diagnose =
       options["diagnose"].doc("Output additional diagnostics?").withDefault<bool>(false);
 }
@@ -227,7 +231,8 @@ void Collisions::transform(Options& state) {
           // Collision frequency
           const BoutReal nu = SQ(SQ(SI::qe) * Zi) * floor(Ni[i], 0.0)
                               * floor(coulomb_log, 1.0) * (1. + me_mi)
-                              / (3 * pow(PI * (vesq + visq), 1.5) * SQ(SI::e0 * SI::Me));
+                              / (3 * pow(PI * (vesq + visq), 1.5) * SQ(SI::e0 * SI::Me))
+                              * ei_multiplier;
 #if CHECK >= 2
 	  if (!std::isfinite(nu)) {
 	    throw BoutException("Collisions 195 {}: {} at {}: Ni {}, Ne {}, Clog {}, vesq {}, visq {}, Te {}, Ti {}\n",


### PR DESCRIPTION
See title. Adds new setting under `[collisions]`: `ei_multiplier`. This serves as a user-set arbitrary scaling factor on the ei collision rate.