### PR TITLE
Updates to allow builds with spack v1.

### DIFF
--- a/activate_h3env
+++ b/activate_h3env
@@ -182,9 +182,10 @@ if ! command -v "$spacktivate_cmd" &> /dev/null
     return 1
 fi
 
-# Check that BOUT-spack has been cloned
+# Check that the BOUT-spack submodule has been cloned
 sm_name="BOUT-spack"
-repo_yaml="${REPO_ROOT}/external/${sm_name}/repo.yaml"
+bout_spack_relpath="${sm_name}/spack_repo/bout"
+repo_yaml="${REPO_ROOT}/external/${bout_spack_relpath}/repo.yaml"
 if [ ! -f "$repo_yaml" ]
   then
     echo "$repo_yaml doesn't exist. Has the ${sm_name} git submodule been initialised?"

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -319,11 +319,21 @@ Ubuntu:
    sudo apt update
    sudo apt install -y build-essential ca-certificates coreutils curl environment-modules gfortran git gpg lsb-release python3 python3-distutils python3-venv unzip zip
 
-Now, clone spack (the command below checks out version 0.23.1).
+Now, clone spack. You must use version v1.0.0 or newer. At the time of writing this section,
+version v1.1.0 has been tested:
 
 .. code-block:: bash
    
-   git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git -b releases/v0.23
+   git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git -b releases/v1.1.0
+
+.. important::
+   If you have an existing Spack installation of a version before v1.0.0, you will need to uninstall it first.
+   Do this by uninstalling all packages and deleting the spack directory:
+
+   .. code-block:: bash
+
+      spack uninstall --all
+      rm -rf ~/.spack
 
 Initialise spack. Add this command to your .bashrc or similar to make spack available in all new shells:
 
@@ -336,7 +346,7 @@ The ``spack`` command should now be available; e.g.
 .. code-block:: bash
 
    spack --version
-    > 0.23.1 (2bfcc69fa870d3c6919be87593f22647981b648a)
+    > 1.1.0 (0c2be44e4ece21eb091ad5de4c97716b7c6d4c87)
 
 Libraries and executables associated with spack packages are installed to ``$SPACK_ROOT/opt/spack``
 by default (``$SPACK_ROOT`` is wherever you cloned spack to). Build files, however, are placed in
@@ -357,6 +367,8 @@ and edit it to include
       build_stage:
          - $spack/var/spack/stage
          - $user_cache_path/stage
+
+
 
 Install Hermes-3 and dependencies
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -324,7 +324,7 @@ version v1.1.0 has been tested:
 
 .. code-block:: bash
    
-   git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git -b releases/v1.1.0
+   git clone -c feature.manyFiles=true --depth=2 https://github.com/spack/spack.git -b v1.1.0
 
 .. important::
    If you have an existing Spack installation of a version before v1.0.0, you will need to uninstall it first.

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,7 @@ spack:
   concretizer:
     unify: when_possible
   repos:
-    - ./external/BOUT-spack
-    - $spack/var/spack/repos/builtin
+    - ./external/BOUT-spack/spack_repo/bout
   packages:
     all:
       providers:

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,21 +5,21 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - hermes-3%gcc ^boutpp+petsc+sundials ^petsc+hypre+mumps
-    - cmake
+  - hermes-3%gcc ^boutpp+petsc+sundials ^petsc+hypre+mumps
+  - cmake
   view:
     gcc:
       root: ./views/gcc
-      select: ["%gcc"]
+      select: [ '%gcc' ]
       link_type: symlink
   concretizer:
     unify: when_possible
   repos:
-    - ./external/BOUT-spack/spack_repo/bout
+    bout: ./external/BOUT-spack/spack_repo/bout
   packages:
     all:
       providers:
-        mpi: [mpich, openmpi]
+        mpi: [ mpich, openmpi ]
   develop:
     boutpp:
       path: ./external/BOUT-dev

--- a/spack.yaml
+++ b/spack.yaml
@@ -10,7 +10,7 @@ spack:
   view:
     gcc:
       root: ./views/gcc
-      select: [ '%gcc' ]
+      select: [ '%gcc', '^python' ]
       link_type: symlink
   concretizer:
     unify: when_possible


### PR DESCRIPTION
- Updates the package repository via https://github.com/boutproject/BOUT-spack/pull/15
- Corresponding changes to spack.yaml and the environment wrapper script, activate_h3env.
- Adds a conflict to py-xbout to prevent it pulling in llvm via py-pandas

ToDo:
- [x] Resolve problem with petsc+hypre (Tries to use `hypre@2.12.x` and fails)
- [x] The new spack build installs llvm, for some reason. Find a way to not do that.

---

N.B. Using the latest release (v2025.11) of the spack-packages repo sets the hypre version required by petsc incorrectly, causing the petsc build to fail.
This has been fixed on the develop branch and will be included in the next release.

As a workaround, switch to the develop version of the package repo by editing [SPACK_INSTALL]/etc/spack/defaults/base/repos.yaml:

```
repos:
  builtin:
    git: https://github.com/spack/spack-packages.git
    branch: develop
	# branch: releases/v2025.11
```
... then running `spack repo update`

---

Resolves #404.