### PR TITLE
zero_current: throw exception if velocity already set

### DIFF
--- a/src/zero_current.cxx
+++ b/src/zero_current.cxx
@@ -56,7 +56,7 @@ void ZeroCurrent::transform(Options &state) {
 
   // Get the species density
   Options& species = state["species"][name];
-  if (IS_SET(species["velocity"])) {
+  if (species["velocity"].isSet()) {
     throw BoutException("Cannot use zero_current in species {} if velocity already set\n", name);
   }
   Field3D N = getNoBoundary<Field3D>(species["density"]);

--- a/src/zero_current.cxx
+++ b/src/zero_current.cxx
@@ -56,6 +56,9 @@ void ZeroCurrent::transform(Options &state) {
 
   // Get the species density
   Options& species = state["species"][name];
+  if (IS_SET(species["velocity"])) {
+    throw BoutException("Cannot use zero_current in species {} if velocity already set\n", name);
+  }
   Field3D N = getNoBoundary<Field3D>(species["density"]);
 
   velocity = current / (-charge * floor(N, 1e-5));


### PR DESCRIPTION
Accidentally evolving momentum and setting zero current should throw an exception.