### PR TITLE
Fixing 1D neutral transport equations

### DIFF
--- a/include/neutral_parallel_diffusion.hxx
+++ b/include/neutral_parallel_diffusion.hxx
@@ -36,6 +36,14 @@ struct NeutralParallelDiffusion : public Component {
     equation_fix = options["equation_fix"]
       .doc("Fix correcting pressure advection and conductivity factors?")
       .withDefault<bool>(true);
+
+    thermal_conduction = options["thermal_conducton"]
+      .doc("Enable conduction?")
+      .withDefault<bool>(true);
+
+    viscosity = options["viscosity"]
+      .doc("Enable viscosity?")
+      .withDefault<bool>(true);
   }
 
   ///
@@ -65,6 +73,8 @@ private:
 
   bool diagnose; ///< Output diagnostics?
   bool equation_fix;  ///< Fix incorrect 3/2 factor in pressure advection?
+  bool thermal_conduction; ///< Enable conduction?
+  bool viscosity; ///< Enable viscosity?
 
   /// Per-species diagnostics
   struct Diagnostics {

--- a/include/neutral_parallel_diffusion.hxx
+++ b/include/neutral_parallel_diffusion.hxx
@@ -32,6 +32,10 @@ struct NeutralParallelDiffusion : public Component {
     diagnose = options["diagnose"]
       .doc("Output additional diagnostics?")
       .withDefault<bool>(false);
+
+    equation_fix = options["equation_fix"]
+      .doc("Fix correcting pressure advection and conductivity factors?")
+      .withDefault<bool>(true);
   }
 
   ///
@@ -60,6 +64,7 @@ private:
   BoutReal dneut; ///< cross-field diffusion projection (B  / Bpol)^2
 
   bool diagnose; ///< Output diagnostics?
+  bool equation_fix;  ///< Fix incorrect 3/2 factor in pressure advection?
 
   /// Per-species diagnostics
   struct Diagnostics {

--- a/src/neutral_parallel_diffusion.cxx
+++ b/src/neutral_parallel_diffusion.cxx
@@ -55,12 +55,15 @@ void NeutralParallelDiffusion::transform(Options& state) {
     kappa_n.applyBoundary("neumann");
 
     // Heat transfer
-    Field3D E = FV::Div_par_K_Grad_par(kappa_n, Tn)                 // Conduction
-      + FV::Div_par_K_Grad_par(Dn * advection_factor * Pn, logPn);  // Pressure advection
+    Field3D E = + FV::Div_par_K_Grad_par(
+      Dn * advection_factor * Pn, logPn);        // Pressure advection
+    if (thermal_conduction) {
+      E += FV::Div_par_K_Grad_par(kappa_n, Tn);   // Conduction
+    }
     add(species["energy_source"], E);
 
     Field3D F = 0.0;
-    if (IS_SET(species["velocity"])) {
+    if (IS_SET(species["velocity"]) and viscosity) {
       // Relationship between heat conduction and viscosity for neutral
       // gas Chapman, Cowling "The Mathematical Theory of Non-Uniform
       // Gases", CUP 1952 Ferziger, Kaper "Mathematical Theory of

--- a/src/neutral_parallel_diffusion.cxx
+++ b/src/neutral_parallel_diffusion.cxx
@@ -26,25 +26,37 @@ void NeutralParallelDiffusion::transform(Options& state) {
     const Field3D Pn = IS_SET(species["pressure"]) ?
       GET_VALUE(Field3D, species["pressure"]) : Nn * Tn;
 
-    // Diffusion coefficient
+    BoutReal advection_factor = 0;
+    BoutReal kappa_factor = 0;
+
+    if (equation_fix) {
+      advection_factor = (5. / 2);    // This is equivalent to 5/3 if on pressure basis
+      kappa_factor = (5. / 2);
+    } else {
+      advection_factor = (3. / 2);
+      kappa_factor = 1;
+    }
+
+    // Pressure-diffusion coefficient
     Field3D Dn = dneut * Tn / (AA * nu);
     Dn.applyBoundary("dirichlet_o2");
     mesh->communicate(Dn);
 
     // Cross-field diffusion calculated from pressure gradient
+    // This is the pressure-diffusion approximation 
     Field3D logPn = log(floor(Pn, 1e-7));
     logPn.applyBoundary("neumann");
 
-    // Particle diffusion
+    // Particle advection
     Field3D S = FV::Div_par_K_Grad_par(Dn * Nn, logPn);
     add(species["density_source"], S);
 
-    Field3D kappa_n = Nn * Dn;
+    Field3D kappa_n = kappa_factor * Nn * Dn;
     kappa_n.applyBoundary("neumann");
 
-    // Heat conduction
-    Field3D E = FV::Div_par_K_Grad_par(kappa_n, Tn) // Parallel
-      + FV::Div_par_K_Grad_par(Dn * (3. / 2) * Pn, logPn); // Perpendicular diffusion
+    // Heat transfer
+    Field3D E = FV::Div_par_K_Grad_par(kappa_n, Tn)                 // Conduction
+      + FV::Div_par_K_Grad_par(Dn * advection_factor * Pn, logPn);  // Pressure advection
     add(species["energy_source"], E);
 
     Field3D F = 0.0;

--- a/tests/integrated/1D-recycling/runtest
+++ b/tests/integrated/1D-recycling/runtest
@@ -44,9 +44,9 @@ if Te_up < 50 or Te_up > 70:
 Ti = collect("Td+", tind=-1, path=path)
 Ti_up = Ti[-1,0,0,0] * Tnorm
 # Upstream ion temperature should be about 140eV
-if Ti_up < 130 or Ti_up > 150:
+if Ti_up < 140 or Ti_up > 160:
   success = False
-  print("Ion temperature failed: {}eV. Expecting about 140eV".format(Ti_up))
+  print("Ion temperature failed: {}eV. Expecting about 150eV".format(Ti_up))
 
 if success:
   print(" => Test passed")


### PR DESCRIPTION
Some of the factors in the neutral transport equations have been incorrect. We fixed these in the advanced fluid neutral model implementation in 2D which is still in progress: https://github.com/mikekryjak/hermes-3/blob/E-AFN-neutadv-hotneut/src/neutral_mixed.cxx

There is no reason to not have these implemented in 1D straight away so that the equations are correct. In particular this has been prompted by my comparison against ReMKiT1D with Stefan Mijin.

The fixes are:
- The pressure advection factor is now 5/2 instead of 3/2. This corresponds to the V grad P form without the compression term and is closer to the solution with the compression term than the P div V form. It is also what's used in the AFN model (Horsten 2017)
- The factor on kappa should be 5/2 as per Chapman-Enskog and as per Horsten 2017.

I made the choice for these fixes to be enabled by default but to retain a flag to recover previous behaviour as this will change profiles. Here is the impact on 1D-recycling:

![image](https://github.com/bendudson/hermes-3/assets/62797494/b5f76735-0036-4508-a3c6-e22917dede7c)

To do:

- [x] Fix equations
- [x] Check if docs need to be updated
- [x] Fix test case
