### PR TITLE
Improved consistency in sheath_boundary_simple

### DIFF
--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -222,7 +222,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
             // Add flux due to difference in boundary values
             flux = s.R * sv.R * sv.R // Use right cell edge values
               + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
-              * (s.R * sv.R - n_mid * v_mid);
+              * n_mid * (sv.R - v_mid); // Damp differences in velocity, not flux
           }
         } else {
           // Maximum wave speed in the two cells
@@ -251,7 +251,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
             flux =
               s.L * sv.L * sv.L
               - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
-              * (s.L * sv.L - n_mid * v_mid);
+              * n_mid * (sv.L - v_mid);
           }
         } else {
           // Maximum wave speed in the two cells

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -65,6 +65,10 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
 /// Version of function that returns flows
 const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f, Field3D& flux_xlow, Field3D& flux_ylow);
 
+/// Version with energy flow diagnostic
+const Field3D Div_par_K_Grad_par_mod(const Field3D& k, const Field3D& f, Field3D& flow_ylow,
+                                     bool bndry_flux = true);
+
 namespace FV {
 
 /// Superbee limiter
@@ -203,27 +207,27 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
         // Right boundary
 
         // Calculate velocity at right boundary (y+1/2)
-        BoutReal vpar = 0.5 * (v(i, j, k) + v(i, j + 1, k));
+        BoutReal v_mid = 0.5 * (sv.c + sv.p);
+        // And mid-point density at right boundary
+        BoutReal n_mid = 0.5 * (s.c + s.p);
         BoutReal flux;
 
         if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
           // Last point in domain
 
-          BoutReal bndryval = 0.5 * (s.c + s.p);
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = bndryval * vpar * vpar;
+            flux = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux =
-                s.R * sv.R * sv.R
-                + BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j + 1, k)))
-                  * (s.R * sv.R - bndryval * vpar);
+            flux = s.R * sv.R * sv.R // Use right cell edge values
+              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
+              * (s.R * sv.R - n_mid * v_mid);
           }
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
-                                  fabs(v(i, j, k)), fabs(v(i, j + 1, k)));
+                                  fabs(sv.c), fabs(sv.p));
 
           flux = s.R * 0.5 * (sv.R + amax) * sv.R;
         }
@@ -234,25 +238,25 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
         ////////////////////////////////////////////
         // Calculate at left boundary
 
-        vpar = 0.5 * (v(i, j, k) + v(i, j - 1, k));
+        v_mid = 0.5 * (sv.c + sv.m);
+        n_mid = 0.5 * (s.c + s.m);
 
         if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
           // First point in domain
-          BoutReal bndryval = 0.5 * (s.c + s.m);
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = bndryval * vpar * vpar;
+            flux = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
             flux =
-                s.L * sv.L * sv.L
-                - BOUTMAX(wave_speed(i, j, k), fabs(v(i, j, k)), fabs(v(i, j - 1, k)))
-                  * (s.L * sv.L - bndryval * vpar);
+              s.L * sv.L * sv.L
+              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
+              * (s.L * sv.L - n_mid * v_mid);
           }
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
-                                  fabs(v(i, j, k)), fabs(v(i, j - 1, k)));
+                                  fabs(sv.c), fabs(sv.m));
 
           flux = s.L * 0.5 * (sv.L - amax) * sv.L;
         }
@@ -264,6 +268,180 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
   }
   return fromFieldAligned(result, "RGN_NOBNDRY");
 }
+
+// Calculates viscous heating due to numerical momentum fluxes
+template <typename CellEdges = MC>
+const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
+                                  const Field3D& wave_speed_in, bool fixflux = true) {
+
+  ASSERT1(areFieldsCompatible(f_in, v_in));
+  ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
+
+  Mesh* mesh = f_in.getMesh();
+
+  CellEdges cellboundary;
+
+  /// Ensure that f, v and wave_speed are field aligned
+  Field3D f = toFieldAligned(f_in, "RGN_NOX");
+  Field3D v = toFieldAligned(v_in, "RGN_NOX");
+  Field3D wave_speed = toFieldAligned(wave_speed_in, "RGN_NOX");
+
+  Coordinates* coord = f_in.getCoordinates();
+
+  Field3D result{zeroFrom(f)};
+
+  // Only need one guard cell, so no need to communicate fluxes
+  // Instead calculate in guard cells to preserve fluxes
+  int ys = mesh->ystart - 1;
+  int ye = mesh->yend + 1;
+
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+
+    if (!mesh->firstY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cell to get fluxes consistent between processors
+      ys = mesh->ystart - 1;
+    } else {
+      // Don't include the boundary cell. Note that this implies special
+      // handling of boundaries later
+      ys = mesh->ystart;
+    }
+
+    if (!mesh->lastY(i) || mesh->periodicY(i)) {
+      // Calculate in guard cells
+      ye = mesh->yend + 1;
+    } else {
+      // Not in boundary cells
+      ye = mesh->yend;
+    }
+
+    for (int j = ys; j <= ye; j++) {
+      // Pre-calculate factors which multiply fluxes
+
+      // For right cell boundaries
+      BoutReal common_factor = (coord->J(i, j) + coord->J(i, j + 1))
+                               / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
+
+      BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+
+      // For left cell boundaries
+      common_factor = (coord->J(i, j) + coord->J(i, j - 1))
+                      / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
+
+      BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+
+      for (int k = 0; k < mesh->LocalNz; k++) {
+
+        ////////////////////////////////////////////
+        // Reconstruct f at the cell faces
+        // This calculates s.R and s.L for the Right and Left
+        // face values on this cell
+
+        // Reconstruct f at the cell faces
+        Stencil1D s;
+        s.c = f(i, j, k);
+        s.m = f(i, j - 1, k);
+        s.p = f(i, j + 1, k);
+
+        cellboundary(s); // Calculate s.R and s.L
+
+        // Reconstruct v at the cell faces
+        Stencil1D sv;
+        sv.c = v(i, j, k);
+        sv.m = v(i, j - 1, k);
+        sv.p = v(i, j + 1, k);
+
+        cellboundary(sv);
+
+        ////////////////////////////////////////////
+        // Right boundary
+
+        // Calculate velocity at right boundary (y+1/2)
+        BoutReal v_mid = 0.5 * (sv.c + sv.p);
+        // And mid-point density at right boundary
+        BoutReal n_mid = 0.5 * (s.c + s.p);
+        BoutReal flux;
+
+        if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
+          // Last point in domain
+
+          // Expected loss of kinetic energy into boundary
+          // This is used in the sheath boundary condition to calculate
+          // energy losses.
+          BoutReal expected_ke = 0.5 * n_mid * v_mid * v_mid * v_mid;
+
+          if (fixflux) {
+            // Mid-point consistent with boundary conditions
+            // but kinetic energy loss will not match expected
+            // -> Adjust energy balance in pressure equation
+            flux = n_mid * v_mid * v_mid;
+          } else {
+            flux = s.R * sv.R * sv.R
+              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
+              * (s.R * sv.R - n_mid * v_mid);
+          }
+
+          // Assumes that density flux is fixed to boundary value
+          // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
+          BoutReal actual_ke = sv.c * flux - 0.5 * sv.c * sv.c * n_mid * v_mid;
+          
+          // Note: If the actual loss was higher than expected, then
+          //       plasma heating is needed to compensate
+          result(i, j, k) += (actual_ke - expected_ke) * flux_factor_rc;
+
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
+                                  fabs(sv.c), fabs(sv.p));
+
+          // Viscous heating due to relaxation of velocity towards midpoint
+          result(i, j, k) += (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
+          //output.write("Right {}: {} {} | {} | {}\n", j, sv.c, sv.R, v_mid, sv.p);
+          //output.write("Right {}: {}\n", j, (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc);
+        }
+
+        ////////////////////////////////////////////
+        // Calculate at left boundary
+
+        v_mid = 0.5 * (sv.c + sv.m);
+        n_mid = 0.5 * (s.c + s.m);
+
+        // Expected KE loss. Note minus sign because negative v into boundary
+        BoutReal expected_ke = - 0.5 * n_mid * v_mid * v_mid * v_mid;
+        
+        if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
+          // First point in domain
+          if (fixflux) {
+            // Use mid-point to be consistent with boundary conditions
+            flux = n_mid * v_mid * v_mid;
+          } else {
+            // Add flux due to difference in boundary values
+            flux =
+              s.L * sv.L * sv.L
+              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
+              * (s.L * sv.L - n_mid * v_mid);
+          }
+
+          // Assumes that density flux is fixed to boundary value
+          // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
+          BoutReal actual_ke = - sv.c * flux + 0.5 * sv.c * sv.c * n_mid * v_mid;
+
+          result(i, j, k) += (actual_ke - expected_ke) * flux_factor_lc;
+        } else {
+          // Maximum wave speed in the two cells
+          BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
+                                  fabs(sv.c), fabs(sv.m));
+
+          // Viscous heating due to relaxation
+          result(i, j, k) += (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
+          //output.write("Left {}: {} | {} | {} {}\n", j, sv.m, v_mid, sv.L, sv.c);
+          //output.write("Left {}: {}\n", j, (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc);
+        }
+      }
+    }
+  }
+  return fromFieldAligned(result, "RGN_NOBNDRY");
+}
+  
 /// Finite volume parallel divergence
 ///
 /// NOTE: Modified version, applies limiter to velocity and field
@@ -282,10 +460,14 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
 /// @param[in] fixflux     Fix the flux at the boundary to be the value at the
 ///                        midpoint (for boundary conditions)
 ///
+/// @param[out] flow_ylow    Flow at the lower Y cell boundary
+///                          Already includes area factor * flux
+///
 /// NB: Uses to/from FieldAligned coordinates
 template <typename CellEdges = MC>
 const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                          const Field3D& wave_speed_in, bool fixflux = true) {
+                          const Field3D& wave_speed_in,
+                          Field3D &flow_ylow, bool fixflux = true) {
 
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
   ASSERT1_FIELDS_COMPATIBLE(f_in, wave_speed_in);
@@ -309,6 +491,7 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
   Coordinates* coord = f_in.getCoordinates();
 
   Field3D result{zeroFrom(f)};
+  flow_ylow = zeroFrom(f);
 
   // Only need one guard cell, so no need to communicate fluxes
   // Instead calculate in guard cells to preserve fluxes
@@ -345,6 +528,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
       BoutReal flux_factor_rp =
           common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
 
+      BoutReal area_rp = common_factor * coord->dx(i, j + 1) * coord->dz(i, j + 1);
+      
       // For left cell boundaries
       common_factor = (coord->J(i, j) + coord->J(i, j - 1))
                       / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
@@ -352,6 +537,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
       BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
       BoutReal flux_factor_lm =
           common_factor / (coord->dy(i, j - 1) * coord->J(i, j - 1));
+
+      BoutReal area_lc = common_factor * coord->dx(i, j) * coord->dz(i, j);
 #endif
       for (int k = 0; k < mesh->LocalNz; k++) {
 #if BOUT_USE_METRIC_3D
@@ -359,11 +546,13 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
         BoutReal common_factor =
             (coord->J(i, j, k) + coord->J(i, j + 1, k))
             / (sqrt(coord->g_22(i, j, k)) + sqrt(coord->g_22(i, j + 1, k)));
-
+        
         BoutReal flux_factor_rc =
             common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
         BoutReal flux_factor_rp =
             common_factor / (coord->dy(i, j + 1, k) * coord->J(i, j + 1, k));
+
+        BoutReal area_rp = common_factor * coord->dx(i, j + 1, k) * coord->dz(i, j + 1, k);
 
         // For left cell boundaries
         common_factor = (coord->J(i, j, k) + coord->J(i, j - 1, k))
@@ -373,6 +562,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
             common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
         BoutReal flux_factor_lm =
             common_factor / (coord->dy(i, j - 1, k) * coord->J(i, j - 1, k));
+
+        BoutReal area_lc = common_factor * coord->dx(i, j, k) * coord->dz(i, j, k);
 #endif
 
         ////////////////////////////////////////////
@@ -416,8 +607,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
             // Add flux due to difference in boundary values
             flux = s.R * vpar + wave_speed(i, j, k) * (s.R - bndryval);
           }
-        } else {
 
+        } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j + 1, k),
                                   fabs(v(i, j, k)), fabs(v(i, j + 1, k)));
@@ -427,6 +618,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 
         result(i, j, k) += flux * flux_factor_rc;
         result(i, j + 1, k) -= flux * flux_factor_rp;
+
+        flow_ylow(i, j + 1, k) += flux * area_rp;
 
         ////////////////////////////////////////////
         // Calculate at left boundary
@@ -453,8 +646,13 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 
         result(i, j, k) -= flux * flux_factor_lc;
         result(i, j - 1, k) += flux * flux_factor_lm;
+
+        flow_ylow(i, j, k) += flux * area_lc;
       }
     }
+  }
+  if (are_unaligned) {
+    flow_ylow = fromFieldAligned(flow_ylow, "RGN_NOBNDRY");
   }
   return are_unaligned ? fromFieldAligned(result, "RGN_NOBNDRY") : result;
 }

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -270,9 +270,11 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
 }
 
 // Calculates viscous heating due to numerical momentum fluxes
+// and flow of kinetic energy (in flow_ylow)
 template <typename CellEdges = MC>
 const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
-                                  const Field3D& wave_speed_in, bool fixflux = true) {
+                                  const Field3D& wave_speed_in, Field3D &flow_ylow,
+                                  bool fixflux = true) {
 
   ASSERT1(areFieldsCompatible(f_in, v_in));
   ASSERT1(areFieldsCompatible(f_in, wave_speed_in));
@@ -289,6 +291,7 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
   Coordinates* coord = f_in.getCoordinates();
 
   Field3D result{zeroFrom(f)};
+  flow_ylow = zeroFrom(f);
 
   // Only need one guard cell, so no need to communicate fluxes
   // Instead calculate in guard cells to preserve fluxes
@@ -322,12 +325,14 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
                                / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j + 1)));
 
       BoutReal flux_factor_rc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal area_rp = common_factor * coord->dx(i, j + 1) * coord->dz(i, j + 1);
 
       // For left cell boundaries
       common_factor = (coord->J(i, j) + coord->J(i, j - 1))
                       / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
 
       BoutReal flux_factor_lc = common_factor / (coord->dy(i, j) * coord->J(i, j));
+      BoutReal area_lc = common_factor * coord->dx(i, j) * coord->dz(i, j);
 
       for (int k = 0; k < mesh->LocalNz; k++) {
 
@@ -359,7 +364,6 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
         BoutReal v_mid = 0.5 * (sv.c + sv.p);
         // And mid-point density at right boundary
         BoutReal n_mid = 0.5 * (s.c + s.p);
-        BoutReal flux;
 
         if (mesh->lastY(i) && (j == mesh->yend) && !mesh->periodicY(i)) {
           // Last point in domain
@@ -369,24 +373,30 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
           // energy losses.
           BoutReal expected_ke = 0.5 * n_mid * v_mid * v_mid * v_mid;
 
+          BoutReal flux_mom;
           if (fixflux) {
             // Mid-point consistent with boundary conditions
             // but kinetic energy loss will not match expected
             // -> Adjust energy balance in pressure equation
-            flux = n_mid * v_mid * v_mid;
+            flux_mom = n_mid * v_mid * v_mid;
           } else {
-            flux = s.R * sv.R * sv.R
+            flux_mom = s.R * sv.R * sv.R
               + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
               * (s.R * sv.R - n_mid * v_mid);
           }
 
-          // Assumes that density flux is fixed to boundary value
+          // Assume that particle flux is fixed to boundary value
+          const BoutReal flux_part = n_mid * v_mid;
+
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
-          BoutReal actual_ke = sv.c * flux - 0.5 * sv.c * sv.c * n_mid * v_mid;
+          BoutReal actual_ke = sv.c * flux_mom - 0.5 * sv.c * sv.c * flux_part;
           
           // Note: If the actual loss was higher than expected, then
           //       plasma heating is needed to compensate
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_rc;
+
+          // Final flow through boundary is the expected value
+          flow_ylow(i, j + 1, k) += expected_ke * area_rp; //expected_ke * area_rp;
 
         } else {
           // Maximum wave speed in the two cells
@@ -395,8 +405,14 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 
           // Viscous heating due to relaxation of velocity towards midpoint
           result(i, j, k) += (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
-          //output.write("Right {}: {} {} | {} | {}\n", j, sv.c, sv.R, v_mid, sv.p);
-          //output.write("Right {}: {}\n", j, (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc);
+
+          // Kinetic energy flow into next cell.
+          // Note: Different from flow out of this cell; the difference
+          //       is in the viscous heating.
+          BoutReal flux_part = s.R * 0.5 * (sv.R + amax);
+          BoutReal flux_mom = flux_part * sv.R;
+
+          flow_ylow(i, j + 1, k) += (sv.p * flux_mom - 0.5 * SQ(sv.p) * flux_part) * area_rp;
         }
 
         ////////////////////////////////////////////
@@ -410,22 +426,27 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
         
         if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
           // First point in domain
+          BoutReal flux_mom;
           if (fixflux) {
             // Use mid-point to be consistent with boundary conditions
-            flux = n_mid * v_mid * v_mid;
+            flux_mom = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux =
+            flux_mom =
               s.L * sv.L * sv.L
               - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
               * (s.L * sv.L - n_mid * v_mid);
           }
 
-          // Assumes that density flux is fixed to boundary value
+          // Assume that density flux is fixed to boundary value
+          const BoutReal flux_part = n_mid * v_mid;
+
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
-          BoutReal actual_ke = - sv.c * flux + 0.5 * sv.c * sv.c * n_mid * v_mid;
+          BoutReal actual_ke = - sv.c * flux_mom + 0.5 * sv.c * sv.c * flux_part;
 
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_lc;
+
+          flow_ylow(i, j, k) -= expected_ke * area_lc;
         } else {
           // Maximum wave speed in the two cells
           BoutReal amax = BOUTMAX(wave_speed(i, j, k), wave_speed(i, j - 1, k),
@@ -433,12 +454,19 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 
           // Viscous heating due to relaxation
           result(i, j, k) += (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
-          //output.write("Left {}: {} | {} | {} {}\n", j, sv.m, v_mid, sv.L, sv.c);
-          //output.write("Left {}: {}\n", j, (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc);
+
+          // Kinetic energy flow into this cell.
+          // Note: Different from flow out of left cell; the difference
+          //       is in the viscous heating.
+          BoutReal flux_part = s.L * 0.5 * (sv.L - amax);
+          BoutReal flux_mom = flux_part * sv.L;
+
+          flow_ylow(i, j, k) += (sv.c * flux_mom - 0.5 * SQ(sv.c) * flux_part) * area_lc;
         }
       }
     }
   }
+  flow_ylow = fromFieldAligned(flow_ylow, "RGN_NOBNDRY");
   return fromFieldAligned(result, "RGN_NOBNDRY");
 }
   

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -109,6 +109,7 @@ private:
   BoutReal time_normalisation; ///< Normalisation factor [s]
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+  Field3D flow_ylow_conduction; ///< Conduction energy flow diagnostics
 
   bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -109,6 +109,10 @@ private:
   BoutReal time_normalisation; ///< Normalisation factor [s]
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
+
+  bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
+  bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?
+  Field3D Sp_nvh; ///< Pressure source due to artificial viscosity
 };
 
 namespace {

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -110,6 +110,7 @@ private:
   bool source_time_dependent; ///< Is the input source time dependent?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics
   Field3D flow_ylow_conduction; ///< Conduction energy flow diagnostics
+  Field3D flow_ylow_kinetic;    ///< Parallel flow of kinetic energy
 
   bool numerical_viscous_heating; ///< Include heating due to numerical viscosity?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -62,6 +62,9 @@ private:
 
   bool output_ddt; ///< Save time derivatives?
   bool diagnose; ///< Save additional diagnostics?
+
+  Field3D particle_flow_ylow; ///< Flow diagnostics
+  Field3D energy_flow_ylow;
 };
 
 namespace {

--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -87,6 +87,8 @@ private:
   bool always_set_phi; ///< Set phi field?
 
   Field3D wall_potential; ///< Voltage of the wall. Normalised units.
+
+  bool no_flow; ///< No flow speed, only remove energy
 };
 
 namespace {

--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -89,6 +89,8 @@ private:
   Field3D wall_potential; ///< Voltage of the wall. Normalised units.
 
   bool no_flow; ///< No flow speed, only remove energy
+
+  BoutReal density_boundary_mode, pressure_boundary_mode, temperature_boundary_mode; ///< BC mode: 0=LimitFree, 1=ExponentialFree, 2=LinearFree
 };
 
 namespace {

--- a/src/electron_force_balance.cxx
+++ b/src/electron_force_balance.cxx
@@ -14,9 +14,7 @@ void ElectronForceBalance::transform(Options &state) {
     throw BoutException("Cannot calculate potential and use electron force balance\n");
   }
 
-  // Get the electron pressure
-  // Note: The pressure boundary can be set in sheath boundary condition
-  //       which depends on the electron velocity being set here first.
+  // Get the electron pressure, with boundary condition applied
   Options& electrons = state["species"]["e"];
   Field3D Pe = GET_VALUE(Field3D, electrons["pressure"]);
   Field3D Ne = GET_NOBOUNDARY(Field3D, electrons["density"]);

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -229,7 +229,7 @@ void EvolveDensity::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave);
+    ddt(N) -= FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave, flow_ylow);
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
@@ -303,7 +303,7 @@ void EvolveDensity::finally(const Options& state) {
       flow_xlow = get<Field3D>(species["particle_flow_xlow"]);
     }
     if (species.isSet("particle_flow_ylow")) {
-      flow_ylow = get<Field3D>(species["particle_flow_ylow"]);
+      flow_ylow += get<Field3D>(species["particle_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -256,7 +256,7 @@ void EvolveEnergy::finally(const Options& state) {
       fastest_wave = sqrt(T / AA);
     }
 
-    ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave);
+    ddt(E) -= FV::Div_par_mod<hermes::Limiter>(E + P, V, fastest_wave, flow_ylow);
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term
@@ -327,7 +327,9 @@ void EvolveEnergy::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    ddt(E) += FV::Div_par_K_Grad_par(kappa_par, T, false);
+    Field3D flow_ylow_conduction;
+    ddt(E) += Div_par_K_Grad_par_mod(kappa_par, T, flow_ylow_conduction, false);
+    flow_ylow += flow_ylow_conduction;
 
     if (state.isSection("fields") and state["fields"].isSet("Apar_flutter")) {
       // Magnetic flutter term. The operator splits into 4 pieces:
@@ -390,7 +392,7 @@ void EvolveEnergy::finally(const Options& state) {
       flow_xlow = get<Field3D>(species["energy_flow_xlow"]);
     }
     if (species.isSet("energy_flow_ylow")) {
-      flow_ylow = get<Field3D>(species["energy_flow_ylow"]);
+      flow_ylow += get<Field3D>(species["energy_flow_ylow"]);
     }
   }
 }

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -137,9 +137,11 @@ void EvolveMomentum::finally(const Options &state) {
           get<Field3D>(species["density_source"])
           : zeroFrom(Apar);
 
+        Field3D dummy;
+        
         // This is Z * Apar * dn/dt, keeping just leading order terms
         Field3D dndt = density_source
-          - FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave)
+          - FV::Div_par_mod<hermes::Limiter>(N, V, fastest_wave, dummy)
           - Div_n_bxGrad_f_B_XPPM(N, phi, bndry_flux, poloidal_flows, true)
           ;
         if (low_n_diffuse_perp) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -364,7 +364,7 @@ void EvolvePressure::finally(const Options& state) {
 
     // Note: Flux through boundary turned off, because sheath heat flux
     // is calculated and removed separately
-    Field3D flow_ylow_conduction;
+    flow_ylow_conduction;
     ddt(P) += (2. / 3) * Div_par_K_Grad_par_mod(kappa_par, T, flow_ylow_conduction, false);
     flow_ylow += flow_ylow_conduction;
 
@@ -526,6 +526,15 @@ void EvolvePressure::outputVars(Options& state) {
     }
     if (flow_ylow.isAllocated()) {
       set_with_attrs(state[std::string("EnergyFlow_") + name + std::string("_ylow")], flow_ylow,
+                   {{"time_dimension", "t"},
+                    {"units", "W"},
+                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                    {"standard_name", "power"},
+                    {"long_name", name + " power through Y cell face. Note: May be incomplete."},
+                    {"species", name},
+                    {"source", "evolve_pressure"}});
+                    
+      set_with_attrs(state[std::string("ConductionFlow_") + name + std::string("_ylow")], flow_ylow_conduction,
                    {{"time_dimension", "t"},
                     {"units", "W"},
                     {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -226,6 +226,7 @@ void EvolvePressure::finally(const Options& state) {
 
   // Get updated pressure and temperature with boundary conditions
   // Note: Retain pressures which fall below zero
+  P.clearParallelSlices();
   P.setBoundaryTo(get<Field3D>(species["pressure"]));
   Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
 

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -330,7 +330,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
-  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed) // Advection
+  ddt(Nn) = -FV::Div_par_mod<hermes::Limiter>(Nn, Vn, sound_speed, particle_flow_ylow) // Advection
             + FV::Div_a_Grad_perp(DnnNn, logPnlim) // Perpendicular diffusion
       ;
 
@@ -382,12 +382,14 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed) // Advection
+  ddt(Pn) = -FV::Div_par_mod<hermes::Limiter>(Pn, Vn, sound_speed, energy_flow_ylow) // Advection
             - (2. / 3) * Pn * Div_par(Vn)                          // Compression
             + FV::Div_a_Grad_perp(DnnPn, logPnlim) // Perpendicular diffusion
             + FV::Div_a_Grad_perp(DnnNn, Tn)       // Conduction
             + FV::Div_par_K_Grad_par(DnnNn, Tn)    // Parallel conduction
       ;
+
+  energy_flow_ylow *= 5./2;
 
   Sp = pressure_source;
   if (localstate.isSet("energy_source")) {

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -621,8 +621,8 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Set boundary conditions on flows
           Vi[ip] = 2. * visheath - Vi[i];
-          Ni[ip] = Ni[im] * Vi[im] / Vi[ip];  // N*V must be constant between last and guard cell
-          Ne[ip] = Ne[im] / Ni[im] * Ni[ip];  // Assume Ne/Ni constant TODO: is this right?
+          Ni[ip] = Ni[i] * Vi[i] / Vi[ip];  // N*V must be constant between last and guard cell
+          Ne[ip] = Ne[i] / Ni[i] * Ni[ip];  // Assume Ne/Ni constant TODO: is this right?
           Pi[ip] = Ti[ip] * Ni[ip];            // Pressure consistent with N*T
           NVi[ip] = Mi * Ni[ip] * Vi[ip];     // Momentum consistent with N*V
 

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -542,7 +542,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
-          q -= (2.5 * tisheath + 0.5 * Mi * C_i_sq) * nisheath * visheath;
+          q -= (2.5 * tisheath + 0.5 * Mi * SQ(visheath)) * nisheath * visheath;
 
           // Multiply by cell area to get power
           BoutReal heatflow = q * (coord->J[i] + coord->J[im])
@@ -605,7 +605,7 @@ void SheathBoundarySimple::transform(Options& state) {
           // Take into account the flow of energy due to fluid flow
           // This is additional energy flux through the sheath
           // Note: Here this is positive because visheath > 0
-          q -= (2.5 * tisheath + 0.5 * SQ(visheath) * Mi) * nisheath * visheath;
+          q -= (2.5 * tisheath + 0.5 * Mi * SQ(visheath)) * nisheath * visheath;
 
           // Multiply by cell area to get power
           BoutReal heatflow = q * (coord->J[i] + coord->J[ip])

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -338,13 +338,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
         electron_energy_source[i] += power;
 
-        // Total heat flux for diagnostic purposes
-        q = gamma_e * tesheath  * nesheath * vesheath;   // Wm-2
-        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-        electron_sheath_power_ylow[i] += heatflow;       // lower Y, so power placed in final domain cell 
-                      
+        electron_sheath_power_ylow[i] += heatflow * coord->dx[i] * coord->dz[i];       // lower Y, so power placed in final domain cell 
       }
     }
   }
@@ -398,12 +392,8 @@ void SheathBoundarySimple::transform(Options& state) {
 
         electron_energy_source[i] -= power;
 
-        // Total heat flux for diagnostic purposes
-        q = gamma_e * tesheath * nesheath * vesheath;  // Wm-2
-        heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-        
-        electron_sheath_power_ylow[ip] -= heatflow;    // upper Y, so power placed in first guard cell
+        // Diagnostic contains energy removed in the sheath
+        electron_sheath_power_ylow[ip] += heatflow * coord->dx[i] * coord->dz[i];    // upper Y, so power placed in first guard cell
       }
     }
   }
@@ -535,12 +525,7 @@ void SheathBoundarySimple::transform(Options& state) {
 
           energy_source[i] += power;
 
-          // Calculation of total heat flux for diagnostic purposes
-          q = gamma_i * tisheath * nisheath * visheath;   // Wm-2
-          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-          ion_sheath_power_ylow[i] += heatflow;      // lower Y, so power placed in final domain cell
+          ion_sheath_power_ylow[i] += heatflow * coord->dx[i] * coord->dz[i];      // lower Y, so power placed in final domain cell
         }
       }
     }
@@ -600,18 +585,13 @@ void SheathBoundarySimple::transform(Options& state) {
 
           energy_source[i] -= power; // Note: Sign negative because power > 0
 
-          // Calculation of total heat flux for diagnostic purposes
-          q = gamma_i * tisheath * nisheath * visheath;
-          heatflow = q * (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * (0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]));  // W
-
-          ion_sheath_power_ylow[ip] += heatflow;       // Upper Y, so power placed in first guard cell
+          ion_sheath_power_ylow[ip] += heatflow * coord->dx[i] * coord->dz[i];       // Upper Y, so power placed in first guard cell
         }
       }
-      
     }
     // Finished boundary conditions for this species
     // Put the modified fields back into the state.
+
     Ni.clearParallelSlices();
     Ti.clearParallelSlices();
     Pi.clearParallelSlices();

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -166,6 +166,9 @@ void SheathBoundarySimple::transform(Options& state) {
       const Field3D Ti = getNoBoundary<Field3D>(species["temperature"]);
       const BoutReal Mi = getNoBoundary<BoutReal>(species["AA"]);
       const BoutReal Zi = getNoBoundary<BoutReal>(species["charge"]);
+      Field3D Vi = species.isSet("velocity")
+        ? toFieldAligned(getNoBoundary<Field3D>(species["velocity"]))
+        : zeroFrom(Ni);
 
       if (lower_y) {
         // Sum values, put result in mesh->ystart
@@ -193,7 +196,12 @@ void SheathBoundarySimple::transform(Options& state) {
             // Sound speed squared
             BoutReal C_i_sq = (sheath_ion_polytropic * tisheath + Zi * tesheath) / Mi;
 
-            ion_sum[i] += Zi * nisheath * sqrt(C_i_sq);
+            BoutReal visheath = -sqrt(C_i_sq);
+            if (Vi[i] < visheath) {
+              visheath = Vi[i];
+            }
+
+            ion_sum[i] -= Zi * nisheath * visheath;
           }
         }
       }
@@ -219,7 +227,12 @@ void SheathBoundarySimple::transform(Options& state) {
 
             BoutReal C_i_sq = (sheath_ion_polytropic * tisheath + Zi * tesheath) / Mi;
 
-            ion_sum[i] += Zi * nisheath * sqrt(C_i_sq);
+            BoutReal visheath = sqrt(C_i_sq);
+            if (Vi[i] > visheath) {
+              visheath = Vi[i];
+            }
+
+            ion_sum[i] += Zi * nisheath * visheath;
           }
         }
       }

--- a/src/upstream_density_feedback.cxx
+++ b/src/upstream_density_feedback.cxx
@@ -57,4 +57,13 @@ void UpstreamDensityFeedback::transform(Options& state) {
 
   // Scale the source and add to the species density source
   add(species["density_source"], source_multiplier * density_source_shape);
+
+  // Adding particles to a flowing plasma reduces its kinetic energy
+  // -> Increase internal energy
+  if (IS_SET_NOBOUNDARY(species["velocity"]) and IS_SET(species["AA"])) {
+    const Field3D V = GET_NOBOUNDARY(Field3D, species["velocity"]);
+    const BoutReal Mi = get<BoutReal>(species["AA"]);
+    // Internal energy source
+    add(species["energy_source"], 0.5 * Mi * SQ(V) * source_multiplier * density_source_shape);
+  }
 }


### PR DESCRIPTION
Based on @tbody-cfs's approach in GRILLIX (see his thesis).
- Conserve Ni*Vi into sheath
- Conserve Ni*Ti into sheath
- Conserve Ne/Ni into sheath (not sure how else to deal with quasineutrality).

Previously we did not conserve Ni*Vi, we extrapolated Ni and set Vi to be equal or greater than Bohm. Making this more consistent reduced boundary zigzags in GRILLIX.

Has https://github.com/bendudson/hermes-3/pull/248 merged in.

- [ ] Get it to work