### PR TITLE
Allow for classical_diffusion to support user-set diffusion coefficient

### DIFF
--- a/include/classical_diffusion.hxx
+++ b/include/classical_diffusion.hxx
@@ -15,6 +15,7 @@ private:
 
   bool diagnose; ///< Output additional diagnostics?
   Field3D Dn; ///< Particle diffusion coefficient
+  BoutReal custom_D; ///< User-set particle diffusion coefficient override
 };
 
 namespace {

--- a/src/classical_diffusion.cxx
+++ b/src/classical_diffusion.cxx
@@ -47,6 +47,11 @@ void ClassicalDiffusion::transform(Options &state) {
     Dn = floor(Ptotal, 1e-5) * me * nu_e / (floor(Ne, 1e-5) * Bsq);
   }
 
+  // Set D to zero in all guard cells
+  BOUT_FOR(i, Dn.getRegion("RGN_GUARDS")) {
+      Dn[i] = 0.0;
+    }
+
   for (auto& kv : allspecies.getChildren()) {
     Options& species = allspecies[kv.first]; // Note: Need non-const
 


### PR DESCRIPTION
Currently working with Chris Ridgers on simple Blob2D example. We need to add some kind of diffusion to it, but we don't want to have to evolve collisions. In this PR I modify the `classical_diffusion` component and add a new setting for a user-set D which bypasses collisions:

https://github.com/bendudson/hermes-3/blob/5d1e3811a7eef4da0d394a37cae97d1de5e1797c/src/classical_diffusion.cxx#L12

This then feeds into particle, momentum and pressure diffusion, but there is an additional bit (possibly conduction?) which has a different formulation. I haven't been able to figure it out yet so I disabled it for now - will need to discuss with @bendudson.

https://github.com/bendudson/hermes-3/blob/5d1e3811a7eef4da0d394a37cae97d1de5e1797c/src/classical_diffusion.cxx#L82-L85