### PR TITLE
Set name for potential

### DIFF
--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -217,6 +217,7 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
 void Vorticity::transform(Options& state) {
   AUTO_TRACE();
 
+  phi.name = "phi";
   auto& fields = state["fields"];
 
   // Set the boundary of phi. Both 2D and 3D fields are kept, though the 3D field


### PR DESCRIPTION
Otherwise the name of phi is not reset, as assigning a FieldPerp to a Field3D does not reset the name.