### PR TITLE
Fix electromagnetic component when neutrals are present

### DIFF
--- a/include/electromagnetic.hxx
+++ b/include/electromagnetic.hxx
@@ -4,7 +4,7 @@
 
 #include "component.hxx"
 
-class Laplacian;
+#include "bout/invert_laplace.hxx"
 
 /// Electromagnetic potential A||
 ///

--- a/src/electromagnetic.cxx
+++ b/src/electromagnetic.cxx
@@ -32,7 +32,10 @@ Electromagnetic::Electromagnetic(std::string name, Options &alloptions, Solver* 
   // Use the "Naulin" solver because we need to include toroidal
   // variations of the density (A coefficient)
   aparSolver = Laplacian::create(&options["laplacian"]);
-  aparSolver->savePerformance(*solver, "AparSolver");
+  if (solver != nullptr) {
+    // solver may be null in unit testing
+    aparSolver->savePerformance(*solver, "AparSolver");
+  }
 
   const_gradient = options["const_gradient"]
     .doc("Extrapolate gradient of Apar into all radial boundaries?")

--- a/tests/unit/test_electromagnetic.cxx
+++ b/tests/unit/test_electromagnetic.cxx
@@ -1,0 +1,74 @@
+#include "gtest/gtest.h"
+
+#include "fake_mesh_fixture.hxx"
+#include "test_extras.hxx" // FakeMesh
+
+#include "../../include/electromagnetic.hxx"
+
+/// Global mesh
+namespace bout {
+namespace globals {
+extern Mesh* mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+#include <bout/field_factory.hxx> // For generating functions
+
+// Reuse the "standard" fixture for FakeMesh
+using ElectromagneticTest = FakeMeshFixture;
+
+TEST_F(ElectromagneticTest, CreateComponent) {
+  Options options = {
+      {"units", {{"Tesla", 1.0}, {"eV", 1.0}, {"inv_meters_cubed", 1e19}}}};
+
+  Electromagnetic component("test", options, nullptr);
+}
+
+TEST_F(ElectromagneticTest, TransformNoChargedSpecies) {
+  Options options = {
+      {"units", {{"Tesla", 1.0}, {"eV", 1.0}, {"inv_meters_cubed", 1e19}}}};
+
+  Electromagnetic component("test", options, nullptr);
+
+  // Transform with no charged species
+  Options state = {{"species", {{"d", {{"AA", 2.0}}}}}};
+
+  component.transform(state);
+
+  // Apar should be set
+  EXPECT_TRUE(state["fields"]["Apar"].isSet());
+
+  // Apar should be zero
+  auto Apar = get<Field3D>(state["fields"]["Apar"]);
+  BOUT_FOR_SERIAL(i, Apar.getRegion("RGN_NOBNDRY")) { ASSERT_DOUBLE_EQ(Apar[i], 0.0); }
+
+  // Apar_flutter should not be set
+  EXPECT_FALSE(state["fields"]["Apar_flutter"].isSet());
+}
+
+TEST_F(ElectromagneticTest, FlutterSetsField) {
+  Options options = {{"units", {{"Tesla", 1.0}, {"eV", 1.0}, {"inv_meters_cubed", 1e19}}},
+                     {"test", {{"magnetic_flutter", true}}}};
+
+  Electromagnetic component("test", options, nullptr);
+
+  // Transform with no charged species
+  Options state = {{"species", {{"d", {{"AA", 2.0}}}}}};
+
+  component.transform(state);
+
+  // Apar should be set
+  EXPECT_TRUE(state["fields"]["Apar"].isSet());
+
+  // Apar_flutter should be set
+  EXPECT_TRUE(state["fields"]["Apar_flutter"].isSet());
+
+  // Apar_flutter should be zero
+  auto Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+  BOUT_FOR_SERIAL(i, Apar_flutter.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(Apar_flutter[i], 0.0);
+  }
+}


### PR DESCRIPTION
Previously would throw an exception if a species without a charge was encountered.
Added some unit tests that would have caught the issue.
