### PR TITLE
Unify docs theme with BOUT++

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 breathe
 recommonmark
-sphinx-rtd-theme
+sphinx-book-theme
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -148,11 +148,8 @@ napoleon_use_param = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-if on_readthedocs:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-else:
-    html_theme = 'sphinxdoc'
+
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This PR changes the docs theme to be like BOUT++, see screenshot below. This theme is `sphinx_book_theme` and you must pip install it before building the docs locally. The theme is the same on Readthedocs as locally which helps to make the docs writing experience more predictable - we previously had a different theme locally and it made things look very different once they were up.

One thing I would appreciate feedback on is how to add `sphinx_book_theme` to some sort of python environment requirements so that users don't get confused. I don't think we give any instructions right now on how to build the documentation, so maybe we could add a documentation page on that and instruct the user to install the right theme there? Happy to do that if you think that's the right way forward.

Would also appreciate any tips on Readthedocs gotchas. I've never looked into it and I'm not sure if I'll be breaking anything here.

![image](https://github.com/user-attachments/assets/1090ebdf-8b5e-41dc-82fe-0954fb6753f2)