### PR TITLE
Unit tests and style changes for neutral_mixed.cxx

### DIFF
--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -18,7 +18,7 @@ struct NeutralMixed : public Component {
   /// @param options  Top-level options. Settings will be taken from options[name]
   /// @param solver   Time-integration solver to be used
   NeutralMixed(const std::string& name, Options& options, Solver *solver);
-  
+
   /// Use the final simulation state to update internal state
   /// (e.g. time derivatives)
   void finally(const Options &state) override;
@@ -30,7 +30,7 @@ struct NeutralMixed : public Component {
   void precon(const Options &state, BoutReal gamma) override;
 private:
   std::string name;  ///< Species name
-  
+
   Field3D Nn, Pn, NVn; // Density, pressure and parallel momentum
   Field3D Vn; ///< Neutral parallel velocity
   Field3D Tn; ///< Neutral temperature
@@ -45,6 +45,7 @@ private:
   Field3D DnnNn, DnnPn, DnnTn, DnnNVn; ///< Used for operators
   BoutReal flux_limit; ///< Diffusive flux limit
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
+  BoutReal neutral_lmax;
 
   bool sheath_ydown, sheath_yup;
 

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -301,7 +301,7 @@ void NeutralMixed::finally(const Options& state) {
   // Nn, Pn, NVn, from the local state
   // and set boundary conditions on evolved quantities
   Tn = get<Field3D>(localstate["temperature"]);
-  Vn = get<Field3D>(localstate["density"]);
+  Vn = get<Field3D>(localstate["velocity"]);
   Pn.setBoundaryTo(get<Field3D>(localstate["pressure"]));
   Nn.setBoundaryTo(get<Field3D>(localstate["density"]));
   if (!evolve_momentum) {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -82,6 +82,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                      .doc("Enable stabilising lax flux?")
                      .withDefault<bool>(true);
 
+  neutral_lmax = 0.1 / meters; // Normalised length
+
   flux_limit =
       options["flux_limit"]
           .doc("Limit diffusive fluxes to fraction of thermal speed. <0 means off.")
@@ -224,9 +226,6 @@ void NeutralMixed::transform_impl(GuardedOptions& state) {
   Vn = NVn / (AA * Nnlim);
   Vn.applyBoundary("neumann");
 
-  Pnlim = softFloor(Pn, pressure_floor);
-  Pnlim.applyBoundary();
-
   /////////////////////////////////////////////////////
   // Parallel boundary conditions
   TRACE("Neutral boundary conditions");
@@ -252,7 +251,6 @@ void NeutralMixed::transform_impl(GuardedOptions& state) {
 
         // Zero-gradient pressure
         Pn(r.ind, mesh->ystart - 1, jz) = Pn(r.ind, mesh->ystart, jz);
-        Pnlim(r.ind, mesh->ystart - 1, jz) = Pnlim(r.ind, mesh->ystart, jz);
 
         // No flow into wall
         Vn(r.ind, mesh->ystart - 1, jz) = -Vn(r.ind, mesh->ystart, jz);
@@ -277,7 +275,6 @@ void NeutralMixed::transform_impl(GuardedOptions& state) {
 
         // Zero-gradient pressure
         Pn(r.ind, mesh->yend + 1, jz) = Pn(r.ind, mesh->yend, jz);
-        Pnlim(r.ind, mesh->yend + 1, jz) = Pnlim(r.ind, mesh->yend, jz);
 
         // No flow into wall
         Vn(r.ind, mesh->yend + 1, jz) = -Vn(r.ind, mesh->yend, jz);
@@ -300,6 +297,20 @@ void NeutralMixed::finally(const Options& state) {
   AUTO_TRACE();
   auto& localstate = state["species"][name];
 
+  // extract auxiliary variables derived from
+  // Nn, Pn, NVn, from the local state
+  // and set boundary conditions on evolved quantities
+  Tn = get<Field3D>(localstate["temperature"]);
+  Vn = get<Field3D>(localstate["density"]);
+  Pn.setBoundaryTo(get<Field3D>(localstate["pressure"]));
+  Nn.setBoundaryTo(get<Field3D>(localstate["density"]));
+  if (!evolve_momentum) {
+    // momentum is not evolved, so need to get the value from the localstate
+    NVn = get<Field3D>(localstate["momentum"]);
+  }
+  else {
+    NVn.setBoundaryTo(get<Field3D>(localstate["momentum"]));
+  }
   // Logarithms used to calculate perpendicular velocity
   // V_perp = -Dnn * ( Grad_perp(Nn)/Nn + Grad_perp(Tn)/Tn )
   //
@@ -308,18 +319,18 @@ void NeutralMixed::finally(const Options& state) {
   // Field3D logNn = log(Nn);
   // Field3D logTn = log(Tn);
 
+  // Nnlim Used where division by neutral density is needed
+  Nnlim = softFloor(Nn, density_floor);
+  // Tnlim used where positivity of Tn is required
+  Field3D Tnlim = softFloor(Tn, temperature_floor);
+  // Pnlim used where positivity of Pn is required
+  Pnlim = softFloor(Pn, pressure_floor);
   logPnlim = log(Pnlim);
   logPnlim.applyBoundary();
-
   ///////////////////////////////////////////////////////
   // Calculate cross-field diffusion from collision frequency
   //
   //
-
-  Field3D Tnlim = softFloor(Tn, temperature_floor);
-
-  BoutReal neutral_lmax =
-    0.1 / get<BoutReal>(state["units"]["meters"]); // Normalised length
 
   Field3D Rnn =
     sqrt(Tnlim / AA) / neutral_lmax; // Neutral-neutral collisions [normalised frequency]

--- a/tests/unit/test_neutral_mixed.cxx
+++ b/tests/unit/test_neutral_mixed.cxx
@@ -19,7 +19,8 @@ using namespace bout::globals;
 
 // Reuse the "standard" fixture for FakeMesh
 using NeutralMixedTest = FakeMeshFixture;
-
+// Component test checking only that the state
+// includes Nd, Pd, NVd as evolved variables.
 TEST_F(NeutralMixedTest, CreateComponent) {
   FakeSolver solver;
 
@@ -33,7 +34,8 @@ TEST_F(NeutralMixedTest, CreateComponent) {
   ASSERT_TRUE(state.isSet("Pd"));
   ASSERT_TRUE(state.isSet("NVd"));
 }
-
+// Component test checking only that the state
+// includes Nd, Pd as evolved variables when evolve_momentum = false.
 TEST_F(NeutralMixedTest, CreateComponentEvolveMomentumFalse) {
   FakeSolver solver;
 
@@ -47,7 +49,9 @@ TEST_F(NeutralMixedTest, CreateComponentEvolveMomentumFalse) {
   ASSERT_TRUE(state.isSet("Pd"));
   ASSERT_FALSE(state.isSet("NVd"));
 }
-
+// Transform test checking only that the state has data set in
+// the the required auxiliary variables. Note that boundary conditions
+// are also set in the evolved variables.
 TEST_F(NeutralMixedTest, Transform) {
   FakeSolver solver;
 
@@ -66,7 +70,15 @@ TEST_F(NeutralMixedTest, Transform) {
   ASSERT_TRUE(species.isSet("velocity"));
   ASSERT_TRUE(species.isSet("temperature"));
 }
-
+// Test of finally() for this component following
+// tests of evolve_density and evolve_pressure.
+// We provide a state vector where all fields are constants.
+// We use finally to compute the ddt() of the evolved
+// state variables. For these inputs, the only non-zero
+// contribution comes from the sources, which may be tested
+// by checking that the ddt() variables match expected constants.
+// Note that this test does not check the definition of the
+// differential operators in the right-hand-side of the equations.
 TEST_F(NeutralMixedTest, Finally) {
   FakeSolver solver;
 
@@ -105,7 +117,7 @@ TEST_F(NeutralMixedTest, Finally) {
     ASSERT_DOUBLE_EQ(0.75, ddt_NVd[i]);
   }
 }
-
+// Identical to the test above, but using the collisionality_override variable.
 TEST_F(NeutralMixedTest, FinallyCollisionalityOverride) {
   FakeSolver solver;
 
@@ -145,7 +157,7 @@ TEST_F(NeutralMixedTest, FinallyCollisionalityOverride) {
     ASSERT_DOUBLE_EQ(0.75, ddt_NVd[i]);
   }
 }
-
+// Identical to the test above, but using evolve_momentum = false.
 TEST_F(NeutralMixedTest, FinallyEvolveMomentumFalse) {
   FakeSolver solver;
 

--- a/tests/unit/test_neutral_mixed.cxx
+++ b/tests/unit/test_neutral_mixed.cxx
@@ -34,6 +34,20 @@ TEST_F(NeutralMixedTest, CreateComponent) {
   ASSERT_TRUE(state.isSet("NVd"));
 }
 
+TEST_F(NeutralMixedTest, CreateComponentEvolveMomentumFalse) {
+  FakeSolver solver;
+
+  Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}, {"meters", 1.0}}},
+                  {"d", {{"type","neutral_mixed"}, {"AA", 2.0}, {"evolve_momentum", false}}}};
+  NeutralMixed component("d", options, &solver);
+
+  Options state = solver.getState();
+
+  ASSERT_TRUE(state.isSet("Nd"));
+  ASSERT_TRUE(state.isSet("Pd"));
+  ASSERT_FALSE(state.isSet("NVd"));
+}
+
 TEST_F(NeutralMixedTest, Transform) {
   FakeSolver solver;
 
@@ -57,8 +71,7 @@ TEST_F(NeutralMixedTest, Finally) {
   FakeSolver solver;
 
   Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}, {"meters", 1.0}}},
-                  {"d", {{"type","neutral_mixed"}, {"AA", 2.0}, {"evolve_momentum", true},
-                         {"collisionality_override", 1.0}, {"lax_flux", false}}}};
+                  {"d", {{"type","neutral_mixed"}, {"AA", 2.0}, {"evolve_momentum", true}}}};
   NeutralMixed component("d", options, &solver);
 
   // Call the finally() method with a density, energy, and momentum source
@@ -91,4 +104,78 @@ TEST_F(NeutralMixedTest, Finally) {
   BOUT_FOR_SERIAL(i, ddt_NVd.getRegion("RGN_NOBNDRY")) {
     ASSERT_DOUBLE_EQ(0.75, ddt_NVd[i]);
   }
+}
+
+TEST_F(NeutralMixedTest, FinallyCollisionalityOverride) {
+  FakeSolver solver;
+
+  Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}, {"meters", 1.0}}},
+                  {"d", {{"type","neutral_mixed"}, {"AA", 2.0}, {"evolve_momentum", true},
+                         {"collisionality_override", 1.0}}}};
+  NeutralMixed component("d", options, &solver);
+
+  // Call the finally() method with a density, energy, and momentum source
+  const Options state = {
+      {"species", {{"d", {{"density", 1.0}, {"density_source", 0.5},
+                         {"pressure", 1.0}, {"energy_source", 1.5},
+                         {"momentum", 1.0}, {"momentum_source", 0.75},
+                         {"temperature", 1.0}, {"velocity", 1.0}}}}}};
+  component.finally(state);
+
+  Options ddt = solver.getTimeDerivs();
+
+  ASSERT_TRUE(ddt.isSet("Nd"));
+  Field3D ddt_Nd = ddt["Nd"].as<Field3D>();
+
+  BOUT_FOR_SERIAL(i, ddt_Nd.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(0.5, ddt_Nd[i]);
+  }
+
+  ASSERT_TRUE(ddt.isSet("Pd"));
+  Field3D ddt_Pd = ddt["Pd"].as<Field3D>();
+
+  BOUT_FOR_SERIAL(i, ddt_Pd.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(1.0, ddt_Pd[i]);
+  }
+
+  ASSERT_TRUE(ddt.isSet("NVd"));
+  Field3D ddt_NVd = ddt["NVd"].as<Field3D>();
+
+  BOUT_FOR_SERIAL(i, ddt_NVd.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(0.75, ddt_NVd[i]);
+  }
+}
+
+TEST_F(NeutralMixedTest, FinallyEvolveMomentumFalse) {
+  FakeSolver solver;
+
+  Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}, {"meters", 1.0}}},
+                  {"d", {{"type","neutral_mixed"}, {"AA", 2.0}, {"evolve_momentum", false}}}};
+  NeutralMixed component("d", options, &solver);
+
+  // Call the finally() method with a density, energy, and momentum source
+  const Options state = {
+      {"species", {{"d", {{"density", 1.0}, {"density_source", 0.5},
+                         {"pressure", 1.0}, {"energy_source", 1.5},
+                         {"momentum", 1.0}, {"momentum_source", 0.75},
+                         {"temperature", 1.0}, {"velocity", 1.0}}}}}};
+  component.finally(state);
+
+  Options ddt = solver.getTimeDerivs();
+
+  ASSERT_TRUE(ddt.isSet("Nd"));
+  Field3D ddt_Nd = ddt["Nd"].as<Field3D>();
+
+  BOUT_FOR_SERIAL(i, ddt_Nd.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(0.5, ddt_Nd[i]);
+  }
+
+  ASSERT_TRUE(ddt.isSet("Pd"));
+  Field3D ddt_Pd = ddt["Pd"].as<Field3D>();
+
+  BOUT_FOR_SERIAL(i, ddt_Pd.getRegion("RGN_NOBNDRY")) {
+    ASSERT_DOUBLE_EQ(1.0, ddt_Pd[i]);
+  }
+
+  ASSERT_FALSE(ddt.isSet("NVd"));
 }


### PR DESCRIPTION
Attempt to bring style of neutral_mixed.cxx in line with evolve_pressure.cxx or evolve_density.cxx. Introduce a similar set of unit tests. The integration tests fail: the changes have unexpectedly broken the component.

To address #476 I have tried to change the style of `neutral_mixed.cxx` to enable testing in the same manner as e.g., `evolve_density` and `evolve_pressure`.

EDIT: Integrated and unit tests now passing.