### PR TITLE
Fixing kappa_par conversion

### DIFF
--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", Pnorm * Omega_ci * SQ(rho_s0)},
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0)} )/ Tnorm,
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm,
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm},
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0)} )/ Tnorm,
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm,
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});


### PR DESCRIPTION
Added Tnorm to kappa_par conversion in evolve_pressure (currently line https://github.com/bendudson/hermes-3/blob/8c450228e61d66200de225c168aa80fdfd91f7b2/src/evolve_pressure.cxx#L435)

The kappa_par conversion in evolve pressure was missing a factor of 1/Tnorm, causing the resulting conductivity to be too high. For the 1D recycling case Tnorm = 100 eV, which meant that calculated heat flux would be two orders of magnitude higher than supplied to the system via the pressure source. I've plotted this for the electron parallel conducitve heat flux (see below):

![image](https://github.com/user-attachments/assets/6676fba9-f302-4ea7-a2b9-65bee32e45db)

The sharp eyed may see that the electron heat flux is increasing between the x point and the target, above the supplied power, this is mirrored exactly by the ion heat flux, so energy is still conserved. 