### PR TITLE
Suppress permission warnings

### DIFF
--- a/include/guarded_options.hxx
+++ b/include/guarded_options.hxx
@@ -51,22 +51,22 @@ public:
   /// Returns a list of variables with read-only permission but which
   /// have not been accessed using the `get()` method.
   std::map<std::string, Regions> unreadItems() const {
-#if CHECKLEVEL >= 1
+#if CHECKLEVEL >= 999
     return *unread_variables;
 #else
     throw BoutException(
-        "Reading of items in GuardedOptions is not tracked when CHECKLEVEL < 1");
+        "Reading of items in GuardedOptions is currently disabled");
 #endif
   }
 
   /// Returns a list of variables with read-write permission but which
   /// have not been accessed using the `getWritable()` method.
   std::map<std::string, Regions> unwrittenItems() const {
-#if CHECKLEVEL >= 1
+#if CHECKLEVEL >= 999
     return *unwritten_variables;
 #else
     throw BoutException(
-        "Reading of items in GuardedOptions is not tracked when CHECKLEVEL < 1");
+        "Reading of items in GuardedOptions is currently disabled");
 #endif
   }
 

--- a/src/component.cxx
+++ b/src/component.cxx
@@ -20,7 +20,7 @@ std::unique_ptr<Component> Component::create(const std::string &type,
 void Component::transform(Options& state) {
   GuardedOptions guarded(&state, &state_variable_access);
   transform_impl(guarded);
-#if CHECKLEVEL >= 4
+#if CHECKLEVEL >= 999
   for (auto& [varname, region] : guarded.unreadItems()) {
     output_warn.write("Did not read from state variable {} in region(s) {}\n", varname,
                       Permissions::regionNames(region));

--- a/src/component.cxx
+++ b/src/component.cxx
@@ -20,7 +20,7 @@ std::unique_ptr<Component> Component::create(const std::string &type,
 void Component::transform(Options& state) {
   GuardedOptions guarded(&state, &state_variable_access);
   transform_impl(guarded);
-#if CHECKLEVEL >= 1
+#if CHECKLEVEL >= 3
   for (auto& [varname, region] : guarded.unreadItems()) {
     output_warn.write("Did not read from state variable {} in region(s) {}\n", varname,
                       Permissions::regionNames(region));

--- a/src/component.cxx
+++ b/src/component.cxx
@@ -20,7 +20,7 @@ std::unique_ptr<Component> Component::create(const std::string &type,
 void Component::transform(Options& state) {
   GuardedOptions guarded(&state, &state_variable_access);
   transform_impl(guarded);
-#if CHECKLEVEL >= 3
+#if CHECKLEVEL >= 4
   for (auto& [varname, region] : guarded.unreadItems()) {
     output_warn.write("Did not read from state variable {} in region(s) {}\n", varname,
                       Permissions::regionNames(region));

--- a/src/guarded_options.cxx
+++ b/src/guarded_options.cxx
@@ -36,7 +36,7 @@ GuardedOptions::GuardedOptions(Options* options, Permissions* permissions)
     throw BoutException(
         "Can not construct GuardedOptions with null permissions pointer.");
   }
-#if CHECKLEVEL >= 1
+#if CHECKLEVEL >= 999
   *unread_variables = permissions->getVariablesWithPermission(PermissionTypes::Read);
   // Only add variables with permission ReadIfSet to
   // unread_variables if they are already present in the options
@@ -81,7 +81,9 @@ const Options& GuardedOptions::get([[maybe_unused]] Regions region) const {
       throw BoutException(
           "Only have permission to read {} if it is already set, which it is not.", name);
     }
+#if CHECKLEVEL >= 999
     updateAccessRecords(*unread_variables, varname, region);
+#endif
     return *options;
   }
   throw BoutException("Do not have read permission for {}.", name);
@@ -95,7 +97,9 @@ Options& GuardedOptions::getWritable([[maybe_unused]] Regions region) {
   const std::string name = options->str();
   auto [access, varname] = permissions->canAccess(name, PermissionTypes::Write, region);
   if (access) {
+#if CHECKLEVEL >= 999
     updateAccessRecords(*unwritten_variables, varname, region);
+#endif
     return *options;
   }
   throw BoutException("Do not have write permission for {}.", options->str());

--- a/tests/unit/test_guarded_options.cxx
+++ b/tests/unit/test_guarded_options.cxx
@@ -137,6 +137,7 @@ TEST_F(GuardedOptionsTests, TestGetWritableException) {
       guarded_opts["species"]["d"]["pressure_suffix"].getWritable(Regions::Interior),
       BoutException);
 }
+#endif
 
 TEST_F(GuardedOptionsTests, TestUnreadItems) {
   const std::map<std::string, Regions> expected1 = {
@@ -154,22 +155,38 @@ TEST_F(GuardedOptionsTests, TestUnreadItems) {
   const std::map<std::string, Regions> expected3 = {{"species:d", Regions::All}};
   const std::map<std::string, Regions> expected4;
 
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unreadItems(), expected1);
+#else
+  EXPECT_THROW(guarded_opts.unreadItems(), BoutException);
+#endif
 
   guarded_opts["species:he:density"].get(Regions::Interior);
   guarded_opts["species:d:pressure"].get(Regions::Interior);
   guarded_opts["species:d:collision_frequencies:d_d_coll"].getWritable(
       Regions::Boundaries);
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unreadItems(), expected2);
+#else
+  EXPECT_THROW(guarded_opts.unreadItems(), BoutException);
+#endif
 
   guarded_opts["species"]["he"]["charge"].get();
   guarded_opts["species"]["he"]["density"].get();
   guarded_opts["species:he:velocity"].get(Regions::Boundaries);
   EXPECT_FALSE(guarded_opts["unused"]["option"].get().isSet());
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unreadItems(), expected3);
+#else
+  EXPECT_THROW(guarded_opts.unreadItems(), BoutException);
+#endif
 
   guarded_opts["species:d:velocity"].get();
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unreadItems(), expected4);
+#else
+  EXPECT_THROW(guarded_opts.unreadItems(), BoutException);
+#endif
 }
 
 TEST_F(GuardedOptionsTests, TestUnwrittenItems) {
@@ -183,22 +200,37 @@ TEST_F(GuardedOptionsTests, TestUnwrittenItems) {
       {"species:d:pressure", Regions::Interior}};
   const std::map<std::string, Regions> expected3;
 
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unwrittenItems(), expected1);
+#else
+  EXPECT_THROW(guarded_opts.unwrittenItems(), BoutException);
+#endif
 
   guarded_opts["species:he:pressure"].get(Regions::Interior);
   guarded_opts["species:he:collision_frequency"].get();
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unwrittenItems(), expected1);
+#else
+  EXPECT_THROW(guarded_opts.unwrittenItems(), BoutException);
+#endif
 
   guarded_opts["species"]["he"]["pressure"].getWritable(Regions::Interior);
   guarded_opts["species:d:collision_frequencies:d_d_coll"].getWritable(
       Regions::Boundaries);
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unwrittenItems(), expected2);
+#else
+  EXPECT_THROW(guarded_opts.unwrittenItems(), BoutException);
+#endif
 
   guarded_opts["species:he:collision_frequency"].getWritable();
   guarded_opts["species:d:pressure"].getWritable(Regions::Interior);
+#if CHECKLEVEL >= 999
   EXPECT_EQ(guarded_opts.unwrittenItems(), expected3);
-}
+#else
+  EXPECT_THROW(guarded_opts.unwrittenItems(), BoutException);
 #endif
+}
 
 TEST_F(GuardedOptionsTests, TestNullOptions) {
   EXPECT_THROW(GuardedOptions(nullptr, &permissions), BoutException);


### PR DESCRIPTION
There are warnings when permissions are too loose (https://github.com/boutproject/hermes-3/issues/467). They are very numerous and hard to fix because they don't identify the source component. We need to add the capability for components to know their name to have a realistic chance of resolving this (https://github.com/boutproject/hermes-3/issues/429). 

The warnings are so large that the logs quickly grow to multi-MB in size, making it impractical to run the code or see other checks. Because of this, I think we should disable the warnings until we have a chance of fixing them. 

This PR does this by requiring a `DCHECK=4` (which doesn't exist).

Permissions being too open will not be a problem until the topological sort algorithm is finished (https://github.com/boutproject/hermes-3/pull/428), at which point they will inform the component order. We can resolve this when we work on the algorithm.



