### PR TITLE
Add ADAS CX rate to species collision_frequency

### DIFF
--- a/src/adas_reaction.cxx
+++ b/src/adas_reaction.cxx
@@ -247,4 +247,13 @@ void OpenADASChargeExchange::calculate_rates(Options& electron, Options& from_A,
     subtract(from_B["energy_source"], energy_exchange);
     add(to_B["energy_source"], energy_exchange);
   }
+
+  // Update collision frequency for the colliding species
+  add(from_A["collision_frequency"], cellAverage([&](BoutReal nb, BoutReal ne, BoutReal te) {
+    return floor(nb, 0.0) * rate_coef.evaluate(te * Tnorm, ne * Nnorm) * Nnorm / FreqNorm;
+  }, Ne.getRegion("RGN_NOBNDRY"))(Nb, Ne, Te));
+
+  add(from_B["collision_frequency"], cellAverage([&](BoutReal na, BoutReal ne, BoutReal te) {
+    return floor(na, 0.0) * rate_coef.evaluate(te * Tnorm, ne * Nnorm) * Nnorm / FreqNorm;
+  }, Ne.getRegion("RGN_NOBNDRY"))(Na, Ne, Te));
 }


### PR DESCRIPTION
The colliding species experience a collision that should impact e.g viscosity and heat conduction.

Note: Collisional processes are complex, and lumping everying together into a single collision frequency is a simplification.

Partly fixes issue #196 