### PR TITLE
Add build* to .gitignore for Git to ignore build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ BOUT.settings
 *.a
 *~
 .DS_Store
-build*
+/build*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ BOUT.settings
 *.a
 *~
 .DS_Store
+build*


### PR DESCRIPTION
Every time I build Hermes-3, I do it into a folder in the Hermes-3 source directory and I have `build` in the name. I've been adding `build*` manually to my .gitignore every time I start a new branch for a year now. It has now occurred to me I can just commit this...

