### PR TITLE
recycling: Diagnostics should be per-channel

### DIFF
--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -50,6 +50,12 @@ private:
     BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
     BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction;   ///< Fraction of ions undergoing fast reflection
     BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor;   ///< Fraction of energy retained by fast recycled neutrals
+
+    // Recycling particle and energy sources for the different sources of recycling
+    // These sources are per-channel and added to the `to` species
+    Field3D target_recycle_density_source, target_recycle_energy_source;
+    Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
+    Field3D pump_density_source, pump_energy_source;  ///< Recycling particle and energy sources for pump recycling
   };
 
   std::vector<RecycleChannel> channels; // Recycling channels
@@ -62,13 +68,6 @@ private:
   Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity
 
   Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR. Provided by user in grid file.
-
-  // Recycling particle and energy sources for the different sources of recycling
-  // Note that SOL, PFR and pump are not applicable to 1D
-  Field3D target_recycle_density_source, target_recycle_energy_source; 
-  Field3D wall_recycle_density_source, wall_recycle_energy_source;  ///< Recycling particle and energy sources for pfr + sol recycling
-  Field3D pump_density_source, pump_energy_source;  ///< Recycling particle and energy sources for pump recycling
-
 };
 
 namespace {


### PR DESCRIPTION
Each recycling channel now outputs diagnostics for particle/momentum/energy sources.
Previously there was only one diagnostic for all channels.