### PR TITLE
Add simplified Ar cooling curves

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1834,6 +1834,11 @@ collisional-radiative model has been set to :math:`1\times 10^{20} \times 0.5ms`
 Each rate has an upper and lower bound beyond which the rate remains constant. 
 Please refer to the source code in `fixed_fraction_radiation.hxx` for the coefficients and bounds used for each rate.
 
+In addition to the above rates, there are three simplified cooling curves for Argon: ``fixed_fraction_argon_simplified1``,
+``fixed_fraction_argon_simplified2`` and ``fixed_fraction_argon_simplified3``. They progressively reduce the nonlinearity in the 
+rate by taking out the curvature from the slopes, taking out the RHS shoulder and taking out the LHS-RHS asymmetry, respectively.
+These rates may be useful in investigating the impact of the different kinds of curve nonlinearities on the solution. 
+
 
 Adjusting reactions
 ~~~~~~~~

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -200,6 +200,33 @@ namespace {
     }
   };
 
+  /// Argon simplified 3
+  /// Based on the ADAS curve above but simplified as a linear interpolation
+  /// between the LHS minimum, peak, and the bottom of RHS slope.
+  /// RHS shoulder is eliminated, radiation becomes 0 at 60eV.
+  /// LHS / RHS asymmetry is eliminated.
+  /// Helpful for studying impact of cooling curve nonlinearity 
+  struct Argon_simplified3{
+    BoutReal curve(BoutReal Te) {
+      
+     if (Te < 0.52) { 
+        return 0; 
+    
+     } else if (Te >= 0.52 and Te < 2.50) {
+        return (1.953534e-35*(2.50 - Te) + 6.053680e-34*(Te - 0.52)) / (2.50 - 0.52);
+
+     } else if (Te >= 2.50 and Te < 19.72) {
+        return (6.053680e-34*(19.72 - Te) + 2.175237e-31*(Te - 2.50)) / (19.72 - 2.50);
+
+     } else if (Te >= 19.72 and Te < 38.02) {
+        return (2.175237e-31*(38.02 - Te) + 0.000000e+00*(Te - 19.72)) / (38.02 - 19.72);
+
+     } else {
+        return 0.0;
+     };
+    }
+  };
+
 
 
 
@@ -226,10 +253,6 @@ struct FixedFractionRadiation : public Component {
     radiation_multiplier = options["R_multiplier"]
       .doc("Scale the radiation rate by this factor")
       .withDefault<BoutReal>(1.0);
-
-    output<<std::string("\n\n****************************************************\n");
-    output << name << radiation_multiplier;
-    output<<std::string("\n****************************************************\n\n");
 
     // Get the units
     auto& units = alloptions["units"];
@@ -322,6 +345,9 @@ namespace {
 
   RegisterComponent<FixedFractionRadiation<Argon_simplified2>>
     registercomponentfixedfractionargonsimplified2("fixed_fraction_argon_simplified2");
+
+  RegisterComponent<FixedFractionRadiation<Argon_simplified3>>
+    registercomponentfixedfractionargonsimplified3("fixed_fraction_argon_simplified3");
 
 }
 

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -144,6 +144,65 @@ namespace {
     }
     }
   };
+
+  /// Argon simplified 1
+  /// Based on the ADAS curve above but simplified as a linear interpolation
+  /// between the LHS minimum, peak, bottom of RHS slope and final value at Te = 3000eV.
+  /// RHS shoulder is preserved.
+  /// Helpful for studying impact of cooling curve nonlinearity 
+  struct Argon_simplified1{
+    BoutReal curve(BoutReal Te) {
+      
+     if (Te < 0.52) { 
+        return 0; 
+    
+     } else if (Te >= 0.52 and Te < 2.50) {
+        return (1.953534e-35*(2.50 - Te) + 6.053680e-34*(Te - 0.52)) / (2.50 - 0.52);
+
+     } else if (Te >= 2.50 and Te < 19.72) {
+        return (6.053680e-34*(19.72 - Te) + 2.175237e-31*(Te - 2.50)) / (19.72 - 2.50);
+
+     } else if (Te >= 19.72 and Te < 59.98) {
+        return (2.175237e-31*(59.98 - Te) + 4.190918e-32*(Te - 19.72)) / (59.98 - 19.72);
+
+     } else if (Te >= 59.98 and Te < 3000.00) {
+        return (4.190918e-32*(3000.00 - Te) + 1.226496e-32*(Te - 59.98)) / (3000.00 - 59.98);
+
+     } else {
+        return 1.226496e-32;
+     }
+    }
+  };
+
+  /// Argon simplified 2
+  /// Based on the ADAS curve above but simplified as a linear interpolation
+  /// between the LHS minimum, peak, and the bottom of RHS slope.
+  /// RHS shoulder is eliminated, radiation becomes 0 at 60eV.
+  /// Helpful for studying impact of cooling curve nonlinearity 
+  struct Argon_simplified2{
+    BoutReal curve(BoutReal Te) {
+      
+     if (Te < 0.52) { 
+        return 0; 
+    
+     } else if (Te >= 0.52 and Te < 2.50) {
+        return (1.953534e-35*(2.50 - Te) + 6.053680e-34*(Te - 0.52)) / (2.50 - 0.52);
+
+     } else if (Te >= 2.50 and Te < 19.72) {
+        return (6.053680e-34*(19.72 - Te) + 2.175237e-31*(Te - 2.50)) / (19.72 - 2.50);
+
+     } else if (Te >= 19.72 and Te < 59.98) {
+        return (2.175237e-31*(59.98 - Te) + 0.000000e+00*(Te - 19.72)) / (59.98 - 19.72);
+
+     } else {
+        return 0.0;
+     }
+    }
+  };
+
+
+
+
 }
 
 /// Set ion densities from electron densities
@@ -257,6 +316,12 @@ namespace {
 
   RegisterComponent<FixedFractionRadiation<Argon_adas>>
     registercomponentfixedfractionargon("fixed_fraction_argon");
+
+  RegisterComponent<FixedFractionRadiation<Argon_simplified1>>
+    registercomponentfixedfractionargonsimplified1("fixed_fraction_argon_simplified1");
+
+  RegisterComponent<FixedFractionRadiation<Argon_simplified2>>
+    registercomponentfixedfractionargonsimplified2("fixed_fraction_argon_simplified2");
 
 }
 


### PR DESCRIPTION
Impurity radiation dominates detachment in reactor-class devices but it's a very nonlinear process partially because of the nonlinearities of the cooling curve:
- Both the LHS and RHS slopes are curved 
- RHS slope tapers off slower than the LHS slope
- RHS slope has a large "shoulder", a region of non-zero radiation at higher temperatures which is also a complex curve

All three features are present in curves of N, Ne, Ar and C to varying degrees. To study the impact of this, I prepared two simplified curves for Argon. `fixed_fraction_argon_simplified1` takes out the curvature from the slopes but preserves their levels:
![image](https://github.com/bendudson/hermes-3/assets/62797494/11d88e1a-31d8-49a7-b198-05d0fcfc09bd)

`fixed_fraction_argon_simplified2` takes out the RHS shoulder:
![image](https://github.com/bendudson/hermes-3/assets/62797494/034cfe8a-8084-4dfa-bd5c-f9f25d430b40)

`fixed_fraction_argon_simplified3` takes out the LHS - RHS asymmetry:
![image](https://github.com/bendudson/hermes-3/assets/62797494/dd304c7f-21ce-499f-a3f3-718a4cf22b74)

Note that there is an additional point in the LHS limit to smooth out the transition to no radiation in the low temperature limit. Sharp transitions there have led to long runtimes in the past.

- [x] Add the first two simplified curves
- [x] Test
- [x] Add the third curve
- [x] Test
- [x] Write docs
