### PR TITLE
Viscous heating and energy conservation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ if(HERMES_TESTS)
   hermes_add_integrated_test(alfven-wave)
   hermes_add_integrated_test(collfreq-braginskii-afn)
   hermes_add_integrated_test(collfreq-multispecies)
+  hermes_add_integrated_test(2D-energy)
 
   # Unit tests
   option(HERMES_UNIT_TESTS "Build the unit tests" ON)

--- a/docs/sphinx/equations.rst
+++ b/docs/sphinx/equations.rst
@@ -1173,6 +1173,58 @@ The form of the vorticity equation is based on `Simakov & Catto
 with the first term modified to conserve energy. In the limit of zero
 ion pressure and constant :math:`B` it reduces to the simplified form.
 
+
+Kinematic viscosity can be included by setting e.g. ``viscosity = 0.1`` in SI units (m^2/s).
+This adds a diffusion of vorticity and corresponding ion heating.
+The viscous friction force in this simplified operator is
+
+.. math::
+
+   \mathbf{F}_\nu = - \nu B \mathbf{b} \times \nabla \Omega
+
+This gives rise to a drift and current with divergence:
+
+.. math::
+
+   \begin{aligned}\nabla\cdot\mathbf{J_{\nu}} =& \nabla\cdot\left[\frac{\mathbf{b}\times\mathbf{F}_\nu}{B}\right] \\
+   =& \nabla\cdot\left[\nu \nabla_\perp \Omega\right]\end{aligned}
+
+Viscous heating is calculated using the work done by a fluid velocity
+consistent with the Boussinesq approximation:
+
+.. math::
+
+   \mathbf{u} = \frac{\mathbf{b}\times\nabla\Phi}{B}
+
+where the generalized potential is
+
+.. math::
+
+   \Phi = \phi + \hat{p} / \overline{n}
+
+The work done is
+
+.. math::
+
+   \mathbf{F}_\nu\cdot\mathbf{u} = -\nu \nabla_\perp\Omega \cdot \nabla_\perp\Phi
+
+This heating is distributed between charged species in proportion to their local mass density.
+The properties of the work done can be analysed by writing in terms of a vector :math:`\mathbf{g}`:
+
+.. math::
+
+   \mathbf{g} = \frac{\overline{A}\overline{n}}{B^2}\nabla_\perp\Phi
+
+to write:
+
+.. math::
+
+   \begin{aligned}\mathbf{F}_\nu\cdot\mathbf{u} =& -\nu\frac{B^2}{\overline{A}\overline{n}} \nabla_\perp\left(\nabla\cdot\mathbf{g}\right)\cdot\mathbf{g} \\
+   =& \nu\frac{B^2}{\overline{A}\overline{n}} \left[\left(\nabla_\perp\mathbf{g} : \nabla_\perp\mathbf{g}\right) - \nabla\cdot\left(\mathbf{g}\cdot\nabla\mathbf{g}\right)\right]\end{aligned}
+
+The last term is not in general positive definite, so this simple form
+of viscosity could in some cases lead to cooling.
+
 .. doxygenstruct:: Vorticity
    :members:
 

--- a/include/braginskii_ion_viscosity.hxx
+++ b/include/braginskii_ion_viscosity.hxx
@@ -74,6 +74,7 @@ private:
   BoutReal bounce_frequency_epsilon; ///< Input inverse aspect ratio for including bounce
                                      ///< frequency change
   BoutReal bounce_frequency_R;       ///< Input major radius
+  BoutReal density_floor;            ///< Minimum density used in calculating Pi_ciperp
   bool diagnose;                     ///< Output additional diagnostics?
 
   /// Per-species diagnostics

--- a/include/braginskii_ion_viscosity.hxx
+++ b/include/braginskii_ion_viscosity.hxx
@@ -61,7 +61,8 @@ struct BraginskiiIonViscosity : public Component {
 
 private:
   BoutReal eta_limit_alpha; ///< Flux limit coefficient
-  bool perpendicular;       ///< Include perpendicular flow? (Requires phi)
+  bool parallel;            ///< Include parallel viscosity (requires parallel velocity)
+  bool perpendicular;       ///< Include perpendicular viscosity? (Requires phi)
   std::map<std::string, std::vector<std::string>>
       collision_names;                   ///< Collisions used for collisionality
   std::string viscosity_collisions_mode; ///< Collision selection, either multispecies or

--- a/include/polarisation_drift.hxx
+++ b/include/polarisation_drift.hxx
@@ -33,6 +33,34 @@ struct PolarisationDrift : public Component {
   PolarisationDrift(std::string name, Options &options, Solver *UNUSED(solver));
 
   void outputVars(Options &state) override;
+
+  // The following functions are public for unit testing
+
+  /// Calculate divergence of all currents except polarisation
+  Field3D calcDivJ(GuardedOptions& state);
+
+  /// Calculate energy exchange term nonlinear in pressure
+  /// due to compression of polarisation drift
+  ///   (3 / 2) ddt(Pi) += (Pi * m_i / n0 / Z) * DivJ
+  ///
+  /// Adds energy_source for all species that have charge, mass and pressure
+  /// Throws a BoutException if boussinesq=true
+  void diamagneticCompression(GuardedOptions& state, Field3D DivJ);
+
+  /// Solve for time derivative of potential
+  /// Using Div(mass_density / B^2 Grad_perp(dphi/dt)) = DivJ
+  Field3D calcMassDensity(GuardedOptions& state);
+
+  /// Calculate poloidal drift potential-flow approximation
+  Field3D calcPolFlowPotential(Field3D mass_density, Field3D DivJ);
+
+  /// Polarisation drift approximated by a potential flow
+  ///
+  /// v_p = - (m_i / (Z_i * B^2)) * Grad(phi_pol)
+  ///
+  /// Sets density_source, energy_source and momentum_source
+  /// for all species with mass and charge.
+  void polarisationAdvection(GuardedOptions& state, Field3D phi_pol);
 private:
   std::unique_ptr<Laplacian> phiSolver; // Laplacian solver in X-Z
 
@@ -72,32 +100,6 @@ private:
   ///     - momentum_source  (if momentum set)
   ///
   void transform_impl(GuardedOptions& state) override;
-
-  /// Calculate divergence of all currents except polarisation
-  Field3D calcDivJ(GuardedOptions& state);
-
-  /// Calculate energy exchange term nonlinear in pressure
-  /// due to compression of polarisation drift
-  ///   (3 / 2) ddt(Pi) += (Pi * m_i / n0 / Z) * DivJ
-  ///
-  /// Adds energy_source for all species that have charge, mass and pressure
-  /// Throws a BoutException if boussinesq=true
-  void diamagneticCompression(GuardedOptions& state, Field3D DivJ);
-
-  /// Solve for time derivative of potential
-  /// Using Div(mass_density / B^2 Grad_perp(dphi/dt)) = DivJ
-  Field3D calcMassDensity(GuardedOptions& state);
-
-  /// Calculate poloidal drift potential-flow approximation
-  Field3D calcPolFlowPotential(Field3D mass_density, Field3D DivJ);
-
-  /// Polarisation drift approximated by a potential flow
-  ///
-  /// v_p = - (m_i / (Z_i * B^2)) * Grad(phi_pol)
-  ///
-  /// Sets density_source, energy_source and momentum_source
-  /// for all species with mass and charge.
-  void polarisationAdvection(GuardedOptions& state, Field3D phi_pol);
 };
 
 namespace {

--- a/include/polarisation_drift.hxx
+++ b/include/polarisation_drift.hxx
@@ -40,8 +40,8 @@ private:
   
   // Diagnostic outputs
   bool diagnose; ///< Save diagnostic outputs?
-  Field3D DivJ; //< Divergence of all other currents
-  Field3D phi_pol; //< Polarisation drift potential
+  Field3D DivJ; ///< Divergence of all other currents
+  Field3D phi_pol; ///< Polarisation drift potential
 
   bool boussinesq; // If true, assume a constant mass density in Jpol
   BoutReal average_atomic_mass; // If boussinesq=true, mass density to use
@@ -70,8 +70,34 @@ private:
   ///     - density_source
   ///     - energy_source    (if pressure set)
   ///     - momentum_source  (if momentum set)
-  /// 
+  ///
   void transform_impl(GuardedOptions& state) override;
+
+  /// Calculate divergence of all currents except polarisation
+  Field3D calcDivJ(GuardedOptions& state);
+
+  /// Calculate energy exchange term nonlinear in pressure
+  /// due to compression of polarisation drift
+  ///   (3 / 2) ddt(Pi) += (Pi * m_i / n0 / Z) * DivJ
+  ///
+  /// Adds energy_source for all species that have charge, mass and pressure
+  /// Throws a BoutException if boussinesq=true
+  void diamagneticCompression(GuardedOptions& state, Field3D DivJ);
+
+  /// Solve for time derivative of potential
+  /// Using Div(mass_density / B^2 Grad_perp(dphi/dt)) = DivJ
+  Field3D calcMassDensity(GuardedOptions& state);
+
+  /// Calculate poloidal drift potential-flow approximation
+  Field3D calcPolFlowPotential(Field3D mass_density, Field3D DivJ);
+
+  /// Polarisation drift approximated by a potential flow
+  ///
+  /// v_p = - (m_i / (Z_i * B^2)) * Grad(phi_pol)
+  ///
+  /// Sets density_source, energy_source and momentum_source
+  /// for all species with mass and charge.
+  void polarisationAdvection(GuardedOptions& state, Field3D phi_pol);
 };
 
 namespace {

--- a/include/polarisation_drift.hxx
+++ b/include/polarisation_drift.hxx
@@ -70,6 +70,7 @@ private:
   bool diagnose; ///< Save diagnostic outputs?
   Field3D DivJ; ///< Divergence of all other currents
   Field3D phi_pol; ///< Polarisation drift potential
+  Options diagnostics; ///< Other diagnostic outputs
 
   bool boussinesq; // If true, assume a constant mass density in Jpol
   BoutReal average_atomic_mass; // If boussinesq=true, mass density to use

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -55,7 +55,7 @@ private:
 
   std::vector<RecycleChannel> channels; // Recycling channels
 
-  bool target_recycle, sol_recycle, pfr_recycle, neutral_pump;  ///< Flags for enabling recycling in different regions
+  bool target_recycle {false}, sol_recycle {false}, pfr_recycle {false}, neutral_pump {false};  ///< Flags for enabling recycling in different regions
   bool diagnose; ///< Save additional post-processing variables?
 
   BoutReal density_floor, pressure_floor; ///< minimum values for Nn, Pn to avoid divide by zero

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -84,6 +84,17 @@ struct Vorticity : public Component {
                    {{"long_name", "plasma potential"},
                     {"source", "vorticity"}});
   }
+
+  // The following are public functions for unit testing
+
+  /// Diamagnetic term in vorticity. Note this is weighted by the mass
+  /// This includes all species, including electrons
+  Field3D calculatePihat(GuardedOptions allspecies);
+
+  /// Calculates Div(Jdia) and sets energy_source for all
+  /// charged species with pressure.
+  Field3D calculateDivJdia(Field3D phi, GuardedOptions allspecies);
+
 private:
   Field3D Vort; // Evolving vorticity
 

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -121,6 +121,7 @@ private:
   Vector2D Curlb_B; // Curvature vector Curl(b/B)
   BoutReal hyper_z; ///< Hyper-viscosity in Z
   Field2D viscosity; ///< Kinematic viscosity
+  Field3D viscous_heating; ///< Heating due to kinematic viscosity
   bool include_viscosity; ///< Is viscosity > 0?
 
   // Diagnostic outputs

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -140,6 +140,7 @@ private:
   Vector2D Curlb_B; // Curvature vector Curl(b/B)
   BoutReal hyper_z; ///< Hyper-viscosity in Z
   Field2D viscosity; ///< Kinematic viscosity
+  bool include_viscosity; ///< Is viscosity > 0?
 
   // Diagnostic outputs
   Field3D DivJdia, DivJcol; // Divergence of diamagnetic and collisional current

--- a/src/braginskii_ion_viscosity.cxx
+++ b/src/braginskii_ion_viscosity.cxx
@@ -33,6 +33,8 @@ BraginskiiIonViscosity::BraginskiiIonViscosity(const std::string& name,
                                                Options& alloptions, Solver*)
     : Component({
         readIfSet("species:{non_electrons}:pressure"),
+        readIfSet("species:{non_electrons}:temperature"),
+        readIfSet("species:{non_electrons}:density"),
         readIfSet("species:{non_electrons}:velocity"),
         readIfSet("species:{non_electrons}:charge"),
         readIfSet("species:{non_electrons}:collision_frequencies:{coll_type}"),

--- a/src/polarisation_drift.cxx
+++ b/src/polarisation_drift.cxx
@@ -172,7 +172,7 @@ Field3D PolarisationDrift::calcMassDensity(GuardedOptions& state) {
     for (auto& kv : allspecies.getChildren()) {
       const GuardedOptions species = kv.second;
 
-      if (!(species.isSet("charge") and species.isSet("AA"))) {
+      if (!(species.isSet("charge") and species.isSet("AA") and species.isSet("density"))) {
         continue; // No charge or mass -> no current
       }
       if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {

--- a/src/polarisation_drift.cxx
+++ b/src/polarisation_drift.cxx
@@ -157,7 +157,15 @@ void PolarisationDrift::diamagneticCompression(GuardedOptions& state, Field3D Di
 
     Field3D energy_source = P * (AA / average_atomic_mass / charge) * DivJ;
 
-    diagnostics[fmt::format("E{}_pol", kv.first)] = energy_source;
+    if (diagnose) {
+      set_with_attrs(diagnostics[fmt::format("E{}_pol", kv.first)], energy_source,
+                     {{"time_dimension", "t"},
+                      {"units", "W m^-3"},
+                      //{"conversion", SI::qe * Tnorm * Nnorm * Omega_ci},
+                      {"long_name", "Compression of polarisation drift"},
+                      {"source", "polarisation_drift"}});
+    }
+
     add(species["energy_source"], energy_source);
   }
 }

--- a/src/polarisation_drift.cxx
+++ b/src/polarisation_drift.cxx
@@ -14,7 +14,8 @@ PolarisationDrift::PolarisationDrift(std::string name, Options& alloptions,
     // here. E.g., species without AA or momentum will be skipped.
     : Component({readIfSet("species:{all_species}:charge"),
                  readOnly("species:{charged}:{inputs}"),
-                 readIfSet("species:{charged}:{optional_inputs}"),
+                 readIfSet("species:{charged}:momentum"),
+                 readIfSet("species:{charged}:pressure", Regions::Interior),
                  readIfSet("fields:{fields}"),
                  readWrite("species:{charged}:{outputs}")}) {
   AUTO_TRACE();
@@ -75,8 +76,7 @@ PolarisationDrift::PolarisationDrift(std::string name, Options& alloptions,
     outputs.push_back("density_source");
     outputs.push_back("momentum_source");
   }
-  substitutePermissions("inputs", {"AA", "density"});
-  substitutePermissions("optional_inputs", {"momentum, pressure"});
+  substitutePermissions("inputs", inputs);
   substitutePermissions("fields", fields);
   // FIXME: energy_source and momentum source are only set if pressure
   // and momentum were set, respectively
@@ -180,7 +180,7 @@ void PolarisationDrift::transform_impl(GuardedOptions& state) {
     // Apply a floor to prevent divide-by-zero errors
     mass_density = floor(mass_density, density_floor);
   }
-  
+
   if (IS_SET(state["fields"]["DivJextra"])) {
     DivJ += get<Field3D>(state["fields"]["DivJextra"]);
   }

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -435,11 +435,14 @@ void Vorticity::transform_impl(GuardedOptions& state) {
         // Set midpoint (boundary) value
         for (int k = 0; k < mesh->LocalNz; k++) {
           phi(mesh->xstart - 1, j, k) = 2. * phivalue - phi(mesh->xstart, j, k);
-
-          // Note: This seems to make a difference, but don't know why.
-          // Without this, get convergence failures with no apparent instability
-          // (all fields apparently smooth, well behaved)
-          phi(mesh->xstart - 2, j, k) = phi(mesh->xstart - 1, j, k);
+        }
+        if (mesh->xstart > 1) {
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            // Note: This seems to make a difference, but don't know why.
+            // Without this, get convergence failures with no apparent instability
+            // (all fields apparently smooth, well behaved)
+            phi(mesh->xstart - 2, j, k) = phi(mesh->xstart - 1, j, k);
+          }
         }
       }
     }
@@ -455,11 +458,15 @@ void Vorticity::transform_impl(GuardedOptions& state) {
         // Set midpoint (boundary) value
         for (int k = 0; k < mesh->LocalNz; k++) {
           phi(mesh->xend + 1, j, k) = 2. * phivalue - phi(mesh->xend, j, k);
-
-          // Note: This seems to make a difference, but don't know why.
-          // Without this, get convergence failures with no apparent instability
-          // (all fields apparently smooth, well behaved)
-          phi(mesh->xend + 2, j, k) = phi(mesh->xend + 1, j, k);
+        }
+        if (mesh->xend < mesh->LocalNx - 2) {
+          for (int k = 0; k < mesh->LocalNz; k++) {
+        
+            // Note: This seems to make a difference, but don't know why.
+            // Without this, get convergence failures with no apparent instability
+            // (all fields apparently smooth, well behaved)
+            phi(mesh->xend + 2, j, k) = phi(mesh->xend + 1, j, k);
+          }
         }
       }
     }

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -218,7 +218,7 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver)
     setPermissions(readWrite("species:{charged}:energy_source"));
     setPermissions(readWrite("fields:DivJdia"));
   }
-  if (diamagnetic_polarisation or collisional_friction) {
+  if (diamagnetic_polarisation or collisional_friction or include_viscosity) {
     // FIXME: Only read if pressure also set
     setPermissions(readIfSet("species:{charged}:AA"));
   }
@@ -230,9 +230,11 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver)
     }
     setPermissions(readIfSet("species:e:temperature", Regions::Interior));
   }
+  if (collisional_friction or include_viscosity) {
+    setPermissions(readOnly("species:{charged}:density", Regions::Interior));
+  }
   if (collisional_friction) {
     setPermissions(readIfSet("species:{all_species}:charge"));
-    setPermissions(readOnly("species:{positive_ions}:density"));
     setPermissions(readIfSet("species:{positive_ions}:collision_frequency"));
     setPermissions(readWrite("fields:DivJcol"));
   }

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -479,7 +479,7 @@ void Vorticity::transform_impl(GuardedOptions& state) {
   //    and sets the boundary between cells to this value.
   //    This shift by 1/2 grid cell is important.
 
-  Field3D phi_plus_pi = copy(phi);// + Pi_hat;
+  Field3D phi_plus_pi = phi + Pi_hat;
 
   if (mesh->firstX()) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -677,9 +677,9 @@ void Vorticity::transform_impl(GuardedOptions& state) {
     // kinetic energy is proportional to mass
 
     Field3D sum_A_n = zeroFrom(Vort); // Sum of atomic mass * density
-    Options& allspecies = state["species"];
+    GuardedOptions allspecies = state["species"];
     for (const auto& kv : allspecies.getChildren()) {
-      const Options& species = kv.second;
+      const GuardedOptions species = kv.second;
 
       if (!(species.isSet("charge") and species.isSet("AA"))) {
         continue; // No charge or mass -> no current
@@ -694,7 +694,7 @@ void Vorticity::transform_impl(GuardedOptions& state) {
     }
 
     for (const auto& kv : allspecies.getChildren()) {
-      Options& species = allspecies[kv.first]; // Note: need non-const
+      GuardedOptions species = allspecies[kv.first]; // Note: need non-const
 
       if (!(species.isSet("charge") and species.isSet("AA"))) {
         continue; // No charge or mass -> no current

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -248,8 +248,10 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver)
     setPermissions(readIfSet("species:{charged}:pressure", Regions::Interior));
     setPermissions(readIfSet("species:{all_species}:charge"));
   }
-  if (diamagnetic) {
+  if (diamagnetic or include_viscosity) {
     setPermissions(readWrite("species:{charged}:energy_source"));
+  }
+  if (diamagnetic) {
     setPermissions(readWrite("fields:DivJdia"));
   }
   if (diamagnetic_polarisation or collisional_friction or include_viscosity) {
@@ -274,6 +276,103 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver)
   }
 }
 
+Field3D Vorticity::calculatePihat(GuardedOptions allspecies) {
+  Pi_hat = 0.0;
+  for (auto& kv : allspecies.getChildren()) {
+    GuardedOptions species = allspecies[kv.first]; // Note: need non-const
+
+    if (!(IS_SET_NOBOUNDARY(species["pressure"]) and species.isSet("charge")
+          and species.isSet("AA"))) {
+      continue; // No pressure, charge or mass -> no polarisation current
+    }
+
+    const auto charge = get<BoutReal>(species["charge"]);
+    if (fabs(charge) < 1e-5) {
+      // No charge
+      continue;
+    }
+
+    // Don't need sheath boundary
+    const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+    const auto AA = get<BoutReal>(species["AA"]);
+
+    Pi_hat += P * (AA / average_atomic_mass / charge);
+  }
+  Pi_hat.applyBoundary("neumann");
+  return Pi_hat;
+}
+
+Field3D Vorticity::calculateDivJdia(Field3D phi, GuardedOptions allspecies) {
+  Vector3D Jdia;
+  Jdia.x = 0.0;
+  Jdia.y = 0.0;
+  Jdia.z = 0.0;
+  Jdia.covariant = Curlb_B.covariant;
+
+  Vector3D Grad_phi = Grad(phi);
+
+  for (auto& kv : allspecies.getChildren()) {
+    GuardedOptions species = allspecies[kv.first]; // Note: need non-const
+
+    if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"]))) {
+      continue; // No pressure or charge -> no diamagnetic current
+    }
+    if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
+      // No charge
+      continue;
+    }
+
+    // Note that the species must have a charge, but charge is not used,
+    // because it cancels out in the expression for current
+
+    auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+
+    // Note: We need boundary conditions on P, so apply the same
+    //       free boundary condition as sheath_boundary.
+    if (P.hasParallelSlices()) {
+      Field3D &P_ydown = P.ydown();
+      Field3D &P_yup = P.yup();
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          P_ydown(r.ind, mesh->ystart - 1, jz) = 2 * P(r.ind, mesh->ystart, jz) - P_yup(r.ind, mesh->ystart + 1, jz);
+        }
+      }
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          P_yup(r.ind, mesh->yend + 1, jz) = 2 * P(r.ind, mesh->yend, jz) - P_ydown(r.ind, mesh->yend - 1, jz);
+        }
+      }
+    } else {
+      Field3D P_fa = toFieldAligned(P);
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(P_fa, r.ind, mesh->ystart, jz);
+          P_fa[i.ym()] = limitFree(P_fa[i.yp()], P_fa[i]);
+        }
+      }
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(P_fa, r.ind, mesh->yend, jz);
+          P_fa[i.yp()] = limitFree(P_fa[i.ym()], P_fa[i]);
+        }
+      }
+      P = fromFieldAligned(P_fa);
+    }
+
+    Vector3D Jdia_species = P * Curlb_B; // Diamagnetic current for this species
+
+    // This term energetically balances diamagnetic term
+    // in the vorticity equation
+    subtract(species["energy_source"], Jdia_species * Grad_phi);
+
+    Jdia += Jdia_species; // Collect total diamagnetic current
+  }
+
+  // Note: This term is central differencing so that it balances
+  // the corresponding compression term in the species pressure equations
+  return Div(Jdia);
+}
+
 void Vorticity::transform_impl(GuardedOptions& state) {
   AUTO_TRACE();
 
@@ -286,32 +385,8 @@ void Vorticity::transform_impl(GuardedOptions& state) {
   //       and only phi is considered, not phi + Pi which is handled in Boussinesq solves
   Pi_hat = 0.0; // Contribution from ion pressure, weighted by atomic mass / charge
   if (diamagnetic_polarisation) {
-    // Diamagnetic term in vorticity. Note this is weighted by the mass
-    // This includes all species, including electrons
-    GuardedOptions allspecies = state["species"];
-    for (auto& kv : allspecies.getChildren()) {
-      GuardedOptions species = allspecies[kv.first]; // Note: need non-const
-
-      if (!(IS_SET_NOBOUNDARY(species["pressure"]) and species.isSet("charge")
-            and species.isSet("AA"))) {
-        continue; // No pressure, charge or mass -> no polarisation current
-      }
-
-      const auto charge = get<BoutReal>(species["charge"]);
-      if (fabs(charge) < 1e-5) {
-        // No charge
-        continue;
-      }
-
-      // Don't need sheath boundary
-      const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
-      const auto AA = get<BoutReal>(species["AA"]);
-
-      Pi_hat += P * (AA / average_atomic_mass / charge);
-    }
+    Pi_hat = calculatePihat(state["species"]);
   }
-
-  Pi_hat.applyBoundary("neumann");
 
   if (phi_boundary_relax) {
     // Update the boundary regions by relaxing towards zero gradient
@@ -544,113 +619,42 @@ void Vorticity::transform_impl(GuardedOptions& state) {
     }
   }
 
+  // Note: The below calculation requires phi derivatives at the Y boundaries
+  //       Setting to free boundaries
+  if (phi.hasParallelSlices()) {
+    Field3D &phi_ydown = phi.ydown();
+    Field3D &phi_yup = phi.yup();
+    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        phi_ydown(r.ind, mesh->ystart - 1, jz) = 2 * phi(r.ind, mesh->ystart, jz) - phi_yup(r.ind, mesh->ystart + 1, jz);
+      }
+    }
+    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        phi_yup(r.ind, mesh->yend + 1, jz) = 2 * phi(r.ind, mesh->yend, jz) - phi_ydown(r.ind, mesh->yend - 1, jz);
+      }
+    }
+  } else {
+    Field3D phi_fa = toFieldAligned(phi);
+    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        phi_fa(r.ind, mesh->ystart - 1, jz) = 2 * phi_fa(r.ind, mesh->ystart, jz) - phi_fa(r.ind, mesh->ystart + 1, jz);
+      }
+    }
+    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        phi_fa(r.ind, mesh->yend + 1, jz) = 2 * phi_fa(r.ind, mesh->yend, jz) - phi_fa(r.ind, mesh->yend - 1, jz);
+      }
+    }
+    phi = fromFieldAligned(phi_fa);
+  }
+
   ddt(Vort) = 0.0;
 
   if (diamagnetic) {
     // Diamagnetic current. This is calculated here so that the energy sources/sinks
     // can be calculated for the evolving species.
-
-    Vector3D Jdia;
-    Jdia.x = 0.0;
-    Jdia.y = 0.0;
-    Jdia.z = 0.0;
-    Jdia.covariant = Curlb_B.covariant;
-
-    // Pre-calculate this rather than calculate for each species
-    // Note: The below calculation requires phi derivatives at the Y boundaries
-    //       Setting to free boundaries
-    if (phi.hasParallelSlices()) {
-      Field3D &phi_ydown = phi.ydown();
-      Field3D &phi_yup = phi.yup();
-      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-        for (int jz = 0; jz < mesh->LocalNz; jz++) {
-          phi_ydown(r.ind, mesh->ystart - 1, jz) = 2 * phi(r.ind, mesh->ystart, jz) - phi_yup(r.ind, mesh->ystart + 1, jz);
-        }
-      }
-      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-        for (int jz = 0; jz < mesh->LocalNz; jz++) {
-          phi_yup(r.ind, mesh->yend + 1, jz) = 2 * phi(r.ind, mesh->yend, jz) - phi_ydown(r.ind, mesh->yend - 1, jz);
-        }
-      }
-    } else {
-      Field3D phi_fa = toFieldAligned(phi);
-      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-        for (int jz = 0; jz < mesh->LocalNz; jz++) {
-          phi_fa(r.ind, mesh->ystart - 1, jz) = 2 * phi_fa(r.ind, mesh->ystart, jz) - phi_fa(r.ind, mesh->ystart + 1, jz);
-        }
-      }
-      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-        for (int jz = 0; jz < mesh->LocalNz; jz++) {
-          phi_fa(r.ind, mesh->yend + 1, jz) = 2 * phi_fa(r.ind, mesh->yend, jz) - phi_fa(r.ind, mesh->yend - 1, jz);
-        }
-      }
-      phi = fromFieldAligned(phi_fa);
-    }
-
-    Vector3D Grad_phi = Grad(phi);
-
-    GuardedOptions allspecies = state["species"];
-
-    for (auto& kv : allspecies.getChildren()) {
-      GuardedOptions species = allspecies[kv.first]; // Note: need non-const
-
-      if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"]))) {
-        continue; // No pressure or charge -> no diamagnetic current
-      }
-      if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
-        // No charge
-        continue;
-      }
-
-      // Note that the species must have a charge, but charge is not used,
-      // because it cancels out in the expression for current
-
-      auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
-
-      // Note: We need boundary conditions on P, so apply the same
-      //       free boundary condition as sheath_boundary.
-      if (P.hasParallelSlices()) {
-        Field3D &P_ydown = P.ydown();
-        Field3D &P_yup = P.yup();
-        for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-          for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            P_ydown(r.ind, mesh->ystart - 1, jz) = 2 * P(r.ind, mesh->ystart, jz) - P_yup(r.ind, mesh->ystart + 1, jz);
-          }
-        }
-        for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-          for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            P_yup(r.ind, mesh->yend + 1, jz) = 2 * P(r.ind, mesh->yend, jz) - P_ydown(r.ind, mesh->yend - 1, jz);
-          }
-        }
-      } else {
-        Field3D P_fa = toFieldAligned(P);
-        for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-          for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            auto i = indexAt(P_fa, r.ind, mesh->ystart, jz);
-            P_fa[i.ym()] = limitFree(P_fa[i.yp()], P_fa[i]);
-          }
-        }
-        for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-          for (int jz = 0; jz < mesh->LocalNz; jz++) {
-            auto i = indexAt(P_fa, r.ind, mesh->yend, jz);
-            P_fa[i.yp()] = limitFree(P_fa[i.ym()], P_fa[i]);
-          }
-        }
-        P = fromFieldAligned(P_fa);
-      }
-
-      Vector3D Jdia_species = P * Curlb_B; // Diamagnetic current for this species
-
-      // This term energetically balances diamagnetic term
-      // in the vorticity equation
-      subtract(species["energy_source"], Jdia_species * Grad_phi);
-
-      Jdia += Jdia_species; // Collect total diamagnetic current
-    }
-
-    // Note: This term is central differencing so that it balances
-    // the corresponding compression term in the species pressure equations
-    DivJdia = Div(Jdia);
+    DivJdia = calculateDivJdia(phi, state["species"]);
     ddt(Vort) += DivJdia;
 
     set(fields["DivJdia"], DivJdia);

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -266,9 +266,9 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver)
   }
   if (collisional_friction or include_viscosity) {
     setPermissions(readOnly("species:{charged}:density", Regions::Interior));
+    setPermissions(readIfSet("species:{all_species}:charge"));
   }
   if (collisional_friction) {
-    setPermissions(readIfSet("species:{all_species}:charge"));
     setPermissions(readIfSet("species:{positive_ions}:collision_frequency"));
     setPermissions(readWrite("fields:DivJcol"));
   }
@@ -722,7 +722,7 @@ void Vorticity::transform_impl(GuardedOptions& state) {
     for (const auto& kv : allspecies.getChildren()) {
       const GuardedOptions species = kv.second;
 
-      if (!(species.isSet("charge") and species.isSet("AA"))) {
+      if (!(species.isSet("charge") and species.isSet("AA") and species.isSet("density"))) {
         continue; // No charge or mass -> no current
       }
       if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
@@ -737,7 +737,7 @@ void Vorticity::transform_impl(GuardedOptions& state) {
     for (const auto& kv : allspecies.getChildren()) {
       GuardedOptions species = allspecies[kv.first]; // Note: need non-const
 
-      if (!(species.isSet("charge") and species.isSet("AA"))) {
+      if (!(species.isSet("charge") and species.isSet("AA") and species.isSet("density"))) {
         continue; // No charge or mass -> no current
       }
       if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {

--- a/tests/integrated/2D-energy/README.md
+++ b/tests/integrated/2D-energy/README.md
@@ -1,0 +1,21 @@
+# 2D energy test
+
+Evolves vorticity, electron density, electron and ion pressure in a 2D
+(32 x 32) box with curvature. Includes kinematic viscosity and ion
+polarisation compression term.
+
+The simulation starts with a non-uniform pressure that is unstable to
+interchange modes. Electron and ion thermal energy is converted to
+perpendicular motion. Viscosity then dissipates the flow, converting
+the flow energy mainly to ion thermal energy.
+
+The expected result is that electron pressure at the end is lower than
+the start, because it has been converted to perpendicular motion. The
+ion pressure should be higher at the end than at the start, because
+motion is converted to ion heat. The total (ion + electron) pressure
+should be higher at the end than the start, because potential energy
+in the initial unstable state has been converted to thermal energy.
+
+This test checks the sign of the electron, ion and total pressure
+changes.  It is very low resolution so does not check the values or
+convergence.

--- a/tests/integrated/2D-energy/data/BOUT.inp
+++ b/tests/integrated/2D-energy/data/BOUT.inp
@@ -1,0 +1,96 @@
+nout = 20
+timestep = 1000
+
+MYG = 0  # No guard cells in Y, 2D simulation
+
+[mesh]
+nx = 36
+ny = 1
+nz = 32
+
+Lrad = 0.05  # Radial width of domain [m]
+Lpol = 0.05  # Poloidal size of domain [m]
+
+Bpxy = 0.35  # Poloidal magnetic field [T]
+Rxy = 1.5   # Major radius [meters]
+
+dx = Lrad * Rxy * Bpxy / (nx - 4)  # Poloidal flux
+dz = Lpol / Rxy / nz   # Angle
+
+hthe = 1
+sinty = 0
+Bxy = Bpxy
+Btxy = 0
+bxcvz = 1./Rxy^2  # Curvature
+
+[solver]
+mxstep = 10000
+
+[hermes]
+# Two species, electrons and ions
+components = e, h+, vorticity, polarisation_drift
+
+recalculate_metric = true  # Calculate metrics from Rxy, Bpxy etc.
+
+Nnorm = 2e18
+Bnorm = mesh:Bxy
+Tnorm = 5
+
+[e]
+type = evolve_density, evolve_pressure
+
+charge = -1
+AA = 1/1836
+
+poloidal_flows = false  # Y flows due to ExB
+thermal_conduction = false  # Parallel heat conduction
+
+[Ne]
+
+function = 1
+
+bndry_all = neumann
+
+[Pe]
+function = 1 + 0.1 * sin(2*pi*x - z)
+bndry_all = neumann
+
+[h+]
+# Set the density so that the plasma is quasineutral
+type = quasineutral, evolve_pressure
+
+charge = 1
+AA = 1
+
+bndry_flux = true
+poloidal_flows = false
+thermal_conduction = false
+
+[Ph+]
+function = Pe:function
+bndry_all = neumann
+
+[vorticity]
+
+diamagnetic = true   # Include diamagnetic current?
+diamagnetic_polarisation = true # Include diamagnetic drift in polarisation current?
+average_atomic_mass = 1.0   # Weighted average atomic mass, for polarisaion current
+bndry_flux = false # Allow flows through radial boundaries
+poloidal_flows = false  # Include poloidal ExB flow
+split_n0 = false  # Split phi into n=0 and n!=0 components
+phi_dissipation = false
+
+phi_boundary_relax = true
+
+phi_dissipation = false # No parallel dynamics
+
+viscosity = 1.0
+
+diagnose = false
+
+[polarisation_drift]
+diamagnetic_polarisation = vorticity:diamagnetic_polarisation
+advection = false
+average_atomic_mass = vorticity:average_atomic_mass
+diagnose = false
+

--- a/tests/integrated/2D-energy/runtest
+++ b/tests/integrated/2D-energy/runtest
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Python script to run and analyse 2D energy test
+
+from boututils.run_wrapper import shell, launch_safe, getmpirun
+from boutdata.collect import collect
+
+import numpy as np
+
+path = "data"
+nproc = 1
+
+# Link to the executable
+shell("ln -s ../../../hermes-3 hermes-3")
+
+# Delete old data
+shell("rm data/BOUT.dmp.*.nc")
+
+# Launch using MPI
+s, out = launch_safe("./hermes-3 -d data", nproc=nproc, pipe=True)
+
+# Save output to log file
+f = open("run.log", "w")
+f.write(out)
+f.close()
+
+# Collect data
+pe = collect("Pe", path=path, info=False)
+pi = collect("Ph+", path=path, info=False)
+
+pe_tot = np.mean(pe[:, 2:-2, 0, :], axis=(1,2))
+pi_tot = np.mean(pi[:, 2:-2, 0, :], axis=(1,2))
+p_tot = pe_tot + pi_tot
+
+success = True
+
+# Expect electron pressure to fall
+if pe_tot[-1] > pe_tot[0]:
+  print(f"Expected final Pe ({pe_tot[-1]}) to be lower than initial ({pe_tot[0]})")
+  success = False
+
+# Expect ion pressure to rise
+if pi_tot[-1] < pi_tot[0]:
+  print(f"Expected final Ph+ ({pi_tot[-1]}) to be higher than initial ({pi_tot[0]})")
+  success = False
+
+# Expect total pressure to rise
+if p_tot[-1] < p_tot[0]:
+  print(f"Expected final P ({p_tot[-1]}) to be higher than initial ({p_tot[0]})")
+  success = False
+
+if success:
+  print(" => Test passed")
+  exit(0)
+else:
+  print(" => Test failed")
+  exit(1)

--- a/tests/unit/test_braginskii_ion_viscosity.cxx
+++ b/tests/unit/test_braginskii_ion_viscosity.cxx
@@ -56,6 +56,7 @@ TEST_F(BraginskiiIonViscosityTest, ViscosityPressureScaling) {
   Options state1;
   Options state2;
   state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["temperature"] = 1;
   state1["species"]["d+"]["charge"] = 1;
   state1["species"]["d+"]["AA"] = 2.;
   state1["species"]["d+"]["velocity"] = linearGradient(1., 0., 1., 1., 1., 0., 0.);
@@ -85,6 +86,7 @@ TEST_F(BraginskiiIonViscosityTest, ViscosityCollisionScaling) {
   Options state1;
   Options state2;
   state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["temperature"] = 1;
   state1["species"]["d+"]["charge"] = 1;
   state1["species"]["d+"]["AA"] = 2.;
   state1["species"]["d+"]["velocity"] = linearGradient(1., 0., 1., 1., 1., 0., 0.);
@@ -117,6 +119,7 @@ TEST_F(BraginskiiIonViscosityTest, ViscosityVelocityScaling) {
   Options state1;
   Options state2;
   state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["temperature"] = 1;
   state1["species"]["d+"]["charge"] = 1;
   state1["species"]["d+"]["AA"] = 2.;
   state1["species"]["d+"]["collision_frequencies"]["d+_d+_coll"] = 0.5;
@@ -152,6 +155,7 @@ TEST_F(BraginskiiIonViscosityTest, ViscosityCollisionMode) {
   Options state1;
   Options state2;
   state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["temperature"] = 1;
   state1["species"]["d+"]["charge"] = 1;
   state1["species"]["d+"]["AA"] = 2.;
   state1["species"]["d+"]["velocity"] = linearGradient(1., 0., 1., 1., 1., 0., 0.);

--- a/tests/unit/test_polarisation_drift.cxx
+++ b/tests/unit/test_polarisation_drift.cxx
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/polarisation_drift.hxx"
+#include <bout/invert_laplace.hxx>
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+using PolarisationDriftTest = FakeMeshFixture;
+
+TEST_F(PolarisationDriftTest, CreateComponent) {
+  Options options;
+
+  PolarisationDrift component("test", options, nullptr);
+}
+

--- a/tests/unit/test_polarisation_drift.cxx
+++ b/tests/unit/test_polarisation_drift.cxx
@@ -25,3 +25,124 @@ TEST_F(PolarisationDriftTest, CreateComponent) {
   PolarisationDrift component("test", options, nullptr);
 }
 
+TEST_F(PolarisationDriftTest, calcDivJZero) {
+  Options options;
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {};
+  Permissions permissions {};
+  GuardedOptions guarded_state {&state, &permissions};
+  Field3D DivJ = component.calcDivJ(guarded_state);
+  ASSERT_TRUE(IsFieldEqual(DivJ, 0.0, "RGN_NOBNDRY"));
+}
+
+TEST_F(PolarisationDriftTest, calcDivJdia) {
+  Options options;
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {{"fields",
+                  {{"DivJdia", 1.0}}}};
+  Permissions permissions {{readOnly("fields")}};
+  GuardedOptions guarded_state {&state, &permissions};
+  Field3D DivJ = component.calcDivJ(guarded_state);
+  ASSERT_TRUE(IsFieldEqual(DivJ, 1.0, "RGN_NOBNDRY"));
+}
+
+TEST_F(PolarisationDriftTest, diamagneticCompression) {
+  Options options {{"polarisation_drift",
+                    {{"average_atomic_mass", 1.5}}}};
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {{"species",
+                  {{"d+",
+                    {{"pressure", 1.2},
+                     {"AA", 2.0},
+                     {"charge", 1.4}}}}}};
+  Permissions permissions {{readOnly("species"),
+                              readWrite("species:d+:energy_source")}};
+  GuardedOptions guarded_state {&state, &permissions};
+  component.diamagneticCompression(guarded_state, 3.0);
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(state["species"]["d+"]["energy_source"]),
+                           1.2 * 2.0 * 3.0 / 1.5 / 1.4, "RGN_NOBNDRY"));
+}
+
+TEST_F(PolarisationDriftTest, calcMassDensityBoussinesq) {
+  Options options {{"polarisation_drift",
+                    {{"boussinesq", true},
+                     {"average_atomic_mass", 1.5}}}};
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {};
+  Permissions permissions {};
+  GuardedOptions guarded_state {&state, &permissions};
+  Field3D mass_density = component.calcMassDensity(guarded_state);
+  ASSERT_TRUE(IsFieldEqual(mass_density, 1.5, "RGN_NOBNDRY"));
+}
+
+TEST_F(PolarisationDriftTest, calcMassDensityNonBoussinesq) {
+  Options options {{"polarisation_drift",
+                    {{"boussinesq", false}}}};
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {{"species",
+                  {{"d+",
+                    {{"AA", 2.0},
+                     {"charge", 1.0},
+                     {"density", 3.0}}}}}};
+  Permissions permissions {{readOnly("species")}};
+  GuardedOptions guarded_state {&state, &permissions};
+  Field3D mass_density = component.calcMassDensity(guarded_state);
+  ASSERT_TRUE(IsFieldEqual(mass_density, 6.0, "RGN_NOBNDRY"));
+}
+
+TEST_F(PolarisationDriftTest, polarisationAdvection) {
+  Options options;
+
+  PolarisationDrift component("polarisation_drift", options, nullptr);
+
+  Options state {{"species",
+                  {{"d+",
+                    {{"charge", 1.0},
+                     {"AA", 2.0},
+                     {"density", 1.0},
+                     {"pressure", 1.0},
+                     {"momentum", 1.0}}},
+                   {"i",
+                    {{"charge", 1.0},
+                     {"AA", 2.0},
+                     {"density", 1.0},
+                     {"momentum", 1.0}}},
+                   {"d",
+                    {{"AA", 2.0}}},
+                   {"d2",
+                    {{"charge", 0.0},
+                     {"AA", 4.0}}},
+                   {"massless",
+                    {{"charge", 1.0}}}}}};
+
+  Permissions permissions {{
+      readOnly("species"),
+      readWrite("species:d+:density_source"),
+      readWrite("species:d+:energy_source"),
+      readWrite("species:d+:momentum_source"),
+      readWrite("species:i:density_source"),
+      readWrite("species:i:momentum_source"),
+    }};
+  GuardedOptions guarded_state {&state, &permissions};
+  component.polarisationAdvection(guarded_state, 0.0);
+  ASSERT_TRUE(state["species"]["d+"].isSet("density_source"));
+  ASSERT_TRUE(state["species"]["d+"].isSet("energy_source"));
+  ASSERT_TRUE(state["species"]["d+"].isSet("momentum_source"));
+
+  ASSERT_TRUE(state["species"]["i"].isSet("density_source"));
+  ASSERT_TRUE(state["species"]["i"].isSet("momentum_source"));
+
+  ASSERT_FALSE(state["species"]["d"].isSet("density_source"));
+  ASSERT_FALSE(state["species"]["d"].isSet("energy_source"));
+  ASSERT_FALSE(state["species"]["d"].isSet("momentum_source"));
+}

--- a/tests/unit/test_vorticity.cxx
+++ b/tests/unit/test_vorticity.cxx
@@ -52,3 +52,34 @@ TEST_F(VorticityTest, Transform) {
   ASSERT_TRUE(state["fields"].isSet("vorticity"));
   ASSERT_TRUE(state["fields"].isSet("phi"));
 }
+
+TEST_F(VorticityTest, KinematicViscosity) {
+  FakeSolver solver;
+
+  Options::root()["mesh"]["paralleltransform"]["type"] = "shifted";
+  Options options {{"units",
+                    {{"seconds", 1.0},
+                     {"Tesla", 1.0},
+                     {"meters", 1.0}}},
+                   {"test",
+                    {{"viscosity", 1.0}}}};
+
+  Vorticity component("test", options, &solver);
+  component.declareAllSpecies({{"e"},
+                               {"d"},
+                               {"d+"},
+                               {}});
+
+  Options state {{"species",
+                  {{"d+",
+                    {{"AA", 2.0},
+                     {"charge", 1.0},
+                     {"density", 1.0}}},
+                   {"d",
+                    {{"AA", 2.0},
+                     {"density", 1.0}}}}}};
+  component.transform(state);
+
+  ASSERT_TRUE(state["species"]["d+"].isSet("energy_source"));
+  ASSERT_FALSE(state["species"]["d"].isSet("energy_source"));
+}

--- a/tests/unit/test_vorticity.cxx
+++ b/tests/unit/test_vorticity.cxx
@@ -1,0 +1,54 @@
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_solver.hxx"
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/vorticity.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+using VorticityTest = FakeMeshFixture;
+
+TEST_F(VorticityTest, CreateComponent) {
+  FakeSolver solver;
+
+  Options::root()["mesh"]["paralleltransform"]["type"] = "shifted";
+  Options options {{"units",
+                    {{"seconds", 1.0},
+                     {"Tesla", 1.0},
+                     {"meters", 1.0}}}};
+
+  Vorticity component("test", options, &solver);
+
+  Options state = solver.getState();
+
+  ASSERT_TRUE(state.isSet("Vort"));
+}
+
+TEST_F(VorticityTest, Transform) {
+  FakeSolver solver;
+
+  Options::root()["mesh"]["paralleltransform"]["type"] = "shifted";
+  Options options {{"units",
+                    {{"seconds", 1.0},
+                     {"Tesla", 1.0},
+                     {"meters", 1.0}}}};
+
+  Vorticity component("test", options, &solver);
+
+  Options state;
+  component.transform(state);
+
+  ASSERT_TRUE(state["fields"].isSet("vorticity"));
+  ASSERT_TRUE(state["fields"].isSet("phi"));
+}


### PR DESCRIPTION
- Adds viscous heating terms to balance kinematic viscosity in the `vorticity` component. Previously this energy would be lost from the system. Includes manual writeup. 
- Integrated test of vorticity with viscosity, checking for expected heating.
- Extend `braginskii_ion_viscosity` perpendicular viscosity, to include Z derivatives. 
- GuardedOptions permissions fixes in `vorticity` and `polarisation_drift`
- Unit testing of `polarisation_drift` and `vorticity` components. Some refactoring of the `transform_impl` function into smaller pieces for testing.