### PR TITLE
Electromagnetic simulations

### DIFF
--- a/docs/sphinx/code_structure.rst
+++ b/docs/sphinx/code_structure.rst
@@ -74,13 +74,14 @@ for new variables which are added to the state:
 * `fields`
 
   * `vorticity`
-  * `phi`       Electrostatic potential
-  * `Apar`      Electromagnetic potential b dot A
-  * `DivJdia`   Divergence of diamagnetic current
-  * `DivJcol`   Divergence of collisional current
-  * `DivJextra` Divergence of current, including 2D parallel current
-    closures.  Not including diamagnetic, parallel current due to
-    flows, or polarisation currents
+  * `phi`           Electrostatic potential
+  * `Apar`          Electromagnetic potential b dot A in induction terms
+  * `Apar_flutter`  The electromagnetic potential (b dot A) in flutter terms
+  * `DivJdia`       Divergence of diamagnetic current
+  * `DivJcol`       Divergence of collisional current
+  * `DivJextra`     Divergence of current, including 2D parallel current
+                    closures.  Not including diamagnetic, parallel current due to
+                    flows, or polarisation currents
 
 For example to get the electron density::
 

--- a/docs/sphinx/code_structure.rst
+++ b/docs/sphinx/code_structure.rst
@@ -54,7 +54,7 @@ for new variables which are added to the state:
     * `charge`  Charge, in units of proton charge (i.e. electron=-1)
     
     * `density`
-    * `momentum`
+    * `momentum` Parallel momentum
     * `pressure`
     * `velocity` Parallel velocity
     * `temperature`
@@ -75,6 +75,7 @@ for new variables which are added to the state:
 
   * `vorticity`
   * `phi`       Electrostatic potential
+  * `Apar`      Electromagnetic potential b dot A
   * `DivJdia`   Divergence of diamagnetic current
   * `DivJcol`   Divergence of collisional current
   * `DivJextra` Divergence of current, including 2D parallel current

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -2045,6 +2045,9 @@ electromagnetic
    ``electromagnetic:apar_core_neumann=true`` (this is the default).
 3. Set the potential core boundary to be constant in Y by setting
    ``vorticity:phi_core_averagey = true``
+4. Magnetic flutter terms must be enabled to be active. They use an
+   ``Apar_flutter`` field, not the ``Apar`` field that is calculated
+   from the induction terms.
 
 This component modifies the definition of momentum of all species, to
 include the contribution from the electromagnetic potential
@@ -2065,7 +2068,10 @@ an additional term in the momentum equation:
 
    \frac{\partial p_s}{\partial t} = \cdots + Z_s e A_{||} \frac{\partial n_s}{\partial t}
 
-These equations are normalised so that in dimensionless quantities
+This is implemented so that the density time-derivative is calculated using the lowest order
+terms (parallel flow and ExB drift).
+
+The above equations are normalised so that in dimensionless quantities
 
 .. math::
 
@@ -2099,6 +2105,14 @@ To convert the species momenta into a current, we take the sum of
 .. math::
 
    - \frac{1}{\beta_{em}} \nabla_\perp^2 A_{||} + \sum_s \frac{Z^2 n_s}{A}A_{||} = \sum_s \frac{Z}{A} p_s
+
+The toroidal variation of density :math:`n_s` must be kept in this
+equation.  By default the iterative "Naulin" solver is used to do
+this: A fast FFT-based method is used in a fixed point iteration,
+correcting for the density variation.
+
+Magnetic flutter terms are 
+
 
 .. doxygenstruct:: Electromagnetic
    :members:

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -2037,6 +2037,7 @@ electromagnetic
 ~~~~~~~~~~~~~~~
 
 **Notes**: When using this module,
+
 1. Set ``sound_speed:alfven_wave=true`` so that the shear Alfven wave
    speed is included in the calculation of the fastest parallel wave
    speed for numerical dissipation.
@@ -2045,7 +2046,8 @@ electromagnetic
    ``electromagnetic:apar_core_neumann=true`` (this is the default).
 3. Set the potential core boundary to be constant in Y by setting
    ``vorticity:phi_core_averagey = true``
-4. Magnetic flutter terms must be enabled to be active. They use an
+4. Magnetic flutter terms must be enabled to be active
+   (``electromagnetic:magnetic_flutter=true``).  They use an
    ``Apar_flutter`` field, not the ``Apar`` field that is calculated
    from the induction terms.
 
@@ -2069,9 +2071,9 @@ an additional term in the momentum equation:
    \frac{\partial p_s}{\partial t} = \cdots + Z_s e A_{||} \frac{\partial n_s}{\partial t}
 
 This is implemented so that the density time-derivative is calculated using the lowest order
-terms (parallel flow and ExB drift).
+terms (parallel flow, ExB drift and a low density numerical diffusion term).
 
-The above equations are normalised so that in dimensionless quantities
+The above equations are normalised so that in dimensionless quantities:
 
 .. math::
 
@@ -2111,8 +2113,17 @@ equation.  By default the iterative "Naulin" solver is used to do
 this: A fast FFT-based method is used in a fixed point iteration,
 correcting for the density variation.
 
-Magnetic flutter terms are 
+Magnetic flutter terms are disabled by default, and can be enabled by setting
 
+.. code-block:: ini
+
+   [electromagnetic]
+   magnetic_flutter = true
+
+This writes an ``Apar_flutter`` field to the state, which then enables perturbed
+parallel derivative terms in the ``evolve_density``, ``evolve_pressure``, ``evolve_energy`` and
+``evolve_momentum`` components. Parallel flow terms are modified, and parallel heat
+conduction.
 
 .. doxygenstruct:: Electromagnetic
    :members:

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -2040,8 +2040,11 @@ electromagnetic
 1. Set ``sound_speed:alfven_wave=true`` so that the shear Alfven wave
    speed is included in the calculation of the fastest parallel wave
    speed for numerical dissipation.
-2. For tokamak simulations use zero-Laplacian boundary conditions
-   by setting ``electromagnetic:apar_boundary_neumann=false``.
+2. For tokamak simulations use Neumann boundary condition on the core
+   and Dirichlet on SOL and PF boundaries by setting
+   ``electromagnetic:apar_core_neumann=true`` (this is the default).
+3. Set the potential core boundary to be constant in Y by setting
+   ``vorticity:phi_core_averagey = true``
 
 This component modifies the definition of momentum of all species, to
 include the contribution from the electromagnetic potential
@@ -2055,8 +2058,14 @@ Assumes that "momentum" :math:`p_s` calculated for all species
    p_s = m_s n_s v_{||s} + Z_s e n_s A_{||}
 
 which arises once the electromagnetic contribution to the force on
-each species is included in the momentum equation. This is normalised
-so that in dimensionless quantities
+each species is included in the momentum equation. This requires
+an additional term in the momentum equation:
+
+.. math::
+
+   \frac{\partial p_s}{\partial t} = \cdots + Z_s e A_{||} \frac{\partial n_s}{\partial t}
+
+These equations are normalised so that in dimensionless quantities
 
 .. math::
 

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -23,8 +23,8 @@
 
  */
 
-#ifndef __DIV_OPS_H__
-#define __DIV_OPS_H__
+#ifndef DIV_OPS_H
+#define DIV_OPS_H
 
 #include <bout/field3d.hxx>
 #include <bout/vector3d.hxx>
@@ -43,6 +43,11 @@ const Field3D Div_par_diffusion_index(const Field3D& f, bool bndry_flux = true);
 const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f,
                                     bool bndry_flux = true, bool poloidal = false,
                                     bool positive = false);
+
+/// This version has an extra coefficient 'g' that is linearly interpolated
+/// onto cell faces
+const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D &n, const Field3D &g, const Field3D &f, 
+                                    bool bndry_flux = true, bool positive = false);
 
 const Field3D Div_Perp_Lap_FV_Index(const Field3D& a, const Field3D& f, bool xflux);
 
@@ -456,4 +461,4 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 
 } // namespace FV
 
-#endif //  __DIV_OPS_H__
+#endif //  DIV_OPS_H

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -216,7 +216,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
           } else {
             // Add flux due to difference in boundary values
             flux =
-                s.R * vpar * sv.R
+                s.R * sv.R * sv.R
                 + BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j + 1, k)))
                   * (s.R * sv.R - bndryval * vpar);
           }
@@ -245,7 +245,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
           } else {
             // Add flux due to difference in boundary values
             flux =
-                s.L * vpar * sv.L
+                s.L * sv.L * sv.L
                 - BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j - 1, k)))
                   * (s.L * sv.L - bndryval * vpar);
           }

--- a/include/electromagnetic.hxx
+++ b/include/electromagnetic.hxx
@@ -64,6 +64,10 @@ private:
 
   std::unique_ptr<Laplacian> aparSolver; // Laplacian solver in X-Z
 
+  bool const_gradient; // Set neumann boundaries by extrapolation
+  BoutReal apar_boundary_timescale; // Relaxation timescale
+  BoutReal last_time;  // The last time the boundaries were updated
+
   bool diagnose; ///< Output additional diagnostics?
 };
 

--- a/include/electromagnetic.hxx
+++ b/include/electromagnetic.hxx
@@ -68,6 +68,9 @@ private:
   BoutReal apar_boundary_timescale; // Relaxation timescale
   BoutReal last_time;  // The last time the boundaries were updated
 
+  bool magnetic_flutter; ///< Set the magnetic flutter term?
+  Field3D Apar_flutter;
+
   bool diagnose; ///< Output additional diagnostics?
 };
 

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -37,6 +37,8 @@ struct Vorticity : public Component {
   ///     Relax radial phi boundaries towards zero-gradient?
   ///   - phi_boundary_timescale: float, 1e-4
   ///     Timescale for phi boundary relaxation [seconds]
+  ///   - phi_core_averagey: bool, default false
+  ///     Average phi core boundary in Y? (if phi_boundary_relax)
   ///   - phi_dissipation: bool, default true
   ///     Parallel dissipation of potential (Recommended)
   ///   - poloidal_flows: bool, default true
@@ -128,7 +130,8 @@ private:
   bool phi_boundary_relax; ///< Relax boundary to zero-gradient
   BoutReal phi_boundary_timescale; ///< Relaxation timescale [normalised]
   BoutReal phi_boundary_last_update; ///< Time when last updated
-
+  bool phi_core_averagey; ///< Average phi core boundary in Y?
+  
   bool split_n0; // Split phi into n=0 and n!=0 components
   LaplaceXY* laplacexy; // Laplacian solver in X-Y (n=0)
 

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -1140,3 +1140,161 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
 
   return result;
 }
+
+const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D &n, const Field3D &g, const Field3D &f, 
+                                    bool bndry_flux, bool positive) {
+  Field3D result{0.0};
+
+  Coordinates *coord = mesh->getCoordinates();
+  
+  //////////////////////////////////////////
+  // X-Z advection.
+  //
+  //             Z
+  //             |
+  //
+  //    fmp --- vU --- fpp
+  //     |      nU      |
+  //     |               |
+  //    vL nL        nR vR    -> X
+  //     |               |
+  //     |      nD       |
+  //    fmm --- vD --- fpm
+  //
+
+  int nz = mesh->LocalNz;
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
+      for (int k = 0; k < nz; k++) {
+        int kp = (k + 1) % nz;
+        int kpp = (kp + 1) % nz;
+        int km = (k - 1 + nz) % nz;
+        int kmm = (km - 1 + nz) % nz;
+
+        // 1) Interpolate stream function f onto corners fmp, fpp, fpm
+
+        BoutReal fmm = 0.25 * (f(i, j, k) + f(i - 1, j, k) + f(i, j, km) +
+                               f(i - 1, j, km));
+        BoutReal fmp = 0.25 * (f(i, j, k) + f(i, j, kp) + f(i - 1, j, k) +
+                               f(i - 1, j, kp)); // 2nd order accurate
+        BoutReal fpp = 0.25 * (f(i, j, k) + f(i, j, kp) + f(i + 1, j, k) +
+                               f(i + 1, j, kp));
+        BoutReal fpm = 0.25 * (f(i, j, k) + f(i + 1, j, k) + f(i, j, km) +
+                               f(i + 1, j, km));
+
+        // 2) Calculate velocities on cell faces
+
+        BoutReal vU = coord->J(i, j) * (fmp - fpp) / coord->dx(i, j); // -J*df/dx
+        BoutReal vD = coord->J(i, j) * (fmm - fpm) / coord->dx(i, j); // -J*df/dx
+
+        BoutReal vR = 0.5 * (coord->J(i, j) + coord->J(i + 1, j)) * (fpp - fpm) /
+                      coord->dz(i, j); // J*df/dz
+        BoutReal vL = 0.5 * (coord->J(i, j) + coord->J(i - 1, j)) * (fmp - fmm) /
+                      coord->dz(i, j); // J*df/dz
+
+        // 3) Calculate g on cell faces
+
+        BoutReal gU = 0.5 * (g(i, j, kp) + g(i, j, k));
+        BoutReal gD = 0.5 * (g(i, j, km) + g(i, j, k));
+        BoutReal gR = 0.5 * (g(i + 1, j, k) + g(i, j, k));
+        BoutReal gL = 0.5 * (g(i - 1, j, k) + g(i, j, k));
+
+        // 4) Calculate n on the cell faces. The sign of the
+        //    velocity determines which side is used.
+
+        // X direction
+        Stencil1D s;
+        s.c = n(i, j, k);
+        s.m = n(i - 1, j, k);
+        s.mm = n(i - 2, j, k);
+        s.p = n(i + 1, j, k);
+        s.pp = n(i + 2, j, k);
+
+        MC(s, coord->dx(i, j));
+        
+        // Right side
+        if ((i == mesh->xend) && (mesh->lastX())) {
+          // At right boundary in X
+
+          if (bndry_flux) {
+            BoutReal flux;
+            if (vR > 0.0) {
+              // Flux to boundary
+              flux = vR * s.R * gR;
+            } else {
+              // Flux in from boundary
+              flux = vR * 0.5 * (n(i + 1, j, k) + n(i, j, k)) * gR;
+            }
+
+            result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
+            result(i + 1, j, k) -=
+                flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
+          }
+        } else {
+          // Not at a boundary
+          if (vR > 0.0) {
+            // Flux out into next cell
+            BoutReal flux = vR * s.R * gR;
+            result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
+            result(i + 1, j, k) -=
+                flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
+          }
+        }
+
+        // Left side
+
+        if ((i == mesh->xstart) && (mesh->firstX())) {
+          // At left boundary in X
+
+          if (bndry_flux) {
+            BoutReal flux;
+
+            if (vL < 0.0) {
+              // Flux to boundary
+              flux = vL * s.L * gL;
+
+            } else {
+              // Flux in from boundary
+              flux = vL * 0.5 * (n(i - 1, j, k) + n(i, j, k)) * gL;
+            }
+            result(i, j, k) -= flux / (coord->dx(i, j) * coord->J(i, j));
+            result(i - 1, j, k) +=
+                flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
+          }
+        } else {
+          // Not at a boundary
+
+          if (vL < 0.0) {
+            BoutReal flux = vL * s.L * gL;
+            result(i, j, k) -= flux / (coord->dx(i, j) * coord->J(i, j));
+            result(i - 1, j, k) +=
+                flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
+          }
+        }
+
+        /// NOTE: Need to communicate fluxes
+
+        // Z direction
+        s.m = n(i, j, km);
+        s.mm = n(i, j, kmm);
+        s.p = n(i, j, kp);
+        s.pp = n(i, j, kpp);
+
+        MC(s, coord->dz(i, j));
+
+        if (vU > 0.0) {
+          BoutReal flux = vU * s.R * gU/ (coord->J(i, j) * coord->dz(i, j));
+          result(i, j, k) += flux;
+          result(i, j, kp) -= flux;
+        }
+        if (vD < 0.0) {
+          BoutReal flux = vD * s.L * gD / (coord->J(i, j) * coord->dz(i, j));
+          result(i, j, k) -= flux;
+          result(i, j, km) += flux;
+        }
+      }
+    }
+  }
+  FV::communicateFluxes(result);
+  return result;
+}

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -124,8 +124,6 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
     }
   }
 
-
-
   neumann_boundary_average_z = alloptions[std::string("N") + name]["neumann_boundary_average_z"]
     .doc("Apply neumann boundary with Z average?")
     .withDefault<bool>(false);
@@ -232,6 +230,14 @@ void EvolveDensity::finally(const Options& state) {
     }
 
     ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave);
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+      // Note: Using -Apar_flutter rather than reversing sign in front,
+      //       so that upwinding is handled correctly
+      ddt(N) -= Div_n_g_bxGrad_f_B_XZ(N, V, -Apar_flutter);
+    }
   }
 
   if (low_n_diffuse) {

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -231,7 +231,7 @@ void EvolveDensity::finally(const Options& state) {
 
     ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave);
 
-    if (state["fields"].isSet("Apar_flutter")) {
+    if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
       const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
       // Note: Using -Apar_flutter rather than reversing sign in front,

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -258,7 +258,7 @@ void EvolveEnergy::finally(const Options& state) {
 
     ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave);
 
-    if (state["fields"].isSet("Apar_flutter")) {
+    if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
       const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
       ddt(E) -= Div_n_g_bxGrad_f_B_XZ(E + P, V, -Apar_flutter);
@@ -329,7 +329,7 @@ void EvolveEnergy::finally(const Options& state) {
     // is calculated and removed separately
     ddt(E) += FV::Div_par_K_Grad_par(kappa_par, T, false);
 
-    if (state["fields"].isSet("Apar_flutter")) {
+    if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term. The operator splits into 4 pieces:
       // Div(k b b.Grad(T)) = Div(k b0 b0.Grad(T)) + Div(k d0 db.Grad(T))
       //                    + Div(k db b0.Grad(T)) + Div(k db db.Grad(T))

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -257,6 +257,12 @@ void EvolveEnergy::finally(const Options& state) {
     }
 
     ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave);
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+      ddt(E) -= Div_n_g_bxGrad_f_B_XZ(E + P, V, -Apar_flutter);
+    }
   }
 
   if (species.isSet("low_n_coeff")) {
@@ -322,6 +328,20 @@ void EvolveEnergy::finally(const Options& state) {
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
     ddt(E) += FV::Div_par_K_Grad_par(kappa_par, T, false);
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term. The operator splits into 4 pieces:
+      // Div(k b b.Grad(T)) = Div(k b0 b0.Grad(T)) + Div(k d0 db.Grad(T))
+      //                    + Div(k db b0.Grad(T)) + Div(k db db.Grad(T))
+      // The first term is already calculated above.
+      // Here we add the terms containing db
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+      Field3D db_dot_T = bracket(T, Apar_flutter, BRACKET_ARAKAWA);
+      Field3D b0_dot_T = Grad_par(T);
+      mesh->communicate(db_dot_T, b0_dot_T);
+      ddt(E) += Div_par(kappa_par * db_dot_T)
+        - Div_n_g_bxGrad_f_B_XZ(kappa_par, db_dot_T + b0_dot_T, Apar_flutter);
+    }
   }
 
   if (hyper_z > 0.) {

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -132,7 +132,10 @@ void EvolveMomentum::finally(const Options &state) {
       if (state["fields"].isSet("Apar")) {
         // Include a correction term for electromagnetic simulations
         const Field3D Apar = get<Field3D>(state["fields"]["Apar"]);
-        const Field3D density_source = get<Field3D>(species["density_source"]);
+
+        const Field3D density_source = species.isSet("density_source") ?
+          get<Field3D>(species["density_source"])
+          : zeroFrom(Apar);
 
         // This is Z * Apar * dn/dt, keeping just leading order terms
         ddt(NV) += Z * Apar * (density_source

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -167,7 +167,7 @@ void EvolveMomentum::finally(const Options &state) {
     ddt(NV) -= Grad_par(P);
   }
 
-  if (state["fields"].isSet("Apar_flutter")) {
+  if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
     // Magnetic flutter term
     const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
     ddt(NV) -= Div_n_g_bxGrad_f_B_XZ(NV, V, -Apar_flutter);

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -262,7 +262,7 @@ void EvolvePressure::finally(const Options& state) {
       ddt(P) += (2. / 3) * V * Grad_par(P);
     }
 
-    if (state["fields"].isSet("Apar_flutter")) {
+    if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
       const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
       ddt(P) -= (5. / 3) * Div_n_g_bxGrad_f_B_XZ(P, V, -Apar_flutter);
@@ -347,7 +347,7 @@ void EvolvePressure::finally(const Options& state) {
     // is calculated and removed separately
     ddt(P) += (2. / 3) * FV::Div_par_K_Grad_par(kappa_par, T, false);
 
-    if (state["fields"].isSet("Apar_flutter")) {
+    if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term. The operator splits into 4 pieces:
       // Div(k b b.Grad(T)) = Div(k b0 b0.Grad(T)) + Div(k d0 db.Grad(T))
       //                    + Div(k db b0.Grad(T)) + Div(k db db.Grad(T))

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -261,6 +261,13 @@ void EvolvePressure::finally(const Options& state) {
 
       ddt(P) += (2. / 3) * V * Grad_par(P);
     }
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+      ddt(P) -= (5. / 3) * Div_n_g_bxGrad_f_B_XZ(P, V, -Apar_flutter);
+      ddt(P) += (2. / 3) * V * bracket(P, Apar_flutter, BRACKET_ARAKAWA);
+    }
   }
 
   if (species.isSet("low_n_coeff")) {
@@ -339,6 +346,20 @@ void EvolvePressure::finally(const Options& state) {
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
     ddt(P) += (2. / 3) * FV::Div_par_K_Grad_par(kappa_par, T, false);
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term. The operator splits into 4 pieces:
+      // Div(k b b.Grad(T)) = Div(k b0 b0.Grad(T)) + Div(k d0 db.Grad(T))
+      //                    + Div(k db b0.Grad(T)) + Div(k db db.Grad(T))
+      // The first term is already calculated above.
+      // Here we add the terms containing db
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+      Field3D db_dot_T = bracket(T, Apar_flutter, BRACKET_ARAKAWA);
+      Field3D b0_dot_T = Grad_par(T);
+      mesh->communicate(db_dot_T, b0_dot_T);
+      ddt(P) += (2. / 3) * (Div_par(kappa_par * db_dot_T) -
+                            Div_n_g_bxGrad_f_B_XZ(kappa_par, db_dot_T + b0_dot_T, Apar_flutter));
+    }
   }
 
   if (hyper_z > 0.) {

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -348,6 +348,10 @@ void SheathBoundary::transform(Options &state) {
         BoutReal q = ((gamma_e - 1 - 1 / (electron_adiabatic - 1)) * tesheath
                       - 0.5 * Me * SQ(vesheath))
                      * nesheath * vesheath;
+        if (q > 0.0) {
+          // Note: This could happen if tesheath > 2*phisheath
+          q = 0.0;
+        }
 
         // Multiply by cell area to get power
         BoutReal flux = q * (coord->J[i] + coord->J[im])
@@ -410,7 +414,10 @@ void SheathBoundary::transform(Options &state) {
         BoutReal q = ((gamma_e - 1 - 1 / (electron_adiabatic - 1)) * tesheath
                       - 0.5 * Me * SQ(vesheath))
                      * nesheath * vesheath;
-
+        if (q < 0.0) {
+          // Note: This could happen if tesheath > 2*phisheath
+          q = 0.0;
+        }
         // Multiply by cell area to get power
         BoutReal flux = q * (coord->J[i] + coord->J[ip])
                         / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -161,6 +161,10 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
     // the first time RHS function is called
     phi_boundary_last_update = -1.;
 
+    phi_core_averagey = options["phi_core_averagey"]
+      .doc("Average phi core boundary in Y?")
+      .withDefault<bool>(false) and mesh->periodicY(mesh->xstart);
+
     phi_boundary_timescale = options["phi_boundary_timescale"]
                                  .doc("Timescale for phi boundary relaxation [seconds]")
                                  .withDefault(1e-4)
@@ -270,12 +274,32 @@ void Vorticity::transform(Options& state) {
       phi_boundary_last_update = time;
 
       if (mesh->firstX()) {
-        for (int j = mesh->ystart; j <= mesh->yend; j++) {
-          BoutReal phivalue = 0.0;
-          for (int k = 0; k < mesh->LocalNz; k++) {
-            phivalue += phi(mesh->xstart, j, k);
+        BoutReal phivalue = 0.0;
+        if (phi_core_averagey) {
+          BoutReal philocal = 0.0;
+          for (int j = mesh->ystart; j <= mesh->yend; j++) {
+            for (int k = 0; k < mesh->LocalNz; k++) {
+              philocal += phi(mesh->xstart, j, k);
+            }
           }
-          phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+          MPI_Comm comm_inner = mesh->getYcomm(0);
+          int np;
+          MPI_Comm_size(comm_inner, &np);
+          MPI_Allreduce(&philocal,
+                        &phivalue,
+                        1, MPI_DOUBLE,
+                        MPI_SUM, comm_inner);
+          phivalue /= (np * mesh->LocalNz * mesh->LocalNy);
+        }
+
+        for (int j = mesh->ystart; j <= mesh->yend; j++) {
+          if (!phi_core_averagey) {
+            phivalue = 0.0; // Calculate phi boundary for each Y index separately
+            for (int k = 0; k < mesh->LocalNz; k++) {
+              phivalue += phi(mesh->xstart, j, k);
+            }
+            phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+          }
 
           // Old value of phi at boundary
           BoutReal oldvalue =


### PR DESCRIPTION
More work on electromagnetic simulations. Now running in axisymmetric simulations at least. Still testing in 3D.

- Add missing term to momentum equation, needed for energy conservation

- Add option to force phi to be constant on core boundary

- By default set Apar to zero on SOL and PF boundary, zero-gradient on core boundary.

Commit [b1d627f](https://github.com/bendudson/hermes-3/pull/230/commits/b1d627f44d87dce7023f49f55a90a4abb67d7945) fixes issue #237 by setting the boundary conditions on the saved variable.
