### PR TITLE
collisions: Disable ion-neutral and electron-neutral by default

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -969,7 +969,8 @@ listed after all the species groups in the component list, so that all
 the species are present in the state.
 
 One of the most important is the `collisions`_ component. This sets collision
-times for all species, which are then used 
+times for all species, which are then used in other components to calculate
+quantities like heat diffusivities and viscosity closures.
 
 .. _sound_speed:
 
@@ -1176,12 +1177,18 @@ species :math:`b` due to temperature differences, is given by:
 
 - Ion-neutral and electron-neutral collisions
 
+  *Note*: These are disabled by default. If enabled, care is needed to
+  avoid double-counting collisions in atomic reactions e.g charge-exchange
+  reacgtions.
+  
   The cross-section for elastic collisions between charged and neutral
   particles can vary significantly. Here for simplicity we just take
   a value of :math:`5\times 10^{-19}m^2` from the NRL formulary.
 
 - Neutral-neutral collisions
 
+  *Note* This is enabled by default.
+  
   The cross-section is given by
 
 .. math::

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1179,7 +1179,7 @@ species :math:`b` due to temperature differences, is given by:
 
   *Note*: These are disabled by default. If enabled, care is needed to
   avoid double-counting collisions in atomic reactions e.g charge-exchange
-  reacgtions.
+  reactions.
   
   The cross-section for elastic collisions between charged and neutral
   particles can vary significantly. Here for simplicity we just take

--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -33,13 +33,13 @@ Collisions::Collisions(std::string name, Options& alloptions, Solver*) {
                      .withDefault<bool>(true);
   electron_neutral = options["electron_neutral"]
                          .doc("Include electron-neutral elastic collisions?")
-                         .withDefault<bool>(true);
+                         .withDefault<bool>(false);
   ion_ion = options["ion_ion"]
                 .doc("Include ion-ion elastic collisions?")
                 .withDefault<bool>(true);
   ion_neutral = options["ion_neutral"]
                     .doc("Include ion-neutral elastic collisions?")
-                    .withDefault<bool>(true);
+                    .withDefault<bool>(false);
   neutral_neutral = options["neutral_neutral"]
                         .doc("Include neutral-neutral elastic collisions?")
                         .withDefault<bool>(true);


### PR DESCRIPTION
These may be double-counted if atomic reactions are included. Added a note to the manual.

ion-electron, electron-electron, ion-ion, and neutral-neutral collisions are still enabled by default.

Fixes #241. 
