### PR TITLE
Coulomb log fix

### DIFF
--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -218,7 +218,7 @@ void Collisions::transform(Options& state) {
               ((Te[i] < 0.1) || (Ni[i] < 1e10) || (Ne[i] < 1e10)) ? 10
               : (Te[i] < Ti[i] * me_mi)
                   ? 23 - 0.5 * log(Ni[i]) + 1.5 * log(Ti[i]) - log(SQ(Zi) * Ai)
-              : (Te[i] < 10 * SQ(Zi))
+              : (Te[i] < exp(2) * SQ(Zi)) // Fix to ei coulomb log from S.Mijin ReMKiT1D
                   // Ti m_e/m_i < Te < 10 Z^2
                   ? 30.0 - 0.5 * log(Ne[i]) - log(Zi) + 1.5 * log(Te[i])
                   // Ti m_e/m_i < 10 Z^2 < Te

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", Pnorm * Omega_ci * SQ(rho_s0)},
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0)} )/ Tnorm,
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm,
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm},
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -432,7 +432,7 @@ void EvolvePressure::outputVars(Options& state) {
       set_with_attrs(state[std::string("kappa_par_") + name], kappa_par,
                      {{"time_dimension", "t"},
                       {"units", "W / m / eV"},
-                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0)} )/ Tnorm,
+                      {"conversion", (Pnorm * Omega_ci * SQ(rho_s0) )/ Tnorm,
                       {"long_name", name + " heat conduction coefficient"},
                       {"species", name},
                       {"source", "evolve_pressure"}});


### PR DESCRIPTION
S. Mijin Identified a discontinuity in the NRL formulary fits for the electron ion coulomb log, this can be rectified by altering the change over point to exp(2.0) see attached. 

- [ ] Run tests on 1D recycling. 
<img width="499" alt="image" src="https://github.com/user-attachments/assets/a53a1e6d-5711-44b3-8e83-bccb2e29946e">
