### PR TITLE
Fix AA permissions in neutral_boundary

### DIFF
--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -9,7 +9,8 @@ NeutralBoundary::NeutralBoundary(std::string name, Options& alloptions,
                                  [[maybe_unused]] Solver* solver)
     : Component({writeBoundary("species:{name}:{outputs}"),
                  writeBoundaryIfSet("species:{name}:{conditional_outputs}"),
-                 readWrite("species:{name}:energy_source")}),
+                 readWrite("species:{name}:energy_source"),
+                 readOnly("species:{name}:AA")}),
       name(name) {
   AUTO_TRACE();
 


### PR DESCRIPTION
`neutral_boundary` was missing the permission to read `AA`.