### PR TITLE
Adding conduction heat flux divergence diagnostic

### DIFF
--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -96,6 +96,8 @@ private:
 
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 
+  Field3D conduction_div; ///< Divergence of heat conduction flux
+
   Field3D source, final_source; ///< External pressure source
   Field3D Sp;     ///< Total pressure source
   FieldGeneratorPtr source_prefactor_function;

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -130,6 +130,7 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
       source_prefactor_function = FieldFactory::get()->parse(str, &p_options);
   }
 
+
   if (p_options["source_only_in_core"]
       .doc("Zero the source outside the closed field-line region?")
       .withDefault<bool>(false)) {
@@ -221,6 +222,8 @@ void EvolvePressure::finally(const Options& state) {
 
   T = get<Field3D>(species["temperature"]);
   N = get<Field3D>(species["density"]);
+  
+  Coordinates* coord = mesh->getCoordinates();
 
   if (species.isSet("charge") and (fabs(get<BoutReal>(species["charge"])) > 1e-5) and
       state.isSection("fields") and state["fields"].isSet("phi")) {
@@ -338,7 +341,8 @@ void EvolvePressure::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    ddt(P) += (2. / 3) * FV::Div_par_K_Grad_par(kappa_par, T, false);
+    conduction_div = (2. / 3) * FV::Div_par_K_Grad_par(kappa_par, T, false);   // [W/m3]
+    ddt(P) += conduction_div;
   }
 
   if (hyper_z > 0.) {
@@ -436,6 +440,15 @@ void EvolvePressure::outputVars(Options& state) {
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});
+
+      set_with_attrs(state[std::string("ConductionDiv_") + name + "_par"], conduction_div * 3/2,
+                     {{"time_dimension", "t"},
+                      {"units", "W m^-3"},
+                      {"conversion", Pnorm * Omega_ci},
+                      {"long_name", name + " parallel energy flow divergence due to heat conduction"},
+                      {"species", name},
+                      {"source", "evolve_pressure"}});
+
     }
     set_with_attrs(state[std::string("T") + name], T,
                    {{"time_dimension", "t"},

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -441,7 +441,7 @@ void EvolvePressure::outputVars(Options& state) {
                       {"species", name},
                       {"source", "evolve_pressure"}});
 
-      set_with_attrs(state[std::string("ConductionDiv_") + name + "_par"], conduction_div * 3/2,
+      set_with_attrs(state[std::string("div_cond_par_") + name], conduction_div * 3/2,
                      {{"time_dimension", "t"},
                       {"units", "W m^-3"},
                       {"conversion", Pnorm * Omega_ci},


### PR DESCRIPTION
As per the title. The user can integrate it along a 1D domain by using `(cond_div_par_e * dv).sum("pos")`

@PoloidalLloyd is this what you were also trying to do?