### PR TITLE
Update BOUT++ to latest version

### DIFF
--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -186,7 +186,7 @@ int Hermes::init(bool restarting) {
 
   // Put into the options tree, so quantities can be normalised
   // when creating components
-  Options::root()["units"] = units;
+  Options::root()["units"] = units.copy();
   Options::root()["units"].setConditionallyUsed();
 
   // Add the decay length boundary condition to the boundary factory
@@ -255,7 +255,7 @@ int Hermes::rhs(BoutReal time) {
   state = Options();
   
   set(state["time"], time);
-  state["units"] = units; 
+  state["units"] = units.copy();
 
   // Call all the components
   scheduler->transform(state);

--- a/src/snb_conduction.cxx
+++ b/src/snb_conduction.cxx
@@ -5,7 +5,7 @@
 using bout::globals::mesh;
 
 void SNBConduction::transform(Options& state) {
-  auto units = state["units"];
+  auto& units = state["units"];
   const auto rho_s0 = get<BoutReal>(units["meters"]);
   const auto Tnorm = get<BoutReal>(units["eV"]);
   const auto Nnorm = get<BoutReal>(units["inv_meters_cubed"]);

--- a/src/transform.cxx
+++ b/src/transform.cxx
@@ -27,6 +27,6 @@ Transform::Transform(std::string name, Options& alloptions, Solver* UNUSED(solve
 
 void Transform::transform(Options& state) {
   for (const auto& lr : transforms) {
-    state[lr.first] = state[lr.second];
+    state[lr.first] = state[lr.second].copy();
   }
 }

--- a/tests/unit/test_collisions.cxx
+++ b/tests/unit/test_collisions.cxx
@@ -70,7 +70,7 @@ TEST_F(CollisionsTest, OneOrTwoSpeciesCharged) {
   state2["species"]["s1"]["charge"] = 1;
   state2["species"]["s1"]["AA"] = 2;
 
-  state2["species"]["s2"] = state2["species"]["s1"];
+  state2["species"]["s2"] = state2["species"]["s1"].copy();
 
   // Run calculations
   component.transform(state1);

--- a/tests/unit/test_extras.hxx
+++ b/tests/unit/test_extras.hxx
@@ -51,13 +51,13 @@ inline std::ostream& operator<< (std::ostream &out, const SpecificInd<N> &index)
 }
 
 /// Helpers to get the type of a Field as a string
-auto inline getFieldType(MAYBE_UNUSED(const Field2D& field)) -> std::string {
+auto inline getFieldType([[maybe_unused]] const Field2D& field) -> std::string {
   return "Field2D";
 }
-auto inline getFieldType(MAYBE_UNUSED(const Field3D& field)) -> std::string {
+auto inline getFieldType([[maybe_unused]] const Field3D& field) -> std::string {
   return "Field3D";
 }
-auto inline getFieldType(MAYBE_UNUSED(const FieldPerp& field)) -> std::string {
+auto inline getFieldType([[maybe_unused]] const FieldPerp& field) -> std::string {
   return "FieldPerp";
 }
 
@@ -333,14 +333,14 @@ class FakeGridDataSource : public GridDataSource {
 public:
   FakeGridDataSource() {}
   /// Constructor setting values which can be fetched from this source
-  FakeGridDataSource(Options& values) : values(values) {}
+  FakeGridDataSource(Options& values) : values(values.copy()) {}
 
   /// Take an rvalue (e.g. initializer list), convert to lvalue and delegate constructor
   FakeGridDataSource(Options&& values) : FakeGridDataSource(values) {}
 
   bool hasVar(const std::string& UNUSED(name)) override { return false; }
 
-  bool get(MAYBE_UNUSED(Mesh* m), std::string& sval, const std::string& name,
+  bool get([[maybe_unused]] Mesh* m, std::string& sval, const std::string& name,
            const std::string& def = "") override {
     if (values[name].isSet()) {
       sval = values[name].as<std::string>();
@@ -349,7 +349,7 @@ public:
     sval = def;
     return false;
   }
-  bool get(MAYBE_UNUSED(Mesh* m), int& ival, const std::string& name,
+  bool get([[maybe_unused]] Mesh* m, int& ival, const std::string& name,
            int def = 0) override {
     if (values[name].isSet()) {
       ival = values[name].as<int>();
@@ -358,7 +358,7 @@ public:
     ival = def;
     return false;
   }
-  bool get(MAYBE_UNUSED(Mesh* m), BoutReal& rval, const std::string& name,
+  bool get([[maybe_unused]] Mesh* m, BoutReal& rval, const std::string& name,
            BoutReal def = 0.0) override {
     if (values[name].isSet()) {
       rval = values[name].as<BoutReal>();
@@ -395,15 +395,15 @@ public:
     return false;
   }
 
-  bool get(MAYBE_UNUSED(Mesh* m), MAYBE_UNUSED(std::vector<int>& var),
-           MAYBE_UNUSED(const std::string& name), MAYBE_UNUSED(int len),
-           MAYBE_UNUSED(int def) = 0, Direction = GridDataSource::X) override {
+  bool get([[maybe_unused]] Mesh* m, [[maybe_unused]] std::vector<int>& var,
+           [[maybe_unused]] const std::string& name, [[maybe_unused]] int len,
+           [[maybe_unused]] int def = 0, Direction = GridDataSource::X) override {
     throw BoutException("Not Implemented");
     return false;
   }
-  bool get(MAYBE_UNUSED(Mesh* m), MAYBE_UNUSED(std::vector<BoutReal>& var),
-           MAYBE_UNUSED(const std::string& name), MAYBE_UNUSED(int len),
-           MAYBE_UNUSED(int def) = 0,
+  bool get([[maybe_unused]] Mesh* m, [[maybe_unused]] std::vector<BoutReal>& var,
+           [[maybe_unused]] const std::string& name, [[maybe_unused]] int len,
+           [[maybe_unused]] int def = 0,
            Direction UNUSED(dir) = GridDataSource::X) override {
     throw BoutException("Not Implemented");
     return false;


### PR DESCRIPTION
Updates the default version of BOUT++ that is downloaded by CMake.

Adds some nice features including:
- Support for ADIOS2 file format, for outputs and restarts
- Changes to Options, to make accidental copying much harder
- Update to C++17 standard, with some tidying up

This will be a breaking change, since the `Options::copy()` method was added, replacing the copy constructor. 