### PR TITLE
Updates for electromagnetic tokamak simulations

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -2017,8 +2017,17 @@ the potential in time as a diffusion equation.
 .. doxygenstruct:: RelaxPotential
    :members:
 
+.. _electromagnetic:
+
 electromagnetic
 ~~~~~~~~~~~~~~~
+
+**Notes**: When using this module,
+1. Set ``sound_speed:alfven_wave=true`` so that the shear Alfven wave
+   speed is included in the calculation of the fastest parallel wave
+   speed for numerical dissipation.
+2. For tokamak simulations use zero-Laplacian boundary conditions
+   by setting ``electromagnetic:apar_boundary_neumann=false``.
 
 This component modifies the definition of momentum of all species, to
 include the contribution from the electromagnetic potential

--- a/docs/sphinx/tests.rst
+++ b/docs/sphinx/tests.rst
@@ -213,6 +213,7 @@ Alfven wave
 -----------
 
 The equations solved are
+
 .. math::
 
    \begin{aligned}
@@ -237,7 +238,7 @@ Rearranging results in a quadratic dispersion relation:
 
 .. math::
 
-   \omega^2\left(1 + \frac{k_\perp^2 c^2}{\omega_{pe}^2}\right) + i 0.51\nu_{ei}\frac{k_\perp^2 c^2}{\omega_{pe}^2\omega - k_{||}^2V_A^2 = 0
+   \omega^2\left(1 + \frac{k_\perp^2 c^2}{\omega_{pe}^2}\right) + i 0.51\nu_{ei}\frac{k_\perp^2 c^2}{\omega_{pe}^2}\omega - k_{||}^2V_A^2 = 0
 
 where :math:`V_A = B / \sqrt{\mu_0 n_0 m_i}` is the Alfven speed, and
 :math:`c / \omega_{pe} = \sqrt{m_e / \left(\mu_0 n_0 e^2\right)}` is

--- a/src/electromagnetic.cxx
+++ b/src/electromagnetic.cxx
@@ -21,11 +21,18 @@ Electromagnetic::Electromagnetic(std::string name, Options &alloptions, Solver*)
   auto& options = alloptions[name];
 
   aparSolver = Laplacian::create(&options["laplacian"]);
-  // Set zero-gradient (neumann) boundary conditions
-  aparSolver->setInnerBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
-  aparSolver->setOuterBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
-  //aparSolver->setInnerBoundaryFlags(INVERT_DC_LAP + INVERT_AC_LAP);
-  //aparSolver->setOuterBoundaryFlags(INVERT_DC_LAP + INVERT_AC_LAP);
+
+  if (options["apar_boundary_neumann"]
+      .doc("Neumann radial boundaries? False => Zero Laplace")
+      .withDefault<bool>(false)) {
+    // Set zero-gradient (neumann) boundary conditions
+    aparSolver->setInnerBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+    aparSolver->setOuterBoundaryFlags(INVERT_DC_GRAD + INVERT_AC_GRAD);
+  } else {
+    // Laplacian = 0 boundary conditions
+    aparSolver->setInnerBoundaryFlags(INVERT_DC_LAP + INVERT_AC_LAP);
+    aparSolver->setOuterBoundaryFlags(INVERT_DC_LAP + INVERT_AC_LAP);
+  }
 
   diagnose = options["diagnose"]
     .doc("Output additional diagnostics?")

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -49,27 +49,6 @@ BoutReal limitFree(BoutReal fm, BoutReal fc) {
 
   return fp;
 }
-
-void applyDirichletBoundary(Field2D &f) {
-  for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-    f(r.ind, mesh->ystart - 1) = -f(r.ind, mesh->ystart);
-  }
-  for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-    f(r.ind, mesh->yend + 1) = -f(r.ind, mesh->yend);
-  }
-
-  if (mesh->lastX()) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      f(mesh->xend + 1, y) = -f(mesh->xend, y);
-    }
-  }
-  // Not applying to core boundary
-  if (mesh->firstX() && !mesh->periodicY(mesh->xstart)) {
-    for (int y = mesh->ystart; y <= mesh->yend; y++) {
-      f(mesh->xstart - 1, y) = -f(mesh->xstart, y);
-    }
-  }
-}
 }
 
 Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
@@ -227,10 +206,6 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
   Curlb_B.z *= SQ(Lnorm);
 
   Curlb_B *= 2. / coord->Bxy;
-
-  applyDirichletBoundary(Curlb_B.x);
-  applyDirichletBoundary(Curlb_B.y);
-  applyDirichletBoundary(Curlb_B.z);
 
   Bsq = SQ(coord->Bxy);
 
@@ -521,12 +496,12 @@ void Vorticity::transform(Options& state) {
         Field3D &P_yup = P.yup();
         for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            P_ydown(r.ind, mesh->ystart - 1, jz) = P(r.ind, mesh->ystart, jz); //2 * P(r.ind, mesh->ystart, jz) - P_yup(r.ind, mesh->ystart + 1, jz);
+            P_ydown(r.ind, mesh->ystart - 1, jz) = 2 * P(r.ind, mesh->ystart, jz) - P_yup(r.ind, mesh->ystart + 1, jz);
           }
         }
         for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            P_yup(r.ind, mesh->yend + 1, jz) = P(r.ind, mesh->yend, jz); //2 * P(r.ind, mesh->yend, jz) - P_ydown(r.ind, mesh->yend - 1, jz);
+            P_yup(r.ind, mesh->yend + 1, jz) = 2 * P(r.ind, mesh->yend, jz) - P_ydown(r.ind, mesh->yend - 1, jz);
           }
         }
       } else {
@@ -534,13 +509,13 @@ void Vorticity::transform(Options& state) {
         for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             auto i = indexAt(P_fa, r.ind, mesh->ystart, jz);
-            P_fa[i.ym()] = P_fa[i]; //limitFree(P_fa[i.yp()], P_fa[i]);
+            P_fa[i.ym()] = limitFree(P_fa[i.yp()], P_fa[i]);
           }
         }
         for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
           for (int jz = 0; jz < mesh->LocalNz; jz++) {
             auto i = indexAt(P_fa, r.ind, mesh->yend, jz);
-            P_fa[i.yp()] = P_fa[i]; //limitFree(P_fa[i.ym()], P_fa[i]);
+            P_fa[i.yp()] = limitFree(P_fa[i.ym()], P_fa[i]);
           }
         }
         P = fromFieldAligned(P_fa);

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -486,9 +486,6 @@ void Vorticity::transform(Options& state) {
 
       auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
 
-      P.clearParallelSlices();
-      phi.clearParallelSlices();
-      
       // Note: We need boundary conditions on P, so apply the same
       //       free boundary condition as sheath_boundary.
       if (P.hasParallelSlices()) {

--- a/tests/integrated/alfven-wave/data/BOUT.inp
+++ b/tests/integrated/alfven-wave/data/BOUT.inp
@@ -44,6 +44,7 @@ loadmetric = false # Load metric from Bxy, Rxy etc?
 
 [electromagnetic]
 diagnose = true
+apar_boundary_neumann = true # Neumann radial boundary conditions
 
 [vorticity]
 


### PR DESCRIPTION
Main things:
- Zero-laplace radial boundary condition on Apar by default. Neumann as an option for e.g. slab simulations.
- Note to include Alfven wave in calculation of fastest wave. If omitted, numerical instabilities tend to occur at the target, particularly inboard targets with high B and low density (i.e. high Alfven speed).
