### PR TITLE
Add radiation diagnostics for impurity transport

### DIFF
--- a/include/adas_carbon.hxx
+++ b/include/adas_carbon.hxx
@@ -1,134 +1,134 @@
-#pragma once
-#ifndef ADAS_CARBON_H
-#define ADAS_CARBON_H
+// #pragma once
+// #ifndef ADAS_CARBON_H
+// #define ADAS_CARBON_H
 
-#include "adas_reaction.hxx"
+// #include "adas_reaction.hxx"
 
-#include <array>
-#include <initializer_list>
+// #include <array>
+// #include <initializer_list>
 
-/// Ionisation energies in eV
-/// from https://www.webelements.com/carbon/atoms.html
-/// Conversion 1 kJ mol‑1 = 1.0364e-2 eV
-/// These are added (removed) from the electron energy during recombination (ionisation)
-constexpr std::array<BoutReal, 6> carbon_ionisation_energy{
-    11.26, 24.38, 47.89, 64.49, 392.09, 489.99};
+// /// Ionisation energies in eV
+// /// from https://www.webelements.com/carbon/atoms.html
+// /// Conversion 1 kJ mol‑1 = 1.0364e-2 eV
+// /// These are added (removed) from the electron energy during recombination (ionisation)
+// constexpr std::array<BoutReal, 6> carbon_ionisation_energy{
+//     11.26, 24.38, 47.89, 64.49, 392.09, 489.99};
 
-/// The name of the species. This initializer list can be passed to a string
-/// constructor, or used to index into an Options tree.
-///
-/// c, c+, c+2, c+3, ...
-///
-/// Special cases for level=0, 1
-///
-/// @tparam level  The ionisation level: 0 is neutral, 6 is fully stripped
-template <int level>
-constexpr std::initializer_list<char> carbon_species_name{'c', '+', '0' + level};
+// /// The name of the species. This initializer list can be passed to a string
+// /// constructor, or used to index into an Options tree.
+// ///
+// /// c, c+, c+2, c+3, ...
+// ///
+// /// Special cases for level=0, 1
+// ///
+// /// @tparam level  The ionisation level: 0 is neutral, 6 is fully stripped
+// template <int level>
+// constexpr std::initializer_list<char> carbon_species_name{'c', '+', '0' + level};
 
-template <>
-constexpr std::initializer_list<char> carbon_species_name<1>{'c', '+'};
+// template <>
+// constexpr std::initializer_list<char> carbon_species_name<1>{'c', '+'};
 
-template <>
-constexpr std::initializer_list<char> carbon_species_name<0>{'c'};
+// template <>
+// constexpr std::initializer_list<char> carbon_species_name<0>{'c'};
 
-/// ADAS effective ionisation (ADF11)
-///
-/// @tparam level  The ionisation level of the ion on the left of the reaction
-template <int level>
-struct ADASCarbonIonisation : public OpenADAS {
-  ADASCarbonIonisation(std::string, Options& alloptions, Solver*)
-      : OpenADAS(alloptions["units"], "scd96_c.json", "plt96_c.json", level,
-                 -carbon_ionisation_energy[level]) {}
+// /// ADAS effective ionisation (ADF11)
+// ///
+// /// @tparam level  The ionisation level of the ion on the left of the reaction
+// template <int level>
+// struct ADASCarbonIonisation : public OpenADAS {
+//   ADASCarbonIonisation(std::string, Options& alloptions, Solver*)
+//       : OpenADAS(alloptions["units"], "scd96_c.json", "plt96_c.json", level,
+//                  -carbon_ionisation_energy[level]) {}
 
-  void transform(Options& state) override {
-    calculate_rates(
-        state["species"]["e"],                           // Electrons
-        state["species"][carbon_species_name<level>],    // From this ionisation state
-        state["species"][carbon_species_name<level + 1>] // To this state
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     calculate_rates(
+//         state["species"]["e"],                           // Electrons
+//         state["species"][carbon_species_name<level>],    // From this ionisation state
+//         state["species"][carbon_species_name<level + 1>] // To this state
+//     );
+//   }
+// };
 
-/////////////////////////////////////////////////
+// /////////////////////////////////////////////////
 
-/// ADAS effective recombination coefficients (ADF11)
-///
-/// @tparam level  The ionisation level of the ion on the right of the reaction
-template <int level>
-struct ADASCarbonRecombination : public OpenADAS {
-  /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
-  ADASCarbonRecombination(std::string, Options& alloptions, Solver*)
-      : OpenADAS(alloptions["units"], "acd96_c.json", "prb96_c.json", level,
-                 carbon_ionisation_energy[level]) {}
+// /// ADAS effective recombination coefficients (ADF11)
+// ///
+// /// @tparam level  The ionisation level of the ion on the right of the reaction
+// template <int level>
+// struct ADASCarbonRecombination : public OpenADAS {
+//   /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
+//   ADASCarbonRecombination(std::string, Options& alloptions, Solver*)
+//       : OpenADAS(alloptions["units"], "acd96_c.json", "prb96_c.json", level,
+//                  carbon_ionisation_energy[level]) {}
 
-  void transform(Options& state) override {
-    calculate_rates(
-        state["species"]["e"],                            // Electrons
-        state["species"][carbon_species_name<level + 1>], // From this ionisation state
-        state["species"][carbon_species_name<level>]      // To this state
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     calculate_rates(
+//         state["species"]["e"],                            // Electrons
+//         state["species"][carbon_species_name<level + 1>], // From this ionisation state
+//         state["species"][carbon_species_name<level>]      // To this state
+//     );
+//   }
+// };
 
-/// @tparam level     The ionisation level of the ion on the right of the reaction
-/// @tparam Hisotope  The hydrogen isotope ('h', 'd' or 't')
-template <int level, char Hisotope>
-struct ADASCarbonCX : public OpenADASChargeExchange {
-  /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
-  ADASCarbonCX(std::string, Options& alloptions, Solver*)
-      : OpenADASChargeExchange(alloptions["units"], "ccd96_c.json", level) {}
+// /// @tparam level     The ionisation level of the ion on the right of the reaction
+// /// @tparam Hisotope  The hydrogen isotope ('h', 'd' or 't')
+// template <int level, char Hisotope>
+// struct ADASCarbonCX : public OpenADASChargeExchange {
+//   /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
+//   ADASCarbonCX(std::string, Options& alloptions, Solver*)
+//       : OpenADASChargeExchange(alloptions["units"], "ccd96_c.json", level) {}
 
-  void transform(Options& state) override {
-    Options& species = state["species"];
-    calculate_rates(
-        species["e"],                            // Electrons
-        species[carbon_species_name<level + 1>], // From this ionisation state
-        species[{Hisotope}],                     //    and this neutral hydrogen atom
-        species[carbon_species_name<level>],     // To this state
-        species[{Hisotope, '+'}]                 //    and this hydrogen ion
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     Options& species = state["species"];
+//     calculate_rates(
+//         species["e"],                            // Electrons
+//         species[carbon_species_name<level + 1>], // From this ionisation state
+//         species[{Hisotope}],                     //    and this neutral hydrogen atom
+//         species[carbon_species_name<level>],     // To this state
+//         species[{Hisotope, '+'}]                 //    and this hydrogen ion
+//     );
+//   }
+// };
 
-namespace {
-// Ionisation by electron-impact
-RegisterComponent<ADASCarbonIonisation<0>> register_ionisation_c0("c + e -> c+ + 2e");
-RegisterComponent<ADASCarbonIonisation<1>> register_ionisation_c1("c+ + e -> c+2 + 2e");
-RegisterComponent<ADASCarbonIonisation<2>> register_ionisation_c2("c+2 + e -> c+3 + 2e");
-RegisterComponent<ADASCarbonIonisation<3>> register_ionisation_c3("c+3 + e -> c+4 + 2e");
-RegisterComponent<ADASCarbonIonisation<4>> register_ionisation_c4("c+4 + e -> c+5 + 2e");
-RegisterComponent<ADASCarbonIonisation<5>> register_ionisation_c5("c+5 + e -> c+6 + 2e");
+// namespace {
+// // Ionisation by electron-impact
+// RegisterComponent<ADASCarbonIonisation<0>> register_ionisation_c0("c + e -> c+ + 2e");
+// RegisterComponent<ADASCarbonIonisation<1>> register_ionisation_c1("c+ + e -> c+2 + 2e");
+// RegisterComponent<ADASCarbonIonisation<2>> register_ionisation_c2("c+2 + e -> c+3 + 2e");
+// RegisterComponent<ADASCarbonIonisation<3>> register_ionisation_c3("c+3 + e -> c+4 + 2e");
+// RegisterComponent<ADASCarbonIonisation<4>> register_ionisation_c4("c+4 + e -> c+5 + 2e");
+// RegisterComponent<ADASCarbonIonisation<5>> register_ionisation_c5("c+5 + e -> c+6 + 2e");
 
-// Recombination
-RegisterComponent<ADASCarbonRecombination<0>> register_recombination_c0("c+ + e -> c");
-RegisterComponent<ADASCarbonRecombination<1>> register_recombination_c1("c+2 + e -> c+");
-RegisterComponent<ADASCarbonRecombination<2>> register_recombination_c2("c+3 + e -> c+2");
-RegisterComponent<ADASCarbonRecombination<3>> register_recombination_c3("c+4 + e -> c+3");
-RegisterComponent<ADASCarbonRecombination<4>> register_recombination_c4("c+5 + e -> c+4");
-RegisterComponent<ADASCarbonRecombination<5>> register_recombination_c5("c+6 + e -> c+5");
+// // Recombination
+// RegisterComponent<ADASCarbonRecombination<0>> register_recombination_c0("c+ + e -> c");
+// RegisterComponent<ADASCarbonRecombination<1>> register_recombination_c1("c+2 + e -> c+");
+// RegisterComponent<ADASCarbonRecombination<2>> register_recombination_c2("c+3 + e -> c+2");
+// RegisterComponent<ADASCarbonRecombination<3>> register_recombination_c3("c+4 + e -> c+3");
+// RegisterComponent<ADASCarbonRecombination<4>> register_recombination_c4("c+5 + e -> c+4");
+// RegisterComponent<ADASCarbonRecombination<5>> register_recombination_c5("c+6 + e -> c+5");
 
-// Charge exchange
-RegisterComponent<ADASCarbonCX<0, 'h'>> register_cx_c0h("c+ + h -> c + h+");
-RegisterComponent<ADASCarbonCX<1, 'h'>> register_cx_c1h("c+2 + h -> c+ + h+");
-RegisterComponent<ADASCarbonCX<2, 'h'>> register_cx_c2h("c+3 + h -> c+2 + h+");
-RegisterComponent<ADASCarbonCX<3, 'h'>> register_cx_c3h("c+4 + h -> c+3 + h+");
-RegisterComponent<ADASCarbonCX<4, 'h'>> register_cx_c4h("c+5 + h -> c+4 + h+");
-RegisterComponent<ADASCarbonCX<5, 'h'>> register_cx_c5h("c+6 + h -> c+5 + h+");
+// // Charge exchange
+// RegisterComponent<ADASCarbonCX<0, 'h'>> register_cx_c0h("c+ + h -> c + h+");
+// RegisterComponent<ADASCarbonCX<1, 'h'>> register_cx_c1h("c+2 + h -> c+ + h+");
+// RegisterComponent<ADASCarbonCX<2, 'h'>> register_cx_c2h("c+3 + h -> c+2 + h+");
+// RegisterComponent<ADASCarbonCX<3, 'h'>> register_cx_c3h("c+4 + h -> c+3 + h+");
+// RegisterComponent<ADASCarbonCX<4, 'h'>> register_cx_c4h("c+5 + h -> c+4 + h+");
+// RegisterComponent<ADASCarbonCX<5, 'h'>> register_cx_c5h("c+6 + h -> c+5 + h+");
 
-RegisterComponent<ADASCarbonCX<0, 'd'>> register_cx_c0d("c+ + d -> c + d+");
-RegisterComponent<ADASCarbonCX<1, 'd'>> register_cx_c1d("c+2 + d -> c+ + d+");
-RegisterComponent<ADASCarbonCX<2, 'd'>> register_cx_c2d("c+3 + d -> c+2 + d+");
-RegisterComponent<ADASCarbonCX<3, 'd'>> register_cx_c3d("c+4 + d -> c+3 + d+");
-RegisterComponent<ADASCarbonCX<4, 'd'>> register_cx_c4d("c+5 + d -> c+4 + d+");
-RegisterComponent<ADASCarbonCX<5, 'd'>> register_cx_c5d("c+6 + d -> c+5 + d+");
+// RegisterComponent<ADASCarbonCX<0, 'd'>> register_cx_c0d("c+ + d -> c + d+");
+// RegisterComponent<ADASCarbonCX<1, 'd'>> register_cx_c1d("c+2 + d -> c+ + d+");
+// RegisterComponent<ADASCarbonCX<2, 'd'>> register_cx_c2d("c+3 + d -> c+2 + d+");
+// RegisterComponent<ADASCarbonCX<3, 'd'>> register_cx_c3d("c+4 + d -> c+3 + d+");
+// RegisterComponent<ADASCarbonCX<4, 'd'>> register_cx_c4d("c+5 + d -> c+4 + d+");
+// RegisterComponent<ADASCarbonCX<5, 'd'>> register_cx_c5d("c+6 + d -> c+5 + d+");
 
-RegisterComponent<ADASCarbonCX<0, 't'>> register_cx_c0t("c+ + t -> c + t+");
-RegisterComponent<ADASCarbonCX<1, 't'>> register_cx_c1t("c+2 + t -> c+ + t+");
-RegisterComponent<ADASCarbonCX<2, 't'>> register_cx_c2t("c+3 + t -> c+2 + t+");
-RegisterComponent<ADASCarbonCX<3, 't'>> register_cx_c3t("c+4 + t -> c+3 + t+");
-RegisterComponent<ADASCarbonCX<4, 't'>> register_cx_c4t("c+5 + t -> c+4 + t+");
-RegisterComponent<ADASCarbonCX<5, 't'>> register_cx_c5t("c+6 + t -> c+5 + t+");
+// RegisterComponent<ADASCarbonCX<0, 't'>> register_cx_c0t("c+ + t -> c + t+");
+// RegisterComponent<ADASCarbonCX<1, 't'>> register_cx_c1t("c+2 + t -> c+ + t+");
+// RegisterComponent<ADASCarbonCX<2, 't'>> register_cx_c2t("c+3 + t -> c+2 + t+");
+// RegisterComponent<ADASCarbonCX<3, 't'>> register_cx_c3t("c+4 + t -> c+3 + t+");
+// RegisterComponent<ADASCarbonCX<4, 't'>> register_cx_c4t("c+5 + t -> c+4 + t+");
+// RegisterComponent<ADASCarbonCX<5, 't'>> register_cx_c5t("c+6 + t -> c+5 + t+");
 
-} // namespace
+// } // namespace
 
-#endif // ADAS_CARBON_H
+// #endif // ADAS_CARBON_H

--- a/include/adas_lithium.hxx
+++ b/include/adas_lithium.hxx
@@ -1,121 +1,121 @@
-#pragma once
-#ifndef ADAS_LITHIUM_H
-#define ADAS_LITHIUM_H
+// #pragma once
+// #ifndef ADAS_LITHIUM_H
+// #define ADAS_LITHIUM_H
 
-#include "adas_reaction.hxx"
+// #include "adas_reaction.hxx"
 
-#include <array>
-#include <initializer_list>
+// #include <array>
+// #include <initializer_list>
 
-/// Ionisation energies in eV
-/// from https://www.webelements.com/lithium/atoms.html
-/// Conversion 1 kJ mol‑1 = 1.0364e-2 eV
-/// These are added (removed) from the electron energy during recombination (ionisation)
-constexpr std::array<BoutReal, 3> lithium_ionisation_energy{
-    5.39, 75.64, 122.45};
+// /// Ionisation energies in eV
+// /// from https://www.webelements.com/lithium/atoms.html
+// /// Conversion 1 kJ mol‑1 = 1.0364e-2 eV
+// /// These are added (removed) from the electron energy during recombination (ionisation)
+// constexpr std::array<BoutReal, 3> lithium_ionisation_energy{
+//     5.39, 75.64, 122.45};
 
-/// The name of the species. This initializer list can be passed to a string
-/// constructor, or used to index into an Options tree.
-///
-/// li, li+, li+2, ...
-///
-/// Special cases for level=0, 1 and 3
-///
-/// @tparam level  The ionisation level: 0 is neutral, 3 is fully stripped.
-template <int level>
-constexpr std::initializer_list<char> lithium_species_name{'l', 'i', '+', '0' + level};
+// /// The name of the species. This initializer list can be passed to a string
+// /// constructor, or used to index into an Options tree.
+// ///
+// /// li, li+, li+2, ...
+// ///
+// /// Special cases for level=0, 1 and 3
+// ///
+// /// @tparam level  The ionisation level: 0 is neutral, 3 is fully stripped.
+// template <int level>
+// constexpr std::initializer_list<char> lithium_species_name{'l', 'i', '+', '0' + level};
 
-template <>
-constexpr std::initializer_list<char> lithium_species_name<3>{'l', 'i', '+', '3'};
+// template <>
+// constexpr std::initializer_list<char> lithium_species_name<3>{'l', 'i', '+', '3'};
 
-template <>
-constexpr std::initializer_list<char> lithium_species_name<1>{'l', 'i', '+'};
+// template <>
+// constexpr std::initializer_list<char> lithium_species_name<1>{'l', 'i', '+'};
 
-template <>
-constexpr std::initializer_list<char> lithium_species_name<0>{'l', 'i'};
+// template <>
+// constexpr std::initializer_list<char> lithium_species_name<0>{'l', 'i'};
 
-/// ADAS effective ionisation (ADF11)
-///
-/// @tparam level  The ionisation level of the ion on the left of the reaction
-template <int level>
-struct ADASLithiumIonisation : public OpenADAS {
-  ADASLithiumIonisation(std::string, Options& alloptions, Solver*)
-      : OpenADAS(alloptions["units"], "scd96_li.json", "plt96_li.json", level,
-                 -lithium_ionisation_energy[level]) {}
+// /// ADAS effective ionisation (ADF11)
+// ///
+// /// @tparam level  The ionisation level of the ion on the left of the reaction
+// template <int level>
+// struct ADASLithiumIonisation : public OpenADAS {
+//   ADASLithiumIonisation(std::string, Options& alloptions, Solver*)
+//       : OpenADAS(alloptions["units"], "scd96_li.json", "plt96_li.json", level,
+//                  -lithium_ionisation_energy[level]) {}
 
-  void transform(Options& state) override {
-    calculate_rates(
-        state["species"]["e"],                         // Electrons
-        state["species"][lithium_species_name<level>],    // From this ionisation state
-        state["species"][lithium_species_name<level + 1>] // To this state
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     calculate_rates(
+//         state["species"]["e"],                         // Electrons
+//         state["species"][lithium_species_name<level>],    // From this ionisation state
+//         state["species"][lithium_species_name<level + 1>] // To this state
+//     );
+//   }
+// };
 
-/////////////////////////////////////////////////
+// /////////////////////////////////////////////////
 
-/// ADAS effective recombination coefficients (ADF11)
-///
-/// @tparam level  The ionisation level of the ion on the right of the reaction
-template <int level>
-struct ADASLithiumRecombination : public OpenADAS {
-  /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
-  ADASLithiumRecombination(std::string, Options& alloptions, Solver*)
-      : OpenADAS(alloptions["units"], "acd96_li.json", "prb96_li.json", level,
-                 lithium_ionisation_energy[level]) {}
+// /// ADAS effective recombination coefficients (ADF11)
+// ///
+// /// @tparam level  The ionisation level of the ion on the right of the reaction
+// template <int level>
+// struct ADASLithiumRecombination : public OpenADAS {
+//   /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
+//   ADASLithiumRecombination(std::string, Options& alloptions, Solver*)
+//       : OpenADAS(alloptions["units"], "acd96_li.json", "prb96_li.json", level,
+//                  lithium_ionisation_energy[level]) {}
 
-  void transform(Options& state) override {
-    calculate_rates(
-        state["species"]["e"],                          // Electrons
-        state["species"][lithium_species_name<level + 1>], // From this ionisation state
-        state["species"][lithium_species_name<level>]      // To this state
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     calculate_rates(
+//         state["species"]["e"],                          // Electrons
+//         state["species"][lithium_species_name<level + 1>], // From this ionisation state
+//         state["species"][lithium_species_name<level>]      // To this state
+//     );
+//   }
+// };
 
-/// @tparam level     The ionisation level of the ion on the right of the reaction
-/// @tparam Hisotope  The hydrogen isotope ('h', 'd' or 't')
-template <int level, char Hisotope>
-struct ADASLithiumCX : public OpenADASChargeExchange {
-  /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
-  ADASLithiumCX(std::string, Options& alloptions, Solver*)
-      : OpenADASChargeExchange(alloptions["units"], "ccd89_li.json", level) {}
+// /// @tparam level     The ionisation level of the ion on the right of the reaction
+// /// @tparam Hisotope  The hydrogen isotope ('h', 'd' or 't')
+// template <int level, char Hisotope>
+// struct ADASLithiumCX : public OpenADASChargeExchange {
+//   /// @param alloptions  The top-level options. Only uses the ["units"] subsection.
+//   ADASLithiumCX(std::string, Options& alloptions, Solver*)
+//       : OpenADASChargeExchange(alloptions["units"], "ccd89_li.json", level) {}
 
-  void transform(Options& state) override {
-    Options& species = state["species"];
-    calculate_rates(
-        species["e"],                          // Electrons
-        species[lithium_species_name<level + 1>], // From this ionisation state
-        species[{Hisotope}],                   //    and this neutral hydrogen atom
-        species[lithium_species_name<level>],     // To this state
-        species[{Hisotope, '+'}]               //    and this hydrogen ion
-    );
-  }
-};
+//   void transform(Options& state) override {
+//     Options& species = state["species"];
+//     calculate_rates(
+//         species["e"],                          // Electrons
+//         species[lithium_species_name<level + 1>], // From this ionisation state
+//         species[{Hisotope}],                   //    and this neutral hydrogen atom
+//         species[lithium_species_name<level>],     // To this state
+//         species[{Hisotope, '+'}]               //    and this hydrogen ion
+//     );
+//   }
+// };
 
-namespace {
-// Ionisation by electron-impact
-RegisterComponent<ADASLithiumIonisation<0>> register_ionisation_li0("li + e -> li+ + 2e");
-RegisterComponent<ADASLithiumIonisation<1>> register_ionisation_li1("li+ + e -> li+2 + 2e");
-RegisterComponent<ADASLithiumIonisation<2>> register_ionisation_li2("li+2 + e -> li+3 + 2e");
+// namespace {
+// // Ionisation by electron-impact
+// RegisterComponent<ADASLithiumIonisation<0>> register_ionisation_li0("li + e -> li+ + 2e");
+// RegisterComponent<ADASLithiumIonisation<1>> register_ionisation_li1("li+ + e -> li+2 + 2e");
+// RegisterComponent<ADASLithiumIonisation<2>> register_ionisation_li2("li+2 + e -> li+3 + 2e");
 
-// Recombination
-RegisterComponent<ADASLithiumRecombination<0>> register_recombination_li0("li+ + e -> li");
-RegisterComponent<ADASLithiumRecombination<1>> register_recombination_li1("li+2 + e -> li+");
-RegisterComponent<ADASLithiumRecombination<2>> register_recombination_li2("li+3 + e -> li+2");
+// // Recombination
+// RegisterComponent<ADASLithiumRecombination<0>> register_recombination_li0("li+ + e -> li");
+// RegisterComponent<ADASLithiumRecombination<1>> register_recombination_li1("li+2 + e -> li+");
+// RegisterComponent<ADASLithiumRecombination<2>> register_recombination_li2("li+3 + e -> li+2");
 
-// Charge exchange
-RegisterComponent<ADASLithiumCX<0, 'h'>> register_cx_li0h("li+ + h -> li + h+");
-RegisterComponent<ADASLithiumCX<1, 'h'>> register_cx_li1h("li+2 + h -> li+ + h+");
-RegisterComponent<ADASLithiumCX<2, 'h'>> register_cx_li2h("li+3 + h -> li+2 + h+");
+// // Charge exchange
+// RegisterComponent<ADASLithiumCX<0, 'h'>> register_cx_li0h("li+ + h -> li + h+");
+// RegisterComponent<ADASLithiumCX<1, 'h'>> register_cx_li1h("li+2 + h -> li+ + h+");
+// RegisterComponent<ADASLithiumCX<2, 'h'>> register_cx_li2h("li+3 + h -> li+2 + h+");
 
-RegisterComponent<ADASLithiumCX<0, 'd'>> register_cx_li0d("li+ + d -> li + d+");
-RegisterComponent<ADASLithiumCX<1, 'd'>> register_cx_li1d("li+2 + d -> li+ + d+");
-RegisterComponent<ADASLithiumCX<2, 'd'>> register_cx_li2d("li+3 + d -> li+2 + d+");
+// RegisterComponent<ADASLithiumCX<0, 'd'>> register_cx_li0d("li+ + d -> li + d+");
+// RegisterComponent<ADASLithiumCX<1, 'd'>> register_cx_li1d("li+2 + d -> li+ + d+");
+// RegisterComponent<ADASLithiumCX<2, 'd'>> register_cx_li2d("li+3 + d -> li+2 + d+");
 
-RegisterComponent<ADASLithiumCX<0, 't'>> register_cx_li0t("li+ + t -> li + t+");
-RegisterComponent<ADASLithiumCX<1, 't'>> register_cx_li1t("li+2 + t -> li+ + t+");
-RegisterComponent<ADASLithiumCX<2, 't'>> register_cx_li2t("li+3 + t -> li+2 + t+");
-} // namespace
+// RegisterComponent<ADASLithiumCX<0, 't'>> register_cx_li0t("li+ + t -> li + t+");
+// RegisterComponent<ADASLithiumCX<1, 't'>> register_cx_li1t("li+2 + t -> li+ + t+");
+// RegisterComponent<ADASLithiumCX<2, 't'>> register_cx_li2t("li+3 + t -> li+2 + t+");
+// } // namespace
 
-#endif // ADAS_LITHIUM_H
+// #endif // ADAS_LITHIUM_H

--- a/include/adas_reaction.hxx
+++ b/include/adas_reaction.hxx
@@ -64,10 +64,12 @@ struct OpenADAS : public Component {
 
   /// Perform the calculation of rates, and transfer of particles/momentum/energy
   ///
-  /// @param electron  The electron species e.g. state["species"]["e"]
-  /// @param from_ion  The ion on the left of the reaction
-  /// @param to_ion    The ion on the right of the reaction
-  void calculate_rates(Options& electron, Options& from_ion, Options& to_ion);
+  /// @param electron      The electron species e.g. state["species"]["e"]
+  /// @param from_ion      The ion on the left of the reaction
+  /// @param to_ion        The ion on the right of the reaction
+  /// @param energy_loss   Radiation energy source in W/m3
+  void calculate_rates(Options& electron, Options& from_ion, Options& to_ion,
+                       Field3D& energy_loss);
 private:
   OpenADASRateCoefficient rate_coef;      ///< Reaction rate coefficient
   OpenADASRateCoefficient radiation_coef; ///< Energy loss (radiation) coefficient

--- a/src/adas_reaction.cxx
+++ b/src/adas_reaction.cxx
@@ -123,7 +123,8 @@ BoutReal OpenADASRateCoefficient::evaluate(BoutReal T, BoutReal n) {
   return pow(10., eval_log_coef);
 }
 
-void OpenADAS::calculate_rates(Options& electron, Options& from_ion, Options& to_ion) {
+void OpenADAS::calculate_rates(Options& electron, Options& from_ion, Options& to_ion,
+                               Field3D& energy_loss) {
   AUTO_TRACE();
 
   Field3D Ne = GET_VALUE(Field3D, electron["density"]);
@@ -170,7 +171,7 @@ void OpenADAS::calculate_rates(Options& electron, Options& from_ion, Options& to
   add(to_ion["energy_source"], energy_exchange);
 
   // Electron energy loss (radiation, ionisation potential)
-  Field3D energy_loss = cellAverage(
+  energy_loss = cellAverage(
       [&](BoutReal ne, BoutReal n1, BoutReal te) {
         return floor(ne, 0.0) * floor(n1, 0.0) *
           radiation_coef.evaluate(te * Tnorm, ne * Nnorm) * Nnorm


### PR DESCRIPTION
There are currently no diagnostics for impurity reactions. This PR sets up an outputVars object to provide a framework for diagnostics and adds only radiation for now.

- [x] Add radiation diagnostics to Ne
- [x] Comment out other impurities for easier testing
- [ ] Test
- [ ] Uncomment other impurity species
