### PR TITLE
WIP: Multiple improvements to sheath boundary and energy balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ BOUT.settings
 *~
 .DS_Store
 /build*
+/docs/build/*

--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -835,6 +835,157 @@ Component boundary conditions
 Hermes-3 includes additional boundary conditions whose complexity requires their implementation
 as components. They may overwrite simple boundary conditions and must be set in the same way as other components.
 
+.. _sheath_boundary_simple:
+
+sheath_boundary_simple
+^^^^^^^^^^^^^^^
+
+This is a top-level component which determines the conditions and sources at the divertor target. 
+First, density, temperature and pressure are extrapolated into the target boundary.
+The extrapolation method for each can be user set, e.g. `density_boundary_mode`. At the moment, 
+the available modes are:
+
+- 0: LimitFree
+   An exponential extrapolation for decreasing quantities and a Neumann boundary for increasing
+   quantities. It is inconsistent between increasing and decreasing values and is not recommended
+   unless you have a reason to use it - it's legacy behaviour.
+
+- 1: ExponentialFree
+   An exponential extrapolation. It is more consistent than LimitFree and has the advantage of 
+   inherently preventing negative values at the target. This is the default and is recommended for most cases.
+   It is defined as :math:`guard = (last)^2 / previous`
+
+- 2: LinearFree
+   A linear extrapolation. It can lead to negative values at the target. However, it is the most 
+   consistent (the linear extrapolation is what second order differencing reduces to at the wall) and has been shown to 
+   reduce "zigzags" or "squiggles" near the target which are common in cell centered codes. Use only
+   if you have a particular reason to care about this.
+   It's defined as :math:`guard = 2 * last - previous`.
+
+In the above definitions, `last`, `previous` and `guard` refer to the final domain cell, the penultimate 
+domain cell and the guard cell respectively. The value at the target is defined to be 
+an interpolation between the last and guard cells, i.e:
+
+.. math::
+   \begin{aligned}
+   target = (last + guard)/2
+   \end{aligned}
+
+After the initial extrapolation, the sheath velocity is set to greater or equal to Bohm speed as according
+to Stangeby, eq. 2.55b, with temperature in eV:
+
+.. math::
+   \begin{aligned}
+   v_{i}^{sheath} \geq [(e T_{e} + \gamma e T_{i})/m_{i}]^{1/2}
+   \end{aligned}
+
+where :math:`\gamma` is the ion polytropic coefficient, which is set to 1 by default as per SOLPS-ITER.
+The electron velocity is calculated from the potential:
+
+.. math::
+   \begin{aligned}
+   \phi^{sheath} &= T_{e} \  ln \biggl[ \sqrt{ T_{e} / (2 \pi m_e) \cdot (1 - G_{e}) \cdot n_{e} / \Gamma_{i}^{tot}} \biggr]   \\ 
+   v_{e}^{sheath} &= -\sqrt{ T_{e} / 2 \pi m_e} \cdot (1-G_{e}) \cdot e^{(- \frac{\phi_{sheath} - \phi_{wall}} {T_{e}})}
+   \end{aligned}
+
+Where :math:`\Gamma_{i}^{tot}` is the total ion particle flux across all species, :math:`G_{e}` is the electron secondary
+emission coefficient (default 1) and :math:`\phi_{wall}` is the wall potential (default 0). Both can be user-set through the
+options `secondary_electron_coef` and `wall_potential`, respectively.
+
+
+Hermes-3 allows the pressure and momentum equations to advect internal and 
+kinetic energy out of the sheath, but disables the conduction term, so before applying any sheath boundary condition,
+the "underlying" sheath heat flux is:
+
+.. math::
+   \begin{aligned}
+   q_{i}^{sheath} &= n_{i} v_{i} (\frac{5}{2} e T_{i}n_{i} + \frac{1}{2} m_i v_{i}^{2})
+
+   q_{e}^{sheath} &= n_{e} v_{e} (\frac{5}{2} e T_{e}n_{e} + \frac{1}{2} m_e v_{e}^{2})
+   \end{aligned}
+
+With both of the above definitions following Stangeby (eqns. 9.61 and 9.63) with the addition of electron kinetic
+energy, and where each variable is evaluated at the sheath (target). Continuing from Stangeby (eqs. 2.89 and 2.94), 
+the above can be represented as the internal energy multiplied by the sheath heat transfer coefficient:
+
+.. math::
+   \begin{aligned}
+   q_{i}^{sheath} &= n_{i} v_{i} \gamma_{i} (e T_{i}n_{i})
+   q_{e}^{sheath} &= n_{e} v_{e} \gamma_{e} (e T_{e}n_{e})
+   \end{aligned}
+
+Where :math:`\gamma_{i}` and :math:`\gamma_{e}` are the **total** ion and electron sheath heat transfer coefficients 
+and are user set through the options `gamma_i` and `gamma_e`. The easiest way to calculate the sheath heat flux leaving the model
+is to use this form of the equations.
+
+Assuming :math:`T_e = T_i`, the "underlying" heat flux corresponds to :math:`\gamma_{i} = 3.5` and :math:`\gamma_{e} = 3.5`.
+In order to facilitate a user-set total gamma, `sheath_boundary_simple` creates a heat sink (or source) 
+based on the difference between the required and "underlying" coefficient:
+
+.. math::
+   \begin{aligned}
+   q_{i}^{additional} &= \gamma_i T_i n_i v_i - (2.5 T_{i} + \frac{1}{2} m_i v_{i}^{2}) n_{i} v_{i}
+
+   q_{e}^{additional} &= \gamma_e T_e n_e v_e - (2.5 T_{e} + \frac{1}{2} m_e v_{e}^{2}) n_{e} v_{e}
+   \end{aligned}
+
+The sheath ion particle flux is facilitated through the underlying density equation advecting density out of the domain:
+
+.. math::
+   \begin{aligned}
+   \Gamma_{i}^{sheath}&= n_{i} v_{i}
+   \end{aligned}
+
+If recycling is enabled, a corresponding recycled neutral particle source is set up in the `recycling` component.
+
+**Usage and other options**
+
+To enable the boundary condition, add `sheath_boundary_simple` to the list of components. The settings are
+accessed through the component header. Use the `lower_y` and `upper_y` flags to enable the boundary on each 
+end of the domain, where `lower` and `upper` refer to the start and end of the poloidal index space, respectively:
+
+.. code-block:: ini
+
+   [hermes]
+   components = d+, sheath_boundary_simple
+
+   [d+]
+   type = noflow_boundary
+
+   noflow_lower_y = true   # This is the default
+   noflow_upper_y = false  # Turn off no-flow at upper y for d+ species
+
+   [sheath_boundary_simple]
+   lower_y = false         # Turn off sheath lower boundary for all species
+   upper_y = true
+
+It can be useful to run the code without neutrals/recycling in order to simplify the physics, e.g. for debugging.
+However, just disabling `recycling` would result in mach flows throughout the whole domain due to the lack of the
+neutral source. To avoid this, you can set `no_flow = true` under `sheath_boundary_simple`. This will set the ion 
+velocity to zero for the particle flux but will keep it at the :math: `v_i \geq c_{bohm}` condition for the heat flux.
+
+By default, the Bohm condition is imposed on the target by the Lax flux. This allows the code to have a small amount 
+of slack, resulting in a not-perfectly-exact setting but a smoother and more stable solution. For debugging, you can
+disable this behaviour and fix the Bohm condition explicitly. This can be done by setting `fix_momentum_boundary_flux` 
+to `true` in the `evolve_pressure` component. Note that this has been observed to increase numerical oscillations near
+the boundary and is not recommended.
+
+.. _sheath_boundary:
+
+sheath_boundary
+^^^^^^^^^^^^^^^
+
+This is intended to give a more rigorous treatment when simulating multi-species, as well as to add models for
+:math:`gamma_e` and :math:`gamma_i` based on Tskhakaya 2005. As this component is considerably more complex, the 
+development may lag behind `sheath_boundary_simple`.
+
+.. _sheath_boundary_insulating:
+
+sheath_boundary_insulating
+^^^^^^^^^^^^^^^
+
+Not yet documented.
+
 .. _noflow_boundary:
 
 noflow_boundary

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -222,7 +222,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
             // Add flux due to difference in boundary values
             flux = s.R * sv.R * sv.R // Use right cell edge values
               + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
-              * (s.R * sv.R - n_mid * v_mid);
+              * n_mid * (sv.R - v_mid); // Damp differences in velocity, not flux
           }
         } else {
           // Maximum wave speed in the two cells
@@ -251,7 +251,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
             flux =
               s.L * sv.L * sv.L
               - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
-              * (s.L * sv.L - n_mid * v_mid);
+              * n_mid * (sv.L - v_mid);
           }
         } else {
           // Maximum wave speed in the two cells

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -65,6 +65,10 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
 /// Version of function that returns flows
 const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f, Field3D& flux_xlow, Field3D& flux_ylow);
 
+/// Version with energy flow diagnostic
+const Field3D Div_par_K_Grad_par_mod(const Field3D& k, const Field3D& f, Field3D& flow_ylow,
+                                     bool bndry_flux = true);
+
 namespace FV {
 
 /// Superbee limiter
@@ -203,27 +207,27 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
         // Right boundary
 
         // Calculate velocity at right boundary (y+1/2)
-        BoutReal vpar = 0.5 * (v(i, j, k) + v(i, j + 1, k));
+        BoutReal v_mid = 0.5 * (sv.c + sv.p);
+        // And mid-point density at right boundary
+        BoutReal n_mid = 0.5 * (s.c + s.p);
         BoutReal flux;
 
         if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
           // Last point in domain
 
-          BoutReal bndryval = 0.5 * (s.c + s.p);
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = bndryval * vpar * vpar;
+            flux = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux =
-                s.R * sv.R * sv.R
-                + BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j + 1, k)))
-                  * (s.R * sv.R - bndryval * vpar);
+            flux = s.R * sv.R * sv.R // Use right cell edge values
+              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
+              * (s.R * sv.R - n_mid * v_mid);
           }
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
-                                  fabs(v(i, j, k)), fabs(v(i, j + 1, k)));
+                                  fabs(sv.c), fabs(sv.p));
 
           flux = s.R * 0.5 * (sv.R + amax) * sv.R;
         }
@@ -234,25 +238,25 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
         ////////////////////////////////////////////
         // Calculate at left boundary
 
-        vpar = 0.5 * (v(i, j, k) + v(i, j - 1, k));
+        v_mid = 0.5 * (sv.c + sv.m);
+        n_mid = 0.5 * (s.c + s.m);
 
         if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
           // First point in domain
-          BoutReal bndryval = 0.5 * (s.c + s.m);
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = bndryval * vpar * vpar;
+            flux = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
             flux =
-                s.L * sv.L * sv.L
-                - BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j - 1, k)))
-                  * (s.L * sv.L - bndryval * vpar);
+              s.L * sv.L * sv.L
+              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
+              * (s.L * sv.L - n_mid * v_mid);
           }
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
-                                  fabs(v(i, j, k)), fabs(v(i, j - 1, k)));
+                                  fabs(sv.c), fabs(sv.m));
 
           flux = s.L * 0.5 * (sv.L - amax) * sv.L;
         }
@@ -264,6 +268,180 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
   }
   return fromFieldAligned(result, "RGN_NOBNDRY");
 }
+
+// Calculates viscous heating due to numerical momentum fluxes
+template <typename CellEdges = MC>
+const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
+                                  const Field3D& wave_speed_in, bool fixflux = true) {
+
+  ASSERT1(areFieldsCompatible(f_in, v_in));
+  ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
+
+  Mesh* mesh = f_in.getMesh();
+
+  CellEdges cellboundary;
+
+  /// Ensure that f, v and wave_speed are field aligned
+  Field3D f = toFieldAligned(f_in, "RGN_NOX");
+  Field3D v = toFieldAligned(v_in, "RGN_NOX");
+  Field3D wave_speed = toFieldAligned(wave_speed_in, "RGN_NOX");
+
+  Coordinates* coord = f_in.getCoordinates();
+
+  Field3D result{zeroFrom(f)};
+
+  // Only need one guard cell, so no need to communicate fluxes
+  // Instead calculate in guard cells to preserve fluxes
+  int ys = mesh->ystart - 1;
+  int ye = mesh->yend + 1;
+
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+
+    if (!mesh->firstY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cell to get fluxes consistent between processors
+      ys = mesh->ystart - 1;
+    } else {
+      // Don't include the boundary cell. Note that this implies special
+      // handling of boundaries later
+      ys = mesh->ystart;
+    }
+
+    if (!mesh->lastY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cells
+      ye = mesh->yend + 1;
+    } else {
+      // Not in boundary cells
+      ye = mesh->yend;
+    }
+
+    for (int j = ys; j <= ye; j++) {
+      // Pre-calculate factors which multiply fluxes
+
+      // For right cell boundaries
+      BoutReal common_factor = (coord->J(i, j) + coord->J(i, j + 1))
+                               / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
+
+      BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+
+      // For left cell boundaries
+      common_factor = (coord->J(i, j) + coord->J(i, j - 1))
+                      / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
+
+      BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+
+      for (int k = 0; k < mesh->LocalNz; k++) {
+
+        ////////////////////////////////////////////
+        // Reconstruct f at the cell faces
+        // This calculates s.R and s.L for the Right and Left
+        // face values on this cell
+
+        // Reconstruct f at the cell faces
+        Stencil1D s;
+        s.c = f(i, j, k);
+        s.m = f(i, j - 1, k);
+        s.p = f(i, j + 1, k);
+
+        cellboundary(s); // Calculate s.R and s.L
+
+        // Reconstruct v at the cell faces
+        Stencil1D sv;
+        sv.c = v(i, j, k);
+        sv.m = v(i, j - 1, k);
+        sv.p = v(i, j + 1, k);
+
+        cellboundary(sv);
+
+        ////////////////////////////////////////////
+        // Right boundary
+
+        // Calculate velocity at right boundary (y+1/2)
+        BoutReal v_mid = 0.5 * (sv.c + sv.p);
+        // And mid-point density at right boundary
+        BoutReal n_mid = 0.5 * (s.c + s.p);
+        BoutReal flux;
+
+        if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
+          // Last point in domain
+
+          // Expected loss of kinetic energy into boundary
+          // This is used in the sheath boundary condition to calculate
+          // energy losses.
+          BoutReal expected_ke = 0.5 * n_mid * v_mid * v_mid * v_mid;
+
+          if (fixflux) {
+            // Mid-point consistent with boundary conditions
+            // but kinetic energy loss will not match expected
+            // -> Adjust energy balance in pressure equation
+            flux = n_mid * v_mid * v_mid;
+          } else {
+            flux = s.R * sv.R * sv.R
+              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
+              * (s.R * sv.R - n_mid * v_mid);
+          }
+
+          // Assumes that density flux is fixed to boundary value
+          // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
+          BoutReal actual_ke = sv.c * flux - 0.5 * sv.c * sv.c * n_mid * v_mid;
+          
+          // Note: If the actual loss was higher than expected, then
+          //       plasma heating is needed to compensate
+          result(i, j, k) += (actual_ke - expected_ke) * flux_factor_rc;
+
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
+                                  fabs(sv.c), fabs(sv.p));
+
+          // Viscous heating due to relaxation of velocity towards midpoint
+          result(i, j, k) += (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
+          //output.write("Right {}: {} {} | {} | {}\n", j, sv.c, sv.R, v_mid, sv.p);
+          //output.write("Right {}: {}\n", j, (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc);
+        }
+
+        ////////////////////////////////////////////
+        // Calculate at left boundary
+
+        v_mid = 0.5 * (sv.c + sv.m);
+        n_mid = 0.5 * (s.c + s.m);
+
+        // Expected KE loss. Note minus sign because negative v into boundary
+        BoutReal expected_ke = - 0.5 * n_mid * v_mid * v_mid * v_mid;
+        
+        if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
+          // First point in domain
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = n_mid * v_mid * v_mid;
+          } else {
+            // Add flux due to difference in boundary values
+            flux =
+              s.L * sv.L * sv.L
+              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
+              * (s.L * sv.L - n_mid * v_mid);
+          }
+
+          // Assumes that density flux is fixed to boundary value
+          // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
+          BoutReal actual_ke = - sv.c * flux + 0.5 * sv.c * sv.c * n_mid * v_mid;
+
+          result(i, j, k) += (actual_ke - expected_ke) * flux_factor_lc;
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
+                                  fabs(sv.c), fabs(sv.m));
+
+          // Viscous heating due to relaxation
+          result(i, j, k) += (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
+          //output.write("Left {}: {} | {} | {} {}\n", j, sv.m, v_mid, sv.L, sv.c);
+          //output.write("Left {}: {}\n", j, (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc);
+        }
+      }
+    }
+  }
+  return fromFieldAligned(result, "RGN_NOBNDRY");
+}
+  
 /// Finite volume parallel divergence
 ///
 /// NOTE: Modified version, applies limiter to velocity and field
@@ -282,10 +460,14 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
 /// @param[in] fixflux     Fix the flux at the boundary to be the value at the
 ///                        midpoint (for boundary conditions)
 ///
+/// @param[out] flow_ylow    Flow at the lower Y cell boundary
+///                          Already includes area factor * flux
+///
 /// NB: Uses to/from FieldAligned coordinates
 template <typename CellEdges = MC>
 const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                          const Field3D& wave_speed_in, bool fixflux = true) {
+                          const Field3D& wave_speed_in,
+                          Field3D &flow_ylow, bool fixflux = true) {
 
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
   ASSERT1_FIELDS_COMPATIBLE(f_in, wave_speed_in);
@@ -309,6 +491,7 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
   Coordinates* coord = f_in.getCoordinates();
 
   Field3D result{zeroFrom(f)};
+  flow_ylow = zeroFrom(f);
 
   // Only need one guard cell, so no need to communicate fluxes
   // Instead calculate in guard cells to preserve fluxes
@@ -345,6 +528,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
       BoutReal flux_factor_rp =
           common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
 
+      BoutReal area_rp = common_factor * coord->dx(i, j + 1) * coord->dz(i, j + 1);
+      
       // For left cell boundaries
       common_factor = (coord->J(i, j) + coord->J(i, j - 1))
                       / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
@@ -352,6 +537,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
       BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
       BoutReal flux_factor_lm =
           common_factor / (coord->dy(i, j - 1) * coord->J(i, j - 1));
+
+      BoutReal area_lc = common_factor * coord->dx(i, j) * coord->dz(i, j);
 #endif
       for (int k = 0; k < mesh->LocalNz; k++) {
 #if BOUT_USE_METRIC_3D
@@ -359,11 +546,13 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
         BoutReal common_factor =
             (coord->J(i, j, k) + coord->J(i, j + 1, k))
             / (sqrt(coord->g_22(i, j, k)) + sqrt(coord->g_22(i, j + 1, k)));
-
+        
         BoutReal flux_factor_rc =
             common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
         BoutReal flux_factor_rp =
             common_factor / (coord->dy(i, j + 1, k) * coord->J(i, j + 1, k));
+
+        BoutReal area_rp = common_factor * coord->dx(i, j + 1, k) * coord->dz(i, j + 1, k);
 
         // For left cell boundaries
         common_factor = (coord->J(i, j, k) + coord->J(i, j - 1, k))
@@ -373,6 +562,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
             common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
         BoutReal flux_factor_lm =
             common_factor / (coord->dy(i, j - 1, k) * coord->J(i, j - 1, k));
+
+        BoutReal area_lc = common_factor * coord->dx(i, j, k) * coord->dz(i, j, k);
 #endif
 
         ////////////////////////////////////////////
@@ -416,8 +607,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
             // Add flux due to difference in boundary values
             flux = s.R * vpar + wave_speed(i, j, k) * (s.R - bndryval);
           }
-        } else {
 
+        } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
                                   fabs(v(i, j, k)), fabs(v(i, j + 1, k)));
@@ -427,6 +618,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 
         result(i, j, k) += flux * flux_factor_rc;
         result(i, j + 1, k) -= flux * flux_factor_rp;
+
+        flow_ylow(i, j + 1, k) += flux * area_rp;
 
         ////////////////////////////////////////////
         // Calculate at left boundary
@@ -453,8 +646,13 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 
         result(i, j, k) -= flux * flux_factor_lc;
         result(i, j - 1, k) += flux * flux_factor_lm;
+
+        flow_ylow(i, j, k) += flux * area_lc;
       }
     }
+  }
+  if (are_unaligned) {
+    flow_ylow = fromFieldAligned(flow_ylow, "RGN_NOBNDRY");
   }
   return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
 }

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -270,9 +270,11 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
 }
 
 // Calculates viscous heating due to numerical momentum fluxes
+// and flow of kinetic energy (in flow_ylow)
 template <typename CellEdges = MC>
 const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
-                                  const Field3D& wave_speed_in, bool fixflux = true) {
+                                  const Field3D& wave_speed_in, Field3D &flow_ylow,
+                                  bool fixflux = true) {
 
   ASSERT1(areFieldsCompatible(f_in, v_in));
   ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
@@ -289,6 +291,7 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
   Coordinates* coord = f_in.getCoordinates();
 
   Field3D result{zeroFrom(f)};
+  flow_ylow = zeroFrom(f);
 
   // Only need one guard cell, so no need to communicate fluxes
   // Instead calculate in guard cells to preserve fluxes
@@ -322,12 +325,14 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
                                / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
 
       BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal area_rp = common_factor * coord->dx(i, j + 1) * coord->dz(i, j + 1);
 
       // For left cell boundaries
       common_factor = (coord->J(i, j) + coord->J(i, j - 1))
                       / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
 
       BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal area_lc = common_factor * coord->dx(i, j) * coord->dz(i, j);
 
       for (int k = 0; k < mesh->LocalNz; k++) {
 
@@ -359,7 +364,6 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
         BoutReal v_mid = 0.5 * (sv.c + sv.p);
         // And mid-point density at right boundary
         BoutReal n_mid = 0.5 * (s.c + s.p);
-        BoutReal flux;
 
         if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
           // Last point in domain
@@ -369,24 +373,30 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
           // energy losses.
           BoutReal expected_ke = 0.5 * n_mid * v_mid * v_mid * v_mid;
 
+          BoutReal flux_mom;
           if (fixflux) {
             // Mid-point consistent with boundary conditions
             // but kinetic energy loss will not match expected
             // -> Adjust energy balance in pressure equation
-            flux = n_mid * v_mid * v_mid;
+            flux_mom = n_mid * v_mid * v_mid;
           } else {
-            flux = s.R * sv.R * sv.R
+            flux_mom = s.R * sv.R * sv.R
               + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
               * (s.R * sv.R - n_mid * v_mid);
           }
 
-          // Assumes that density flux is fixed to boundary value
+          // Assume that particle flux is fixed to boundary value
+          const BoutReal flux_part = n_mid * v_mid;
+
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
-          BoutReal actual_ke = sv.c * flux - 0.5 * sv.c * sv.c * n_mid * v_mid;
+          BoutReal actual_ke = sv.c * flux_mom - 0.5 * sv.c * sv.c * flux_part;
           
           // Note: If the actual loss was higher than expected, then
           //       plasma heating is needed to compensate
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_rc;
+
+          // Final flow through boundary is the expected value
+          flow_ylow(i, j + 1, k) += expected_ke * area_rp; //expected_ke * area_rp;
 
         } else {
           // Maximum wave speed in the two cells
@@ -395,8 +405,14 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 
           // Viscous heating due to relaxation of velocity towards midpoint
           result(i, j, k) += (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
-          //output.write("Right {}: {} {} | {} | {}\n", j, sv.c, sv.R, v_mid, sv.p);
-          //output.write("Right {}: {}\n", j, (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc);
+
+          // Kinetic energy flow into next cell.
+          // Note: Different from flow out of this cell; the difference
+          //       is in the viscous heating.
+          BoutReal flux_part = s.R * 0.5 * (sv.R + amax);
+          BoutReal flux_mom = flux_part * sv.R;
+
+          flow_ylow(i, j + 1, k) += (sv.p * flux_mom - 0.5 * SQ(sv.p) * flux_part) * area_rp;
         }
 
         ////////////////////////////////////////////
@@ -410,22 +426,27 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
         
         if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
           // First point in domain
+          BoutReal flux_mom;
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = n_mid * v_mid * v_mid;
+            flux_mom = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux =
+            flux_mom =
               s.L * sv.L * sv.L
               - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
               * (s.L * sv.L - n_mid * v_mid);
           }
 
-          // Assumes that density flux is fixed to boundary value
+          // Assume that density flux is fixed to boundary value
+          const BoutReal flux_part = n_mid * v_mid;
+
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
-          BoutReal actual_ke = - sv.c * flux + 0.5 * sv.c * sv.c * n_mid * v_mid;
+          BoutReal actual_ke = - sv.c * flux_mom + 0.5 * sv.c * sv.c * flux_part;
 
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_lc;
+
+          flow_ylow(i, j, k) -= expected_ke * area_lc;
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
@@ -433,12 +454,19 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 
           // Viscous heating due to relaxation
           result(i, j, k) += (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
-          //output.write("Left {}: {} | {} | {} {}\n", j, sv.m, v_mid, sv.L, sv.c);
-          //output.write("Left {}: {}\n", j, (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc);
+
+          // Kinetic energy flow into this cell.
+          // Note: Different from flow out of left cell; the difference
+          //       is in the viscous heating.
+          BoutReal flux_part = s.L * 0.5 * (sv.L - amax);
+          BoutReal flux_mom = flux_part * sv.L;
+
+          flow_ylow(i, j, k) += (sv.c * flux_mom - 0.5 * SQ(sv.c) * flux_part) * area_lc;
         }
       }
     }
   }
+  flow_ylow = fromFieldAligned(flow_ylow, "RGN_NOBNDRY");
   return fromFieldAligned(result, "RGN_NOBNDRY");
 }
   

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -109,6 +109,7 @@ private:
   BoutReal time_normalisation; ///< Normalisation factor [s]
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+  Field3D flow_ylow_conduction; ///< Conduction energy flow diagnostics
 
   bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -109,6 +109,10 @@ private:
   BoutReal time_normalisation; ///< Normalisation factor [s]
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+
+  bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
+  bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?
+  Field3D Sp_nvh; ///< Pressure source due to artificial viscosity
 };
 
 namespace {

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -110,6 +110,7 @@ private:
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
   Field3D flow_ylow_conduction; ///< Conduction energy flow diagnostics
+  Field3D flow_ylow_kinetic;    ///< Parallel flow of kinetic energy
 
   bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -62,6 +62,9 @@ private:
 
   bool output_ddt; ///< Save time derivatives?
   bool diagnose; ///< Save additional diagnostics?
+
+  Field3D particle_flow_ylow; ///< Flow diagnostics
+  Field3D energy_flow_ylow;
 };
 
 namespace {

--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -87,6 +87,8 @@ private:
   bool always_set_phi; ///< Set phi field?
 
   Field3D wall_potential; ///< Voltage of the wall. Normalised units.
+
+  bool no_flow; ///< No flow speed, only remove energy
 };
 
 namespace {

--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -89,6 +89,8 @@ private:
   Field3D wall_potential; ///< Voltage of the wall. Normalised units.
 
   bool no_flow; ///< No flow speed, only remove energy
+
+  BoutReal density_boundary_mode, pressure_boundary_mode, temperature_boundary_mode; ///< BC mode: 0=LimitFree, 1=ExponentialFree, 2=LinearFree
 };
 
 namespace {

--- a/src/electron_force_balance.cxx
+++ b/src/electron_force_balance.cxx
@@ -14,9 +14,7 @@ void ElectronForceBalance::transform(Options &state) {
     throw BoutException("Cannot calculate potential and use electron force balance\n");
   }
 
-  // Get the electron pressure
-  // Note: The pressure boundary can be set in sheath boundary condition
-  //       which depends on the electron velocity being set here first.
+  // Get the electron pressure, with boundary condition applied
   Options& electrons = state["species"]["e"];
   Field3D Pe = GET_VALUE(Field3D, electrons["pressure"]);
   Field3D Ne = GET_NOBOUNDARY(Field3D, electrons["density"]);

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -229,7 +229,7 @@ void EvolveDensity::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave);
+    ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave, flow_ylow);
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
@@ -303,7 +303,7 @@ void EvolveDensity::finally(const Options& state) {
       flow_xlow = get<Field3D>(species["particle_flow_xlow"]);
     }
     if (species.isSet("particle_flow_ylow")) {
-      flow_ylow = get<Field3D>(species["particle_flow_ylow"]);
+      flow_ylow += get<Field3D>(species["particle_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -357,7 +357,7 @@ void EvolveDensity::outputVars(Options& state) {
     auto rho_s0 = get<BoutReal>(state["rho_s0"]);
 
     if (flow_xlow.isAllocated()) {
-      set_with_attrs(state[std::string("ParticleFlow_") + name + std::string("_xlow")], flow_xlow,
+      set_with_attrs(state[fmt::format("pf{}_tot_xlow", name)], flow_xlow,
                    {{"time_dimension", "t"},
                     {"units", "s^-1"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
@@ -367,7 +367,7 @@ void EvolveDensity::outputVars(Options& state) {
                     {"source", "evolve_density"}});
     }
     if (flow_ylow.isAllocated()) {
-      set_with_attrs(state[std::string("ParticleFlow_") + name + std::string("_ylow")], flow_ylow,
+      set_with_attrs(state[fmt::format("pf{}_tot_ylow", name)], flow_ylow,
                    {{"time_dimension", "t"},
                     {"units", "s^-1"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -475,7 +475,7 @@ void EvolveEnergy::outputVars(Options& state) {
                     {"source", "evolve_energy"}});
 
     if (flow_xlow.isAllocated()) {
-      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_xlow")], flow_xlow,
+      set_with_attrs(state[fmt::format("ef{}_tot_xlow", name)], flow_xlow,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
@@ -485,7 +485,7 @@ void EvolveEnergy::outputVars(Options& state) {
                     {"source", "evolve_energy"}});
     }
     if (flow_ylow.isAllocated()) {
-      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+      set_with_attrs(state[fmt::format("ef{}_tot_ylow", name)], flow_ylow,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -256,7 +256,7 @@ void EvolveEnergy::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave);
+    ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave, flow_ylow);
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
@@ -327,7 +327,9 @@ void EvolveEnergy::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    ddt(E) += FV::Div_par_K_Grad_par(kappa_par, T, false);
+    Field3D flow_ylow_conduction;
+    ddt(E) += Div_par_K_Grad_par_mod(kappa_par, T, flow_ylow_conduction, false);
+    flow_ylow += flow_ylow_conduction;
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term. The operator splits into 4 pieces:
@@ -390,7 +392,7 @@ void EvolveEnergy::finally(const Options& state) {
       flow_xlow = get<Field3D>(species["energy_flow_xlow"]);
     }
     if (species.isSet("energy_flow_ylow")) {
-      flow_ylow = get<Field3D>(species["energy_flow_ylow"]);
+      flow_ylow += get<Field3D>(species["energy_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -289,7 +289,7 @@ void EvolveMomentum::outputVars(Options &state) {
     auto rho_s0 = get<BoutReal>(state["rho_s0"]);
 
     if (flow_xlow.isAllocated()) {
-      set_with_attrs(state[std::string("MomentumFlow_") + name + std::string("_xlow")], flow_xlow,
+      set_with_attrs(state[fmt::format("mf{}_tot_xlow", name)], flow_xlow,
                    {{"time_dimension", "t"},
                     {"units", "N"},
                     {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
@@ -299,7 +299,7 @@ void EvolveMomentum::outputVars(Options &state) {
                     {"source", "evolve_momentum"}});
     }
     if (flow_ylow.isAllocated()) {
-      set_with_attrs(state[std::string("MomentumFlow_") + name + std::string("_ylow")], flow_ylow,
+      set_with_attrs(state[fmt::format("mf{}_tot_ylow", name)], flow_ylow,
                    {{"time_dimension", "t"},
                     {"units", "N"},
                     {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -137,9 +137,11 @@ void EvolveMomentum::finally(const Options &state) {
           get<Field3D>(species["density_source"])
           : zeroFrom(Apar);
 
+        Field3D dummy;
+        
         // This is Z * Apar * dn/dt, keeping just leading order terms
         Field3D dndt = density_source
-          - FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave)
+          - FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave, dummy)
           - Div_n_bxGrad_f_B_XPPM(N, phi, bndry_flux, poloidal_flows, true)
           ;
         if (low_n_diffuse_perp) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -364,7 +364,7 @@ void EvolvePressure::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    Field3D flow_ylow_conduction;
+    flow_ylow_conduction;
     ddt(P) += (2. / 3) * Div_par_K_Grad_par_mod(kappa_par, T, flow_ylow_conduction, false);
     flow_ylow += flow_ylow_conduction;
 
@@ -526,6 +526,15 @@ void EvolvePressure::outputVars(Options& state) {
     }
     if (flow_ylow.isAllocated()) {
       set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through Y cell face. Note: May be incomplete."},
+                    {"species", name},
+                    {"source", "evolve_pressure"}});
+                    
+      set_with_attrs(state[std::string("ConductionFlow_") + name + std::string("_ylow")], flow_ylow_conduction,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -520,7 +520,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"source", "evolve_pressure"}});
 
     if (flow_xlow.isAllocated()) {
-      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_xlow")], flow_xlow,
+      set_with_attrs(state[fmt::format("ef{}_tot_xlow", name)], flow_xlow,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
@@ -530,7 +530,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"source", "evolve_pressure"}});
     }
     if (flow_ylow.isAllocated()) {
-      set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+      set_with_attrs(state[fmt::format("ef{}_tot_ylow", name)], flow_ylow,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
@@ -539,7 +539,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"species", name},
                     {"source", "evolve_pressure"}});
                     
-      set_with_attrs(state[std::string("ConductionFlow_") + name + std::string("_ylow")], flow_ylow_conduction,
+      set_with_attrs(state[fmt::format("ef{}_cond_ylow", name)], flow_ylow_conduction,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
@@ -548,7 +548,7 @@ void EvolvePressure::outputVars(Options& state) {
                     {"species", name},
                     {"source", "evolve_pressure"}});
 
-      set_with_attrs(state[std::string("KineticFlow_") + name + std::string("_ylow")], flow_ylow_kinetic,
+      set_with_attrs(state[fmt::format("ef{}_kin_ylow", name)], flow_ylow_kinetic,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -559,12 +559,12 @@ void EvolvePressure::outputVars(Options& state) {
     }
 
     if (numerical_viscous_heating) {
-      set_with_attrs(state[std::string("SP") + name + std::string("_nvh")], Sp_nvh,
+      set_with_attrs(state[std::string("E") + name + std::string("_nvh")], Sp_nvh * 3/.2,
                    {{"time_dimension", "t"},
-                    {"units", "Pa s^-1"},
+                    {"units", "W"},
                     {"conversion", Pnorm * Omega_ci},
-                    {"standard_name", "pressure source"},
-                    {"long_name", name + " pressure source from numerical viscous heating"},
+                    {"standard_name", "energy source"},
+                    {"long_name", name + " energy source from numerical viscous heating"},
                     {"species", name},
                     {"source", "evolve_pressure"}});
     }

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -226,6 +226,7 @@ void EvolvePressure::finally(const Options& state) {
 
   // Get updated pressure and temperature with boundary conditions
   // Note: Retain pressures which fall below zero
+  P.clearParallelSlices();
   P.setBoundaryTo(get<Field3D>(species["pressure"]));
   Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
 

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -330,7 +330,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
-  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed) // Advection
+  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed, particle_flow_ylow) // Advection
             + FV::Div_a_Grad_perp(DnnNn, logPnlim) // Perpendicular diffusion
       ;
 
@@ -382,12 +382,14 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed) // Advection
+  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed, energy_flow_ylow) // Advection
             - (2. / 3) * Pn * Div_par(Vn)                          // Compression
             + FV::Div_a_Grad_perp(DnnPn, logPnlim) // Perpendicular diffusion
             + FV::Div_a_Grad_perp(DnnNn, Tn)       // Conduction
             + FV::Div_par_K_Grad_par(DnnNn, Tn)    // Parallel conduction
       ;
+
+  energy_flow_ylow *= 5./2;
 
   Sp = pressure_source;
   if (localstate.isSet("energy_source")) {

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -542,7 +542,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
-          q -= (2.5 * tisheath + 0.5 * Mi * C_i_sq) * nisheath * visheath;
+          q -= (2.5 * tisheath + 0.5 * Mi * SQ(visheath)) * nisheath * visheath;
 
           // Multiply by cell area to get power
           BoutReal heatflow = q * (coord->J[i] + coord->J[im])
@@ -605,7 +605,7 @@ void SheathBoundarySimple::transform(Options& state) {
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
           // Note: Here this is positive because visheath > 0
-          q -= (2.5 * tisheath + 0.5 * SQ(visheath) * Mi) * nisheath * visheath;
+          q -= (2.5 * tisheath + 0.5 * Mi * SQ(visheath)) * nisheath * visheath;
 
           // Multiply by cell area to get power
           BoutReal heatflow = q * (coord->J[i] + coord->J[ip])

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -128,15 +128,15 @@ SheathBoundarySimple::SheathBoundarySimple(std::string name, Options& alloptions
 
   density_boundary_mode = options["density_boundary_mode"]
     .doc("BC mode: 0=LimitFree, 1=ExponentialFree, 2=LinearFree")
-    .withDefault<BoutReal>(0);
+    .withDefault<BoutReal>(1);
 
   pressure_boundary_mode = options["pressure_boundary_mode"]
     .doc("BC mode: 0=LimitFree, 1=ExponentialFree, 2=LinearFree")
-    .withDefault<BoutReal>(0);
+    .withDefault<BoutReal>(1);
 
   temperature_boundary_mode = options["temperature_boundary_mode"]
     .doc("BC mode: 0=LimitFree, 1=ExponentialFree, 2=LinearFree")
-    .withDefault<BoutReal>(0);
+    .withDefault<BoutReal>(1);
 
   
 }

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -338,13 +338,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
         electron_energy_source[i] += power;
 
-        // Total heat flux for diagnostic purposes
-        q = gamma_e * tesheath  * nesheath * vesheath;   // Wm-2
-        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-        electron_sheath_power_ylow[i] += heatflow;       // lower Y, so power placed in final domain cell 
-                      
+        electron_sheath_power_ylow[i] += heatflow * coord->dx[i] * coord->dz[i];       // lower Y, so power placed in final domain cell 
       }
     }
   }
@@ -398,12 +392,8 @@ void SheathBoundarySimple::transform(Options& state) {
 
         electron_energy_source[i] -= power;
 
-        // Total heat flux for diagnostic purposes
-        q = gamma_e * tesheath * nesheath * vesheath;  // Wm-2
-        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-        
-        electron_sheath_power_ylow[ip] -= heatflow;    // upper Y, so power placed in first guard cell
+        // Diagnostic contains energy removed in the sheath
+        electron_sheath_power_ylow[ip] += heatflow * coord->dx[i] * coord->dz[i];    // upper Y, so power placed in first guard cell
       }
     }
   }
@@ -535,12 +525,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           energy_source[i] += power;
 
-          // Calculation of total heat flux for diagnostic purposes
-          q = gamma_i * tisheath * nisheath * visheath;   // Wm-2
-          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-          ion_sheath_power_ylow[i] += heatflow;      // lower Y, so power placed in final domain cell
+          ion_sheath_power_ylow[i] += heatflow * coord->dx[i] * coord->dz[i];      // lower Y, so power placed in final domain cell
         }
       }
     }
@@ -600,18 +585,13 @@ void SheathBoundarySimple::transform(Options& state) {
 
           energy_source[i] -= power; // Note: Sign negative because power > 0
 
-          // Calculation of total heat flux for diagnostic purposes
-          q = gamma_i * tisheath * nisheath * visheath;
-          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-          ion_sheath_power_ylow[ip] += heatflow;       // Upper Y, so power placed in first guard cell
+          ion_sheath_power_ylow[ip] += heatflow * coord->dx[i] * coord->dz[i];       // Upper Y, so power placed in first guard cell
         }
       }
-      
     }
     // Finished boundary conditions for this species
     // Put the modified fields back into the state.
+
     Ni.clearParallelSlices();
     Ti.clearParallelSlices();
     Pi.clearParallelSlices();

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -166,6 +166,9 @@ void SheathBoundarySimple::transform(Options& state) {
       const Field3D Ti = getNoBoundary<Field3D>(species["temperature"]);
       const BoutReal Mi = getNoBoundary<BoutReal>(species["AA"]);
       const BoutReal Zi = getNoBoundary<BoutReal>(species["charge"]);
+      Field3D Vi = species.isSet("velocity")
+        ? toFieldAligned(getNoBoundary<Field3D>(species["velocity"]))
+        : zeroFrom(Ni);
 
       if (lower_y) {
         // Sum values, put result in mesh->ystart
@@ -193,7 +196,12 @@ void SheathBoundarySimple::transform(Options& state) {
             // Sound speed squared
             BoutReal C_i_sq = (sheath_ion_polytropic * tisheath + Zi * tesheath) / Mi;
 
-            ion_sum[i] += Zi * nisheath * sqrt(C_i_sq);
+            BoutReal visheath = -sqrt(C_i_sq);
+            if (Vi[i] < visheath) {
+              visheath = Vi[i];
+            }
+
+            ion_sum[i] -= Zi * nisheath * visheath;
           }
         }
       }
@@ -219,7 +227,12 @@ void SheathBoundarySimple::transform(Options& state) {
 
             BoutReal C_i_sq = (sheath_ion_polytropic * tisheath + Zi * tesheath) / Mi;
 
-            ion_sum[i] += Zi * nisheath * sqrt(C_i_sq);
+            BoutReal visheath = sqrt(C_i_sq);
+            if (Vi[i] > visheath) {
+              visheath = Vi[i];
+            }
+
+            ion_sum[i] += Zi * nisheath * visheath;
           }
         }
       }

--- a/src/upstream_density_feedback.cxx
+++ b/src/upstream_density_feedback.cxx
@@ -57,4 +57,13 @@ void UpstreamDensityFeedback::transform(Options& state) {
 
   // Scale the source and add to the species density source
   add(species["density_source"], source_multiplier * density_source_shape);
+
+  // Adding particles to a flowing plasma reduces its kinetic energy
+  // -> Increase internal energy
+  if (IS_SET_NOBOUNDARY(species["velocity"]) and IS_SET(species["AA"])) {
+    const Field3D V = GET_NOBOUNDARY(Field3D, species["velocity"]);
+    const BoutReal Mi = get<BoutReal>(species["AA"]);
+    // Internal energy source
+    add(species["energy_source"], 0.5 * Mi * SQ(V) * source_multiplier * density_source_shape);
+  }
 }


### PR DESCRIPTION
Working on power balance diagnostics in 1D test case. 

MK edit:
This one turned into quite a journey into resolving an energy imbalance which went as high as 20% for an attached case. There are several fixes, as well as improvements that minimise zigzags at the boundary (a phenomenon that all codes struggle with if they don't have staggered grids) and new diagnostics. The diagnostics allowed us to reach a milestone - the first proper total energy flux balance.

Summary of changes:
- https://github.com/bendudson/hermes-3/pull/248/commits/e371fc7e6aac6d4d915c06a3f57897a627ba63f0: Viscous heating due to the diffusion of kinetic energy caused by the Lax flux viscosity
- https://github.com/bendudson/hermes-3/pull/248/commits/50bff348e455b607c2a1fd7df6cf60bdc84232b7 and https://github.com/bendudson/hermes-3/pull/248/commits/a9223e8abf089026f9e81699ebb53dcde4afd140: The ion bit in `sheath_boundary_simple` was set to `Vi>=Cs`, but it was `Vi=Cs` in the sheath current and electron loops. This would've caused issues in supersonic sheaths.
- https://github.com/bendudson/hermes-3/pull/248/commits/dde009a74eb10cb345341c523f11a84f49d9a2e8: New flag to keep sheath heat transfer but prevent particles leaving the model. This is super useful for debugging as it allows physical conduction-limited conditions with no neutrals.
- https://github.com/bendudson/hermes-3/pull/248/commits/97a21fdfaeb5a1672a57d5dbb4261145bb195566: This caused the majority of our energy imbalance. Pe had parallelSlices inside it due to a missing line. parallelSlices are 3D parallel interpolations that live on cell boundaries. This was being picked up instead of the sheath boundary extrapolation, which is wrong.
- https://github.com/bendudson/hermes-3/pull/248/commits/a002f1aaf3a85c13f2472c81ed2b4f52455076fd: Turns out when you add just a source of density and not pressure, this actually causes an energy sink: this is because when we add `N`, we have terms to dilute the total energy $\frac{5}{2}N_i T_i + \frac{1}{2} m_i N_i V_i^2$. This is done in the pressure equation by a factor proportional to `P=N*T` and in the momentum equation by a factor proportional to `NVi = N_i * V_i`. But because kinetic energy is $V^2$, it ends up reducing more than intended. There is now a new correction term for this called `numerical_viscous_heating` which you can turn on or off.
- https://github.com/bendudson/hermes-3/pull/248/commits/0009f3f9f7a720893894f4c576d90acbc2278b1e: We can either set the sheath boundary values directly or let the Lax flux drive to them. If we do the latter, previously it targetted a flux. It turns out if you make it target a velocity instead, it causes fewer zigzags near the boundary. This makes sense as it's more consistent.
- https://github.com/bendudson/hermes-3/pull/248/commits/ff0349b53a5b15c5284c868f327b808fa14f10d4: By default, our sheath extrapolation was set to Neumann for increasing quantities and exponential free for decreasing quantities. This caused an inconsistency if temperature was decreasing but N and P were increasing into the boundary, which can happen. This commit adds an option to force free extrapolation. We also found that linear extrapolation slightly reduces the boundary zigzag, presumably because it's more consistent with the equations (second order one sided differencing at the wall reduces to a linear extrapolation). Caution - this can make density negative upon extrapolation. An exponential extrapolation prevents this. **The default has been changed to exponential extrapolation**.


This work is part of my comparison to ReMKiT1D.  Here is a comparison showing that a free extrapolation has the best match to Remkit (note - cell centre plot only and **no neutrals**):
![image](https://github.com/user-attachments/assets/e02e81ff-d2a2-4674-8c45-4fcd83e4dfe9)

Testing on 1D-recycling with neutrals enabled, we found that all of the myriad fixes actually increased oscillations at the boundary unless we let the Lax flux set our Bohm condition (this is enabled by default, you can disable it with `fix_sheath_boundary_flux`):
![image](https://github.com/user-attachments/assets/254bcb48-916b-4fce-b7e5-5eb6ea14f03b)

That last result has the following flux balance:
![image](https://github.com/user-attachments/assets/6211a6b1-8f65-4300-b9cc-ec20f62d5a85)

A perfect balance would see the top series (Total Flow) stay constant. It doesn't quite manage that due to the "squiggles" in momentum at the boundary. The next stage is to explore a suggestion from @tbody-cfs which he implemented in GRILLIX (https://github.com/bendudson/hermes-3/pull/257). For now we will leave this as-is.

Remaining actions:

- [x] Rename flow diagnostics
- [x] Decide whether `numerical_viscous_flux` should be on or off by default, and whether `fix_boundary_flux` should be tied to it (see commit comment)
- [x] Add documentation on `sheath_boundary_simple` 
- [x]  Change the default extrapolation to exponential extrapolation (no Neumann when quantity is increasing)




