### PR TITLE
Vorticity phi with constraint

### DIFF
--- a/include/relax_potential.hxx
+++ b/include/relax_potential.hxx
@@ -16,15 +16,42 @@ struct RelaxPotential : public Component {
   /// Options
   ///
   /// - <name>
-  ///   - diamagnetic
-  ///   - diamagnetic_polarisation
-  ///   - average_atomic_mass
-  ///   - bndry_flux
-  ///   - poloidal_flows
-  ///   - split_n0
-  ///   - laplacian
-  ///     Options for the Laplacian phi solver
+  ///   - average_atomic_mass: float, default 2.0
+  ///     Weighted average ion atomic mass for polarisation current
+  ///   - bndry_flux: bool, default true
+  ///     Allow flows through radial (X) boundaries?
+  ///   - collisional_friction: bool, default false
+  ///     Damp vorticity based on mass-weighted collision frequency?
+  ///   - diagnose: bool, false
+  ///     Output additional diagnostics?
+  ///   - diamagnetic: bool, default true
+  ///     Include diamagnetic current, using curvature vector?
+  ///   - diamagnetic_polarisation: bool, default true
+  ///     Include ion diamagnetic drift in polarisation current?
+  ///   - exb_advection: bool, default true
+  ///     Include ExB advection (nonlinear term)?
+  ///   - phi_boundary_relax: bool, default false
+  ///     Relax radial phi boundaries towards zero-gradient?
+  ///   - phi_boundary_timescale: float, 1e-4
+  ///     Timescale for phi boundary relaxation [seconds]
+  ///   - phi_core_averagey: bool, default false
+  ///     Average phi core boundary in Y? (if phi_boundary_relax)
+  ///   - phi_dissipation: bool, default true
+  ///     Parallel dissipation of potential (Recommended)
+  ///   - poloidal_flows: bool, default true
+  ///     Include poloidal ExB flow?
+  ///   - sheath_boundary: bool, default false
+  ///     If phi_boundary_relax is false, set the radial boundary to the sheath potential?
+  ///   - viscosity_perp: Field2D, default 0.0
+  ///     Kinematic viscosity in perpendicular diraction  [m^2/s]
+  ///   - viscosity_par: Field2D, default 0.0
+  ///     Kinematic viscosity in parallel diraction  [m^2/s]
+  ///   - vort_dissipation: bool, default false
+  ///     Parallel dissipation of vorticity?
+  ///   - damp_core_vorticity: bool, default false
+  ///     Damp axisymmetric component of vorticity in cell next to core boundary
   ///
+
   RelaxPotential(std::string name, Options& options, Solver* solver);
 
   /// Optional inputs
@@ -55,13 +82,35 @@ struct RelaxPotential : public Component {
   void finally(const Options& state) override;
 
   void outputVars(Options& state) override;
+
+  // // Save and restore potential phi
+  // void restartVars(Options& state) override {
+  //   AUTO_TRACE();
+
+  //   // NOTE: This is a hack because we know that the loaded restart file
+  //   //       is passed into restartVars in PhysicsModel::postInit
+  //   // The restart value should be used in init() rather than here
+  //   static bool first = true;
+  //   if (first and state.isSet("phi")) {
+  //     first = false;
+  //     phi = state["phi"].as<Field3D>();
+  //   }
+
+  //   // Save the potential
+  //   set_with_attrs(state["phi"], phi,
+  //                  {{"long_name", "plasma potential"},
+  //                   {"source", "vorticity"}});
+  // }
 private:
   Field3D Vort; // Evolving vorticity
 
   Field3D phi1; // Scaled electrostatic potential, evolving in time ϕ_1 = λ_2 ϕ
   Field3D phi;  // Electrostatic potential
 
+  Field3D Pi_hat; ///< Contribution from ion pressure, weighted by atomic mass / charge
+
   bool exb_advection;            //< Include nonlinear ExB advection?
+  bool exb_advection_simplified; // Simplify nonlinear ExB advection form?
   bool diamagnetic;              //< Include diamagnetic current?
   bool diamagnetic_polarisation; //< Include diamagnetic drift in polarisation current?
   bool boussinesq;               ///< Use the Boussinesq approximation?
@@ -70,12 +119,37 @@ private:
   bool poloidal_flows;           ///< Include poloidal ExB flow?
   bool bndry_flux;               ///< Allow flows through radial boundaries?
 
+  bool collisional_friction; ///< Damping of vorticity due to collisional friction
+
   bool sheath_boundary; ///< Set outer boundary to j=0?
+
+  BoutReal Ge; // Secondary electron emission coefficient
+  BoutReal sin_alpha; // sin of angle between magnetic field and wall.
+  Field3D wall_potential; ///< Voltage at the wall. Normalised units.
+
+  bool vort_dissipation; ///< Parallel dissipation of vorticity
+  bool phi_dissipation;  ///< Parallel dissipation of potential
+  bool phi_sheath_dissipation; ///< Dissipation at the sheath if phi < 0
+  bool damp_core_vorticity; ///< Damp axisymmetric component of vorticity
+
+  bool phi_boundary_relax; ///< Relax boundary to zero-gradient
+  BoutReal phi_boundary_timescale; ///< Relaxation timescale [normalised]
+  BoutReal phi_boundary_last_update; ///< Time when last updated
+  bool phi_core_averagey; ///< Average phi core boundary in Y?
 
   Field2D Bsq;      ///< SQ(coord->Bxy)
   Vector2D Curlb_B; ///< Curvature vector Curl(b/B)
+  Field2D viscosity; ///< Perpendicular Kinematic viscosity
+  Field2D viscosity_par;  ///< Parallel Kinematic viscosity
 
-  BoutReal lambda_1, lambda_2;  ///< Relaxation parameters
+  // Relax-potential related variables 
+  BoutReal lambda_1;  ///< Relaxation parameters.  NOTE: lambda_1 has dimentions! 
+  BoutReal lambda_2;  ///< Relaxation parameters
+
+  // Diagnostic outputs
+  Field3D DivJdia, DivJcol; // Divergence of diamagnetic and collisional current
+
+  bool diagnose; ///< Output additional diagnostics?
 };
 
 namespace {

--- a/include/relax_potential.hxx
+++ b/include/relax_potential.hxx
@@ -109,11 +109,12 @@ private:
 
   Field3D Pi_hat; ///< Contribution from ion pressure, weighted by atomic mass / charge
 
+  bool boussinesq;               ///< Use the Boussinesq approximation?
+
   bool exb_advection;            //< Include nonlinear ExB advection?
   bool exb_advection_simplified; // Simplify nonlinear ExB advection form?
   bool diamagnetic;              //< Include diamagnetic current?
   bool diamagnetic_polarisation; //< Include diamagnetic drift in polarisation current?
-  bool boussinesq;               ///< Use the Boussinesq approximation?
   BoutReal average_atomic_mass;  //< Weighted average atomic mass, for polarisaion current
                                  // (Boussinesq approximation)
   bool poloidal_flows;           ///< Include poloidal ExB flow?
@@ -137,7 +138,7 @@ private:
   Vector2D Curlb_B; ///< Curvature vector Curl(b/B)
   BoutReal hyper_z; ///< Hyper-viscosity in Z
   Field2D viscosity; ///< Perpendicular Kinematic viscosity
-  Field2D viscosity_par;  ///< Parallel Kinematic viscosity
+  Field2D viscosity_par; ///< Parallel Kinematic viscosity
 
   // Relax-potential related variables 
   BoutReal lambda_1;  ///< Relaxation parameters.  NOTE: lambda_1 has dimentions! 

--- a/include/relax_potential.hxx
+++ b/include/relax_potential.hxx
@@ -123,10 +123,6 @@ private:
 
   bool sheath_boundary; ///< Set outer boundary to j=0?
 
-  BoutReal Ge; // Secondary electron emission coefficient
-  BoutReal sin_alpha; // sin of angle between magnetic field and wall.
-  Field3D wall_potential; ///< Voltage at the wall. Normalised units.
-
   bool vort_dissipation; ///< Parallel dissipation of vorticity
   bool phi_dissipation;  ///< Parallel dissipation of potential
   bool phi_sheath_dissipation; ///< Dissipation at the sheath if phi < 0
@@ -139,6 +135,7 @@ private:
 
   Field2D Bsq;      ///< SQ(coord->Bxy)
   Vector2D Curlb_B; ///< Curvature vector Curl(b/B)
+  BoutReal hyper_z; ///< Hyper-viscosity in Z
   Field2D viscosity; ///< Perpendicular Kinematic viscosity
   Field2D viscosity_par;  ///< Parallel Kinematic viscosity
 

--- a/include/vorticity.hxx
+++ b/include/vorticity.hxx
@@ -111,11 +111,15 @@ private:
 
   Field3D Pi_hat; ///< Contribution from ion pressure, weighted by atomic mass / charge
 
+  bool constraint;
+  bool boussinesq;               ///< Use the Boussinesq approximation?
+
   bool exb_advection; // Include nonlinear ExB advection?
   bool exb_advection_simplified; // Simplify nonlinear ExB advection form?
   bool diamagnetic; // Include diamagnetic current?
   bool diamagnetic_polarisation; // Include diamagnetic drift in polarisation current
-  BoutReal average_atomic_mass; // Weighted average atomic mass, for polarisaion current (Boussinesq approximation)
+  BoutReal average_atomic_mass; // Weighted average atomic mass, for polarisaion current 
+                                // (Boussinesq approximation)
   bool poloidal_flows;   ///< Include poloidal ExB flow?
   bool bndry_flux;  ///< Allow flows through radial boundaries?
 
@@ -139,7 +143,8 @@ private:
   Field2D Bsq; // SQ(coord->Bxy)
   Vector2D Curlb_B; // Curvature vector Curl(b/B)
   BoutReal hyper_z; ///< Hyper-viscosity in Z
-  Field2D viscosity; ///< Kinematic viscosity
+  Field2D viscosity; ///< Perpendicular Kinematic viscosity
+  Field2D viscosity_par; ///< Parallel Kinematic viscosity
 
   // Diagnostic outputs
   Field3D DivJdia, DivJcol; // Divergence of diamagnetic and collisional current

--- a/src/relax_potential.cxx
+++ b/src/relax_potential.cxx
@@ -1,15 +1,59 @@
-#include <bout/fv_ops.hxx>
 #include <bout/solver.hxx>
+
+#include "../include/relax_potential.hxx"
+
+#include "../include/div_ops.hxx"
+#include <bout/fv_ops.hxx>
+
+#include <bout/constants.hxx>
+#include "../include/hermes_build_config.hxx"
+#include "hermes_utils.hxx"
 
 using bout::globals::mesh;
 
-#include "../include/div_ops.hxx"
-#include "../include/relax_potential.hxx"
+
+namespace {
+/// Limited free gradient of log of a quantity
+/// This ensures that the guard cell values remain positive
+/// while also ensuring that the quantity never increases
+///
+///  fm  fc | fp
+///         ^ boundary
+///
+/// exp( 2*log(fc) - log(fm) )
+///
+BoutReal limitFree(BoutReal fm, BoutReal fc) {
+  if (fm < fc) {
+    return fc; // Neumann rather than increasing into boundary
+  }
+  if (fm < 1e-10) {
+    return fc; // Low / no density condition
+  }
+  BoutReal fp = SQ(fc) / fm;
+#if CHECKLEVEL >= 2
+  if (!std::isfinite(fp)) {
+    throw BoutException("SheathBoundary limitFree: {}, {} -> {}", fm, fc, fp);
+  }
+#endif
+
+  return fp;
+}
+} // namespace
+
 
 RelaxPotential::RelaxPotential(std::string name, Options& alloptions, Solver* solver) {
   AUTO_TRACE();
 
-  auto* coord = mesh->getCoordinates();
+  solver->add(Vort, "Vort"); // Vorticity evolving
+  solver->add(phi1, "phi1"); // Evolving scaled potential ϕ_1 = λ_2 ϕ
+
+  const Options& units = alloptions["units"];
+  // Normalisations
+  const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
+  const BoutReal Bnorm = units["Tesla"];
+  const BoutReal Tnorm = units["eV"];
+  const BoutReal Nnorm = units["inv_meters_cubed"];
+  const BoutReal Lnorm = units["meters"];
 
   auto& options = alloptions[name];
 
@@ -17,13 +61,56 @@ RelaxPotential::RelaxPotential(std::string name, Options& alloptions, Solver* so
                       .doc("Include nonlinear ExB advection?")
                       .withDefault<bool>(true);
 
+  exb_advection_simplified = options["exb_advection_simplified"]
+                      .doc("Simplify nonlinear ExB advection form?")
+                      .withDefault<bool>(true);
+
   diamagnetic =
       options["diamagnetic"].doc("Include diamagnetic current?").withDefault<bool>(true);
+
+  sheath_boundary = options["sheath_boundary"]
+                        .doc("Set potential to j=0 sheath at radial boundaries? (default = 0)")
+                        .withDefault<bool>(false);
+
+  Ge = options["secondary_electron_coef"]
+           .doc("Effective secondary electron emission coefficient")
+           .withDefault(0.0);
+
+  if ((Ge < 0.0) or (Ge > 1.0)) {
+    throw BoutException("Secondary electron emission must be between 0 and 1 ({:e})", Ge);
+  }
+
+  sin_alpha = options["sin_alpha"]
+                  .doc("Sin of the angle between magnetic field line and wall surface. "
+                       "Should be between 0 and 1")
+                  .withDefault(1.0);
+
+  if ((sin_alpha < 0.0) or (sin_alpha > 1.0)) {
+    throw BoutException("Range of sin_alpha must be between 0 and 1");
+  }
+
+  // Read wall voltage, convert to normalised units
+  wall_potential = options["wall_potential"]
+                       .doc("Voltage of the wall [Volts]")
+                       .withDefault(Field3D(0.0))
+                   / Tnorm;
+  // Convert to field aligned coordinates
+  wall_potential = toFieldAligned(wall_potential);
+
+  // Note: wall potential at the last cell before the boundary is used,
+  // not the value at the boundary half-way between cells. This is due
+  // to how twist-shift boundary conditions and non-aligned inputs are
+  // treated; using the cell boundary gives incorrect results.
 
   diamagnetic_polarisation =
       options["diamagnetic_polarisation"]
           .doc("Include diamagnetic drift in polarisation current?")
           .withDefault<bool>(true);
+
+  collisional_friction =
+      options["collisional_friction"]
+          .doc("Damp vorticity based on mass-weighted collision frequency")
+          .withDefault<bool>(false);
 
   boussinesq = options["boussinesq"]
                    .doc("Use the Boussinesq approximation?")
@@ -34,59 +121,384 @@ RelaxPotential::RelaxPotential(std::string name, Options& alloptions, Solver* so
                                  "(Boussinesq approximation)")
                             .withDefault<BoutReal>(2.0); // Deuterium
 
+  bndry_flux = options["bndry_flux"]
+                   .doc("Allow flows through radial boundaries")
+                   .withDefault<bool>(true);
+
   poloidal_flows =
       options["poloidal_flows"].doc("Include poloidal ExB flow").withDefault<bool>(true);
 
-  lambda_1 = options["lambda_1"].doc("λ_1 > λ_2 > 1").withDefault(1.0);
-  lambda_2 = options["lambda_2"].doc("λ_2 > 1").withDefault(10.0);
+  viscosity = 0.0;
+  viscosity = options["viscosity"]
+    .doc("Perpendicular Kinematic viscosity [m^2/s]")
+    .withDefault(viscosity)
+    / (Lnorm * Lnorm * Omega_ci);
+  viscosity.applyBoundary("dirichlet");
 
-  solver->add(Vort, "Vort"); // Vorticity evolving
-  solver->add(phi1, "phi1"); // Evolving scaled potential ϕ_1 = λ_2 ϕ
+  viscosity_par = 0.0;
+  viscosity_par = options["viscosity_par"]
+    .doc("Parallel Kinematic viscosity [m^2/s]")
+    .withDefault(viscosity_par)
+    / (Lnorm * Lnorm * Omega_ci);
+  viscosity_par.applyBoundary("dirichlet");
+  viscosity_par.applyParallelBoundary("parallel_dirichlet_o2");
 
-  if (diamagnetic) {
-    // Read curvature vector
+  vort_dissipation = options["vort_dissipation"]
+                         .doc("Parallel dissipation of vorticity")
+                         .withDefault<bool>(false);
+
+  phi_dissipation = options["phi_dissipation"]
+                        .doc("Parallel dissipation of potential [Recommended]")
+                        .withDefault<bool>(true);
+
+  phi_boundary_relax = options["phi_boundary_relax"]
+                           .doc("Relax x boundaries of phi towards Neumann?")
+                           .withDefault<bool>(false);
+
+  phi_sheath_dissipation = options["phi_sheath_dissipation"]
+    .doc("Add dissipation when phi < 0.0 at the sheath")
+    .withDefault<bool>(false);
+
+  damp_core_vorticity = options["damp_core_vorticity"]
+	  .doc("Damp vorticity at the core boundary?")
+	  .withDefault<bool>(false);
+
+  lambda_1 = options["lambda_1"].doc("λ_1 > 1").withDefault(3e8) / (Tnorm * Omega_ci / SI::qe / Nnorm);
+  lambda_2 = options["lambda_2"].doc("λ_2 > λ_1").withDefault(1.0);
+
+
+  // NOTE(malamast): How do we do that?
+  // Add phi to restart files so that the value in the boundaries
+  // is restored on restart. This is done even when phi is not evolving,
+  // so that phi can be saved and re-loaded
+
+  // Set initial value. Will be overwritten if restarting
+  phi1 = 0.0;
+  Vort = 0.0;
+
+  auto* coord = mesh->getCoordinates();
+
+  if (phi_boundary_relax) {
+    // Set the last update time to -1, so it will reset
+    // the first time RHS function is called
+    phi_boundary_last_update = -1.;
+
+    phi_core_averagey = options["phi_core_averagey"]
+      .doc("Average phi core boundary in Y?")
+      .withDefault<bool>(false) and mesh->periodicY(mesh->xstart);
+
+    phi_boundary_timescale = options["phi_boundary_timescale"]
+                                 .doc("Timescale for phi boundary relaxation [seconds]")
+                                 .withDefault(1e-4)
+                             / get<BoutReal>(alloptions["units"]["seconds"]);
+  }
+
+
+  // Read curvature vector
+  try {
+    Curlb_B.covariant = false; // Contravariant
+    mesh->get(Curlb_B, "bxcv");
+
+  } catch (BoutException& e) {
     try {
-      Curlb_B.covariant = false; // Contravariant
-      mesh->get(Curlb_B, "bxcv");
-
-    } catch (BoutException& e) {
       // May be 2D, reading as 3D
       Vector2D curv2d;
       curv2d.covariant = false;
       mesh->get(curv2d, "bxcv");
       Curlb_B = curv2d;
+    } catch (BoutException& e) {
+      if (diamagnetic) {
+        // Need curvature
+        throw;
+      } else {
+        output_warn.write("No curvature vector in input grid");
+        Curlb_B = 0.0;
+      }
     }
-
-    if (Options::root()["mesh"]["paralleltransform"]["type"].as<std::string>()
-        == "shifted") {
-      Field2D I;
-      mesh->get(I, "sinty");
-      Curlb_B.z += I * Curlb_B.x;
-    }
-
-    Options& units = alloptions["units"];
-    BoutReal Bnorm = units["Tesla"];
-    BoutReal Lnorm = units["meters"];
-
-    Curlb_B.x /= Bnorm;
-    Curlb_B.y *= SQ(Lnorm);
-    Curlb_B.z *= SQ(Lnorm);
-
-    Curlb_B *= 2. / coord->Bxy;
   }
 
+  if (Options::root()["mesh"]["paralleltransform"]["type"].as<std::string>()
+      == "shifted") {
+    Field2D I;
+    mesh->get(I, "sinty");
+    Curlb_B.z += I * Curlb_B.x;
+  }
+
+  Curlb_B.x /= Bnorm;
+  Curlb_B.y *= SQ(Lnorm);
+  Curlb_B.z *= SQ(Lnorm);
+
+  Curlb_B *= 2. / coord->Bxy;
+
   Bsq = SQ(coord->Bxy);
+
+  diagnose = options["diagnose"]
+    .doc("Output additional diagnostics?")
+    .withDefault<bool>(false);
 }
 
 void RelaxPotential::transform(Options& state) {
   AUTO_TRACE();
 
+  Options& allspecies = state["species"];
+
+  // phi.name = "phi";
+  auto& fields = state["fields"];
+
+  // Set the boundary of phi1. 
+  phi1.applyBoundary("neumann");
+
   // Scale potential
   phi = phi1 / lambda_2;
-  phi.applyBoundary("neumann");
-  Vort.applyBoundary("neumann");
 
-  auto& fields = state["fields"];
+  // Set the boundary of Vort. . Needed only if dissipation terms are included. 
+  Vort.applyBoundary("neumann");
+  // Vort.applyBoundary("dirichlet");
+
+  if (Vort.hasParallelSlices()) {
+    Field3D &Vort_ydown = Vort.ydown();
+    Field3D &Vort_yup = Vort.yup();
+    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Vort_ydown(r.ind, mesh->ystart - 1, jz) = 2 * Vort(r.ind, mesh->ystart, jz) - Vort_yup(r.ind, mesh->ystart + 1, jz);
+        Vort_ydown(r.ind, mesh->ystart - 1, jz) = Vort(r.ind, mesh->ystart, jz); // TODO: <! Check if this is correct?
+      }
+    }
+    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Vort_yup(r.ind, mesh->yend + 1, jz) = 2 * Vort(r.ind, mesh->yend, jz) - Vort_ydown(r.ind, mesh->yend - 1, jz);
+        Vort_yup(r.ind, mesh->yend + 1, jz) = Vort(r.ind, mesh->yend, jz);
+      }
+    }
+  } else {
+    Field3D Vort_fa = toFieldAligned(Vort);
+    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Vort_fa(r.ind, mesh->ystart - 1, jz) = 2 * Vort_fa(r.ind, mesh->ystart, jz) - Vort_fa(r.ind, mesh->ystart + 1, jz);
+        Vort_fa(r.ind, mesh->ystart - 1, jz) = Vort_fa(r.ind, mesh->ystart, jz); // Neumann BC
+      }
+    }
+    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        // Vort_fa(r.ind, mesh->yend + 1, jz) = 2 * Vort_fa(r.ind, mesh->yend, jz) - Vort_fa(r.ind, mesh->yend - 1, jz);
+        Vort_fa(r.ind, mesh->yend + 1, jz) = Vort_fa(r.ind, mesh->yend, jz); // Neumann BC
+      }
+    }
+    Vort = fromFieldAligned(Vort_fa);
+  }
+
+  // Set the boundary of phi. 
+  // phi.applyBoundary("neumann");
+
+  // Note: For now the boundary values are all at the midpoint,
+  //       and only phi is considered, not phi + Pi which is handled in Boussinesq solves
+  Pi_hat = 0.0; // Contribution from ion pressure, weighted by atomic mass / charge
+  if (diamagnetic_polarisation) {
+    // Diamagnetic term in vorticity. Note this is weighted by the mass
+    // This includes all species, including electrons
+    // Options& allspecies = state["species"];
+    for (auto& kv : allspecies.getChildren()) {
+      Options& species = allspecies[kv.first]; // Note: need non-const
+
+      if (!(IS_SET_NOBOUNDARY(species["pressure"]) and species.isSet("charge")
+            and species.isSet("AA"))) {
+        continue; // No pressure, charge or mass -> no polarisation current
+      }
+
+      const auto charge = get<BoutReal>(species["charge"]);
+      if (fabs(charge) < 1e-5) {
+        // No charge
+        continue;
+      }
+
+      // Don't need sheath boundary
+      const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+      const auto AA = get<BoutReal>(species["AA"]);
+
+      Pi_hat += P * (AA / average_atomic_mass / charge);
+    }
+  }
+
+  Pi_hat.applyBoundary("neumann");
+
+  if (phi_boundary_relax) {
+    // Update the boundary regions by relaxing towards zero gradient
+    // on a given timescale.
+
+    BoutReal time = get<BoutReal>(state["time"]);
+
+    if (phi_boundary_last_update < 0.0) {
+      // First time this has been called.
+      phi_boundary_last_update = time;
+
+    } else if (time > phi_boundary_last_update) {
+      // Only update if time has advanced
+      // Uses an exponential decay of the weighting of the value in the boundary
+      // so that the solution is well behaved for arbitrary steps
+      BoutReal weight = exp(-(time - phi_boundary_last_update) / phi_boundary_timescale);
+      phi_boundary_last_update = time;
+
+      if (mesh->firstX()) {
+        BoutReal phivalue = 0.0;
+        if (phi_core_averagey) {
+          BoutReal philocal = 0.0;
+          for (int j = mesh->ystart; j <= mesh->yend; j++) {
+            for (int k = 0; k < mesh->LocalNz; k++) {
+              philocal += phi(mesh->xstart, j, k);
+            }
+          }
+          MPI_Comm comm_inner = mesh->getYcomm(0);
+          int np;
+          MPI_Comm_size(comm_inner, &np);
+          MPI_Allreduce(&philocal,
+                        &phivalue,
+                        1, MPI_DOUBLE,
+                        MPI_SUM, comm_inner);
+          phivalue /= (np * mesh->LocalNz * mesh->LocalNy);
+        }
+
+        for (int j = mesh->ystart; j <= mesh->yend; j++) {
+          if (!phi_core_averagey) {
+            phivalue = 0.0; // Calculate phi boundary for each Y index separately
+            for (int k = 0; k < mesh->LocalNz; k++) {
+              phivalue += phi(mesh->xstart, j, k);
+            }
+            phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+          }
+
+          // Old value of phi at boundary
+          BoutReal oldvalue =
+              0.5 * (phi(mesh->xstart - 1, j, 0) + phi(mesh->xstart, j, 0));
+
+          // New value of phi at boundary, relaxing towards phivalue
+          BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+
+          // Set phi at the boundary to this value
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            phi(mesh->xstart - 1, j, k) = 2. * newvalue - phi(mesh->xstart, j, k);
+
+            // Note: This seems to make a difference, but don't know why.
+            // Without this, get convergence failures with no apparent instability
+            // (all fields apparently smooth, well behaved)
+            phi(mesh->xstart - 2, j, k) = phi(mesh->xstart - 1, j, k);
+          }
+        }
+      }
+
+      if (mesh->lastX()) {
+        for (int j = mesh->ystart; j <= mesh->yend; j++) {
+          BoutReal phivalue = 0.0;
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            phivalue += phi(mesh->xend, j, k);
+          }
+          phivalue /= mesh->LocalNz; // Average in Z of point next to boundary
+
+          // Old value of phi at boundary
+          BoutReal oldvalue = 0.5 * (phi(mesh->xend + 1, j, 0) + phi(mesh->xend, j, 0));
+
+          // New value of phi at boundary, relaxing towards phivalue
+          BoutReal newvalue = weight * oldvalue + (1. - weight) * phivalue;
+
+          // Set phi at the boundary to this value
+          for (int k = 0; k < mesh->LocalNz; k++) {
+            phi(mesh->xend + 1, j, k) = 2. * newvalue - phi(mesh->xend, j, k);
+
+            // Note: This seems to make a difference, but don't know why.
+            // Without this, get convergence failures with no apparent instability
+            // (all fields apparently smooth, well behaved)
+            phi(mesh->xend + 2, j, k) = phi(mesh->xend + 1, j, k);
+          }
+        }
+      }
+    }
+  } else {
+    // phi_boundary_relax = false
+    //
+    // Set boundary from temperature, to be consistent with j=0 at sheath
+
+    // Sheath multiplier Te -> phi (2.84522 for Deuterium)
+    BoutReal sheathmult = 0.0;
+    if (sheath_boundary) {
+      BoutReal Me_Mp = get<BoutReal>(state["species"]["e"]["AA"]);
+      sheathmult = log(0.5 * sqrt(1. / (Me_Mp * PI)));
+    }
+
+    Field3D Te; // Electron temperature, use for outer boundary conditions
+    if (state["species"]["e"].isSet("temperature")) {
+      // Electron temperature set
+      Te = GET_NOBOUNDARY(Field3D, state["species"]["e"]["temperature"]);
+    } else {
+      Te = 0.0;
+    }
+
+    // Sheath multiplier Te -> phi (2.84522 for Deuterium if Ti = 0)
+    if (mesh->firstX()) {
+      for (int j = mesh->ystart; j <= mesh->yend; j++) {
+        BoutReal teavg = 0.0; // Average Te in Z
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          teavg += Te(mesh->xstart, j, k);
+        }
+        teavg /= mesh->LocalNz;
+        BoutReal phivalue = sheathmult * teavg;
+        // Set midpoint (boundary) value
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          phi(mesh->xstart - 1, j, k) = 2. * phivalue - phi(mesh->xstart, j, k);
+
+          // Note: This seems to make a difference, but don't know why.
+          // Without this, get convergence failures with no apparent instability
+          // (all fields apparently smooth, well behaved)
+          phi(mesh->xstart - 2, j, k) = phi(mesh->xstart - 1, j, k);
+        }
+      }
+    }
+
+    if (mesh->lastX()) {
+      for (int j = mesh->ystart; j <= mesh->yend; j++) {
+        BoutReal teavg = 0.0; // Average Te in Z
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          teavg += Te(mesh->xend, j, k);
+        }
+        teavg /= mesh->LocalNz;
+        BoutReal phivalue = sheathmult * teavg;
+        // Set midpoint (boundary) value
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          phi(mesh->xend + 1, j, k) = 2. * phivalue - phi(mesh->xend, j, k);
+
+          // Note: This seems to make a difference, but don't know why.
+          // Without this, get convergence failures with no apparent instability
+          // (all fields apparently smooth, well behaved)
+          phi(mesh->xend + 2, j, k) = phi(mesh->xend + 1, j, k);
+        }
+      }
+    }
+  }
+
+
+  // Outer boundary cells
+  if (mesh->firstX()) {
+    for (int i = mesh->xstart - 2; i >= 0; --i) {
+      for (int j = mesh->ystart; j <= mesh->yend; ++j) {
+        for (int k = 0; k < mesh->LocalNz; ++k) {
+          phi(i, j, k) = phi(i + 1, j, k);
+        }
+      }
+    }
+  }
+  if (mesh->lastX()) {
+    for (int i = mesh->xend + 2; i < mesh->LocalNx; ++i) {
+      for (int j = mesh->ystart; j <= mesh->yend; ++j) {
+        for (int k = 0; k < mesh->LocalNz; ++k) {
+          phi(i, j, k) = phi(i - 1, j, k);
+        }
+      }
+    }
+  }
+
+
+  // Ensure that potential is set in the communication guard cells
+  mesh->communicate(phi, phi1, Vort); //NOTE(malamast): Should we include phi1?
+
+  // Vorticity equation
 
   ddt(Vort) = 0.0;
 
@@ -100,18 +512,52 @@ void RelaxPotential::transform(Options& state) {
     Jdia.z = 0.0;
     Jdia.covariant = Curlb_B.covariant;
 
-    Options& allspecies = state["species"];
-
     // Pre-calculate this rather than calculate for each species
+    // Note: The below calculation requires phi derivatives at the Y boundaries
+    // NOTE: Do we actually need that?
+    //       Setting to free boundaries
+
+    if (phi.hasParallelSlices()) {
+      Field3D &phi_ydown = phi.ydown();
+      Field3D &phi_yup = phi.yup();
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          phi_ydown(r.ind, mesh->ystart - 1, jz) = 2 * phi(r.ind, mesh->ystart, jz) - phi_yup(r.ind, mesh->ystart + 1, jz);
+        }
+      }
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          phi_yup(r.ind, mesh->yend + 1, jz) = 2 * phi(r.ind, mesh->yend, jz) - phi_ydown(r.ind, mesh->yend - 1, jz);
+        }
+      }
+    } else {
+      Field3D phi_fa = toFieldAligned(phi);
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          phi_fa(r.ind, mesh->ystart - 1, jz) = 2 * phi_fa(r.ind, mesh->ystart, jz) - phi_fa(r.ind, mesh->ystart + 1, jz);
+        }
+      }
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          phi_fa(r.ind, mesh->yend + 1, jz) = 2 * phi_fa(r.ind, mesh->yend, jz) - phi_fa(r.ind, mesh->yend - 1, jz);
+        }
+      }
+      phi = fromFieldAligned(phi_fa);
+    }
+
     Vector3D Grad_phi = Grad(phi);
 
     for (auto& kv : allspecies.getChildren()) {
       Options& species = allspecies[kv.first]; // Note: need non-const
 
-      if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"])
-            and (get<BoutReal>(species["charge"]) != 0.0))) {
+      if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"]))) {
         continue; // No pressure or charge -> no diamagnetic current
       }
+      if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
+        // No charge
+        continue;
+      }
+
       // Note that the species must have a charge, but charge is not used,
       // because it cancels out in the expression for current
 
@@ -128,27 +574,48 @@ void RelaxPotential::transform(Options& state) {
 
     // Note: This term is central differencing so that it balances
     // the corresponding compression term in the species pressure equations
-    Field3D DivJdia = Div(Jdia);
+    DivJdia = Div(Jdia);
     ddt(Vort) += DivJdia;
 
-    if (diamagnetic_polarisation) {
-      // Calculate energy exchange term nonlinear in pressure
-      // ddt(Pi) += Pi * Div((Pe + Pi) * Curlb_B);
-      for (auto& kv : allspecies.getChildren()) {
-        Options& species = allspecies[kv.first]; // Note: need non-const
+    set(fields["DivJdia"], DivJdia);
+  }
 
-        if (!(IS_SET_NOBOUNDARY(species["pressure"]) and IS_SET(species["charge"])
-              and IS_SET(species["AA"]))) {
-          continue; // No pressure, charge or mass -> no polarisation current due to
-                    // rate of change of diamagnetic flow
-        }
-        auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+  if (collisional_friction) {
+    // Damping of vorticity due to collisions
 
-        add(species["energy_source"], (3. / 2) * P * DivJdia);
+    // Calculate a mass-weighted collision frequency
+    Field3D sum_A_nu_n =
+        zeroFrom(Vort); // Sum of atomic mass * collision frequency * density
+    Field3D sum_A_n = zeroFrom(Vort); // Sum of atomic mass * density
+
+    // const Options& allspecies = state["species"];
+    for (const auto& kv : allspecies.getChildren()) {
+      const Options& species = kv.second;
+
+      if (!(species.isSet("charge") and species.isSet("AA"))) {
+        continue; // No charge or mass -> no current
+      }
+      if (fabs(get<BoutReal>(species["charge"])) < 1e-5) {
+        continue; // Zero charge
+      }
+
+      const BoutReal A = get<BoutReal>(species["AA"]);
+      const Field3D N = GET_NOBOUNDARY(Field3D, species["density"]);
+      const Field3D AN = A * N;
+      sum_A_n += AN;
+      if (IS_SET(species["collision_frequency"])) {
+        sum_A_nu_n += AN * GET_VALUE(Field3D, species["collision_frequency"]);
       }
     }
 
-    set(fields["DivJdia"], DivJdia);
+    Field3D weighted_collision_frequency = sum_A_nu_n / sum_A_n;
+    weighted_collision_frequency.applyBoundary("neumann");
+
+    DivJcol = -FV::Div_a_Grad_perp(
+        weighted_collision_frequency * average_atomic_mass / Bsq, phi + Pi_hat);
+
+    ddt(Vort) += DivJcol;
+    set(fields["DivJcol"], DivJcol);
   }
 
   set(fields["vorticity"], Vort);
@@ -160,16 +627,48 @@ void RelaxPotential::finally(const Options& state) {
 
   const Options& allspecies = state["species"];
 
+  auto* coord = mesh->getCoordinates();
+
   phi = get<Field3D>(state["fields"]["phi"]);
   Vort = get<Field3D>(state["fields"]["vorticity"]);
 
+  // Solve vorticity equation
+
   if (exb_advection) {
-    ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(Vort, phi, bndry_flux, poloidal_flows);
+    // These terms come from divergence of polarisation current
+
+    if (exb_advection_simplified) {
+      // By default this is a simplified nonlinear term
+      ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(Vort, phi, bndry_flux, poloidal_flows);
+
+    } else {
+      // If diamagnetic_polarisation = false and B is constant, then
+      // this term reduces to the simplified form above.
+      //
+      // Because this is implemented in terms of an operation on the result
+      // of an operation, we need to communicate and the resulting stencil is
+      // wider than the simple form.
+      ddt(Vort) -=
+        Div_n_bxGrad_f_B_XPPM(0.5 * Vort, phi, bndry_flux, poloidal_flows);
+
+      // V_ExB dot Grad(Pi)
+      Field3D vEdotGradPi = bracket(phi, Pi_hat, BRACKET_ARAKAWA);
+      vEdotGradPi.applyBoundary("free_o2");
+
+      // delp2(phi) term
+      Field3D DelpPhi_2B2 = 0.5 * average_atomic_mass * Delp2(phi) / Bsq;
+      DelpPhi_2B2.applyBoundary("free_o2");
+
+      mesh->communicate(vEdotGradPi, DelpPhi_2B2);
+
+      ddt(Vort) -= FV::Div_a_Grad_perp(0.5 * average_atomic_mass / Bsq, vEdotGradPi);
+      ddt(Vort) -= Div_n_bxGrad_f_B_XPPM(DelpPhi_2B2, phi + Pi_hat, bndry_flux,
+                                         poloidal_flows);
+    }
   }
 
   if (state.isSection("fields") and state["fields"].isSet("DivJextra")) {
     auto DivJextra = get<Field3D>(state["fields"]["DivJextra"]);
-
     // Parallel current is handled here, to allow different 2D or 3D closures
     // to be used
     ddt(Vort) += DivJextra;
@@ -192,8 +691,88 @@ void RelaxPotential::finally(const Options& state) {
     const BoutReal A = get<BoutReal>(species["AA"]);
 
     // Note: Using NV rather than N*V so that the cell boundary flux is correct
-    ddt(Vort) += Div_par((Z / A) * NV);
+    const Field3D jpar = (Z / A) * NV;
+    ddt(Vort) += Div_par(jpar);
+
+    if (state["fields"].isSet("Apar_flutter")) {
+      // Magnetic flutter term
+      const Field3D Apar_flutter = get<Field3D>(state["fields"]["Apar_flutter"]);
+
+      // Div_par(jpar) = B * Grad_par(jpar / B)
+      // Using the approximation for small delta-B/B
+      // b dot Grad(jpar) = Grad_par(jpar) + [jpar, Apar]
+      ddt(Vort) += coord->Bxy * bracket(jpar / coord->Bxy, Apar_flutter, BRACKET_ARAKAWA);
+    }
   }
+
+  // Viscosity
+  ddt(Vort) += FV::Div_a_Grad_perp(viscosity, Vort);
+
+  ddt(Vort) += FV::Div_par_K_Grad_par(viscosity_par, Vort);  
+  // NOTE(malamast): Need to check if Div_par_K_Grad_par is equivalent with the Laplace_par operator.
+  // ddt(Vort) += viscosity_par * Laplace_par(Vort); 
+
+
+  if (vort_dissipation) {
+    // Adds dissipation term like in other equations
+    Field3D sound_speed = get<Field3D>(state["sound_speed"]);
+    ddt(Vort) -= FV::Div_par(Vort, 0.0, sound_speed);
+  }
+
+  if (phi_dissipation) {
+    // Adds dissipation term like in other equations, but depending on gradient of
+    // potential
+    Field3D sound_speed = get<Field3D>(state["sound_speed"]);
+
+    Field3D zero {0.0};
+    zero.splitParallelSlices();
+    zero.yup() = 0.0;
+    zero.ydown() = 0.0;
+
+    Field3D dummy;
+    ddt(Vort) -= FV::Div_par_mod<hermes::Limiter>(-phi, zero, sound_speed, dummy);
+  }
+
+  if (phi_sheath_dissipation) {
+    // Dissipation when phi < 0.0 at the sheath
+
+    auto phi_fa = toFieldAligned(phi);
+    Field3D dissipation{zeroFrom(phi_fa)};
+    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        auto i = indexAt(phi_fa, r.ind, mesh->ystart, jz);
+        BoutReal phisheath = 0.5*(phi_fa[i] + phi_fa[i.ym()]);
+        dissipation[i] = -floor(-phisheath, 0.0);
+      }
+    }
+
+    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+      for (int jz = 0; jz < mesh->LocalNz; jz++) {
+        auto i = indexAt(phi_fa, r.ind, mesh->yend, jz);
+        BoutReal phisheath = 0.5*(phi_fa[i] + phi_fa[i.yp()]);
+        dissipation[i] = -floor(-phisheath, 0.0);
+      }
+    }
+    ddt(Vort) += fromFieldAligned(dissipation);
+  }
+
+  if (damp_core_vorticity) {
+    // Damp axisymmetric vorticity near core boundary
+    if (mesh->firstX() and mesh->periodicY(mesh->xstart)) {
+      for (int j = mesh->ystart; j <= mesh->yend; j++) {
+        BoutReal vort_avg = 0.0; // Average Vort in Z
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          vort_avg += Vort(mesh->xstart, j, k);
+        }
+        vort_avg /= mesh->LocalNz;
+        for (int k = 0; k < mesh->LocalNz; k++) {
+          ddt(Vort)(mesh->xstart, j, k) -= 0.01 * vort_avg;
+        }
+      }
+    }
+  }
+
+
 
   // Solve diffusion equation for potential
 
@@ -245,7 +824,7 @@ void RelaxPotential::finally(const Options& state) {
       if (diamagnetic_polarisation and species.isSet("pressure")) {
         // Calculate the diamagnetic flow contribution
         const Field3D Pi = get<Field3D>(species["pressure"]);
-        phi_vort += FV::Div_a_Grad_perp(Ai / Bsq, Pi);
+        phi_vort += FV::Div_a_Grad_perp(Ai / Bsq / Zi, Pi);
       }
     }
 
@@ -256,7 +835,15 @@ void RelaxPotential::finally(const Options& state) {
 void RelaxPotential::outputVars(Options& state) {
   AUTO_TRACE();
   // Normalisations
-  auto Tnorm = state["Tnorm"].as<BoutReal>();
+  auto Nnorm = get<BoutReal>(state["Nnorm"]);
+  auto Tnorm = get<BoutReal>(state["Tnorm"]);
+  auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+
+  state["Vort"].setAttributes({{"time_dimension", "t"},
+                               {"units", "C m^-3"},
+                               {"conversion", SI::qe * Nnorm},
+                               {"long_name", "vorticity"},
+                               {"source", "relax_potential"}});
 
   set_with_attrs(state["phi"], phi,
                  {{"time_dimension", "t"},
@@ -265,4 +852,35 @@ void RelaxPotential::outputVars(Options& state) {
                   {"standard_name", "potential"},
                   {"long_name", "plasma potential"},
                   {"source", "relax_potential"}});
+
+  if (diagnose) {
+    set_with_attrs(state["ddt(Vort)"], ddt(Vort),
+                   {{"time_dimension", "t"},
+                    {"units", "A m^-3"},
+                    {"conversion", SI::qe * Nnorm * Omega_ci},
+                    {"long_name", "Rate of change of vorticity"},
+                    {"source", "relax_potential"}});
+    set_with_attrs(state["ddt(phi)"], ddt(phi1),
+                   {{"time_dimension", "t"},
+                    {"units", "V/s"},
+                    {"conversion", Tnorm * Omega_ci},
+                    {"long_name", "Rate of change of electrostatic potential"},
+                    {"source", "relax_potential"}});
+    if (diamagnetic) {
+      set_with_attrs(state["DivJdia"], DivJdia,
+                     {{"time_dimension", "t"},
+                      {"units", "A m^-3"},
+                      {"conversion", SI::qe * Nnorm * Omega_ci},
+                      {"long_name", "Divergence of diamagnetic current"},
+                      {"source", "relax_potential"}});
+    }
+    if (collisional_friction) {
+      set_with_attrs(state["DivJcol"], DivJcol,
+                     {{"time_dimension", "t"},
+                      {"units", "A m^-3"},
+                      {"conversion", SI::qe * Nnorm * Omega_ci},
+                      {"long_name", "Divergence of collisional current"},
+                      {"source", "relax_potential"}});
+    }
+  }
 }

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -53,7 +53,7 @@ Vorticity::Vorticity(std::string name, Options& alloptions, Solver* solver) {
   const BoutReal Lnorm = units["meters"];
 
   exb_advection = options["exb_advection"]
-                      .doc("Include ExB advection (nonlinear term)?")
+                      .doc("Include nonlinear ExB advection?")
                       .withDefault<bool>(true);
 
   exb_advection_simplified = options["exb_advection_simplified"]


### PR DESCRIPTION
Work in progress.

- Added an option in the vorticity component  to solve phi as a constrained equation. 
- Solving phi with Laplacian inversion in the rhs can be very expensive. However, with the constraint option, you can add phi in the sytem of equations and solve a DAE system. 
- This might be useful for 2D simulations with drifts. 
- It seems its working for now but I need to test it for longer runs. 
- I did not include code for the boundaries as is done in the examples for DAE, since we do not evolve the boundaries.  
- The non-boussinesq case is only partially implemented. It will require some improvements there to make it non-boussinesq everywhere. 