### PR TITLE
[WIP] Add `freeze_profiles` option to fix the Z-average profiles

### DIFF
--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -76,6 +76,8 @@ private:
   bool low_p_diffuse_perp; ///< Add artificial cross-field diffusion at low pressure?
   BoutReal hyper_z;    ///< Hyper-diffusion in Z
 
+  bool freeze_profiles; ///< Subtract Z average from time derivatives?
+
   bool evolve_log; ///< Evolve logarithm of density?
   Field3D logN;    ///< Logarithm of density (if evolving)
 

--- a/include/evolve_energy.hxx
+++ b/include/evolve_energy.hxx
@@ -104,6 +104,8 @@ private:
 
   BoutReal hyper_z; ///< Hyper-diffusion
 
+  bool freeze_profiles; ///< Subtract Z average from time derivatives?
+
   bool diagnose;      ///< Output additional diagnostics?
   bool enable_precon; ///< Enable preconditioner?
   Field3D flow_xlow, flow_ylow; ///< Energy flow diagnostics

--- a/include/evolve_momentum.hxx
+++ b/include/evolve_momentum.hxx
@@ -51,6 +51,8 @@ private:
 
   BoutReal hyper_z;  ///< Hyper-diffusion
 
+  bool freeze_profiles; ///< Subtract Z average from time derivatives?
+
   bool diagnose; ///< Output additional diagnostics?
   bool fix_momentum_boundary_flux; ///< Fix momentum flux to boundary condition?
   Field3D flow_xlow, flow_ylow; ///< Momentum flow diagnostics

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -109,6 +109,8 @@ private:
   BoutReal hyper_z; ///< Hyper-diffusion
   BoutReal hyper_z_T; ///< 4th-order dissipation in T
 
+  bool freeze_profiles; ///< Subtract Z average from time derivatives?
+
   bool diagnose; ///< Output additional diagnostics?
   bool enable_precon; ///< Enable preconditioner?
   BoutReal source_normalisation; ///< Normalisation factor [Pa/s]

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -140,6 +140,8 @@ private:
   BoutReal hyper_z; ///< Hyper-viscosity in Z
   Field2D viscosity; ///< Kinematic viscosity
 
+  bool freeze_profiles; ///< Subtract Z average from time derivatives?
+
   // Diagnostic outputs
   Field3D DivJdia, DivJcol; // Divergence of diamagnetic and collisional current
 

--- a/scripts/impurity_curves/implement_new_cooling_curves.ipynb
+++ b/scripts/impurity_curves/implement_new_cooling_curves.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "import pandas as pd\n",

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -48,6 +48,8 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
 
   hyper_z = options["hyper_z"].doc("Hyper-diffusion in Z").withDefault(-1.0);
 
+  freeze_profiles = options["freeze_profiles"].doc("Subtract Z average from time derivatives?").withDefault<bool>(false);
+
   evolve_log = options["evolve_log"]
                    .doc("Evolve the logarithm of density?")
                    .withDefault<bool>(false);
@@ -310,6 +312,10 @@ void EvolveDensity::finally(const Options& state) {
     if (species.isSet("particle_flow_ylow")) {
       flow_ylow += get<Field3D>(species["particle_flow_ylow"]);
     }
+  }
+
+  if (freeze_profiles) {
+    ddt(N) -= DC(ddt(N)); // Remove the DC, i.e. Z-averaged, component.
   }
 }
 

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -81,6 +81,8 @@ EvolveEnergy::EvolveEnergy(std::string name, Options& alloptions, Solver* solver
 
   hyper_z = options["hyper_z"].doc("Hyper-diffusion in Z").withDefault(-1.0);
 
+  freeze_profiles = options["freeze_profiles"].doc("Subtract Z average from time derivatives?").withDefault<bool>(false);
+
   diagnose = options["diagnose"]
                  .doc("Save additional output diagnostics")
                  .withDefault<bool>(false);
@@ -463,6 +465,10 @@ void EvolveEnergy::finally(const Options& state) {
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
     ddt(E) *= get<Field3D>(state["scale_timederivs"]);
+  }
+
+  if (freeze_profiles) {
+    ddt(E) -= DC(ddt(E)); // Remove the DC, i.e. Z-averaged, component.
   }
 
   if (evolve_log) {

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -45,6 +45,8 @@ EvolveMomentum::EvolveMomentum(std::string name, Options &alloptions, Solver *so
 
   hyper_z = options["hyper_z"].doc("Hyper-diffusion in Z").withDefault(-1.0);
 
+  freeze_profiles = options["freeze_profiles"].doc("Subtract Z average from time derivatives?").withDefault<bool>(false);
+
   V.setBoundary(std::string("V") + name);
 
   diagnose = options["diagnose"]
@@ -245,6 +247,10 @@ void EvolveMomentum::finally(const Options &state) {
   // Note: Copy boundary condition so dump file has correct boundary.
   NV_solver.setBoundaryTo(NV);
   NV = NV_solver;
+
+  if (freeze_profiles) {
+    ddt(NV) -= DC(ddt(NV)); // Remove the DC, i.e. Z-averaged, component.
+  }
 }
 
 void EvolveMomentum::outputVars(Options &state) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -88,6 +88,8 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
     .doc("4th-order dissipation of temperature")
     .withDefault<BoutReal>(-1.0);
 
+  freeze_profiles = options["freeze_profiles"].doc("Subtract Z average from time derivatives?").withDefault<bool>(false);
+
   diagnose = options["diagnose"]
     .doc("Save additional output diagnostics")
     .withDefault<bool>(false);
@@ -556,6 +558,10 @@ void EvolvePressure::finally(const Options& state) {
   // Scale time derivatives
   if (state.isSet("scale_timederivs")) {
     ddt(P) *= get<Field3D>(state["scale_timederivs"]);
+  }
+
+  if (freeze_profiles) {
+    ddt(P) -= DC(ddt(P)); // Remove the DC, i.e. Z-averaged, component.
   }
 
   if (evolve_log) {

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -101,6 +101,8 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
 
   hyper_z = options["hyper_z"].doc("Hyper-viscosity in Z. < 0 -> off").withDefault(-1.0);
 
+  freeze_profiles = options["freeze_profiles"].doc("Subtract Z average from time derivatives?").withDefault<bool>(false);
+
   // Numerical dissipation terms
   // These are required to suppress parallel zig-zags in
   // cell centred formulations. Essentially adds (hopefully small)
@@ -758,6 +760,10 @@ void Vorticity::finally(const Options& state) {
         }
       }
     }
+  }
+
+  if (freeze_profiles) {
+    ddt(Vort) -= DC(ddt(Vort)); // Remove the DC, i.e. Z-averaged, component.
   }
 }
 


### PR DESCRIPTION
Removes the DC, i.e. Z-averaged, component of the time-derivatives. This effectively adds artificial, time-varying, sources and sinks to keep the profiles fixed. Not recommended for nonlinear simulations, but useful for linear analysis.