### PR TITLE
Fix for zero lax flux when using [sound_speed]

### DIFF
--- a/include/sound_speed.hxx
+++ b/include/sound_speed.hxx
@@ -35,7 +35,7 @@ struct SoundSpeed : public Component {
 
     fastest_wave_factor = options["fastest_wave_factor"]
       .doc("Multiply the fastest wave by this factor, affecting lax flux strength")
-      .withDefault(0.0);
+      .withDefault(1.0);
 
     if (temperature_floor > 0.0) {
       temperature_floor /= get<BoutReal>(alloptions["units"]["eV"]);


### PR DESCRIPTION
After going loopy trying to fix some poor performance in my simulations, I found severe checkerboarding in the core. This was not always obviously visible because SNES seems to have been partially diffusing it away during large changes in plasma conditions. Running near steady state established a strong checkerboarding pattern, and switching to CVODE resolved it better:

<img width="724" height="795" alt="image" src="https://github.com/user-attachments/assets/4644b96d-b23e-4880-887f-dbd9c3d39582" />

After some digging I found a bug. PR https://github.com/boutproject/hermes-3/pull/251 implemented a factor to scale lax flux strength within `[sound_speed]`, but the default was inexplicably left at zero....

https://github.com/boutproject/hermes-3/blob/5d1baab02b9b67215b0c7cc03fb9378804ce9dab/include/sound_speed.hxx#L36-L38

This means that if you used the `[sound_speed]` component, your lax flux would have been set to zero. If you didn't use the component, your lax flux would have been calculated on a per-species basis - this is a separate implementation which doesn't have a factor on it, so this would have been fine.

For those that don't know, Lax flux is something to combat checkerboarding which is a phenomenon in codes solving on cell centers. The code really depends on it, and disabling it is a recipe for significant instabilities and performance problems. So the good news is that this fix should significantly improve performance for any simulations with `[sound_speed]` enabled.