### PR TITLE
Fix sheath boundary simple 2

### DIFF
--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -295,12 +295,12 @@ void SheathBoundarySimple::transform_impl(GuardedOptions& state) {
           const BoutReal nesheath = 0.5 * (Ne_im + Ne[i]);
           const BoutReal tesheath = floor(0.5 * (Te_im + Te[i]), 1e-5);
 
-          // Note: Floor on nesheath is << floor on ion_sum so that the ratio is
-          // small but non-zero when both go to zero.
+          // Note: Floor on nesheath is the same as on ion_sum so that the ratio is
+          // 1 when both go to zero (implying a flow velocity of 1).
           phi[i] =
               tesheath
               * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge)
-                    * floor(nesheath, 1e-10) / floor(ion_sum[i], 1e-5));
+                    * floor(nesheath, 1e-5) / floor(ion_sum[i], 1e-5));
 
           const BoutReal phi_wall = wall_potential[i];
           phi[i] += phi_wall; // Add bias potential
@@ -326,7 +326,7 @@ void SheathBoundarySimple::transform_impl(GuardedOptions& state) {
           phi[i] =
               tesheath
               * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge)
-                    * floor(nesheath, 1e-10) / floor(ion_sum[i], 1e-5));
+                    * floor(nesheath, 1e-5) / floor(ion_sum[i], 1e-5));
 
           const BoutReal phi_wall = wall_potential[i];
           phi[i] += phi_wall; // Add bias potential

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -295,9 +295,12 @@ void SheathBoundarySimple::transform_impl(GuardedOptions& state) {
           const BoutReal nesheath = 0.5 * (Ne_im + Ne[i]);
           const BoutReal tesheath = floor(0.5 * (Te_im + Te[i]), 1e-5);
 
+          // Note: Floor on nesheath is << floor on ion_sum so that the ratio is
+          // small but non-zero when both go to zero.
           phi[i] =
               tesheath
-              * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge) * nesheath / ion_sum[i]);
+              * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge)
+                    * floor(nesheath, 1e-10) / floor(ion_sum[i], 1e-5));
 
           const BoutReal phi_wall = wall_potential[i];
           phi[i] += phi_wall; // Add bias potential
@@ -322,7 +325,8 @@ void SheathBoundarySimple::transform_impl(GuardedOptions& state) {
 
           phi[i] =
               tesheath
-              * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge) * nesheath / ion_sum[i]);
+              * log(sqrt(tesheath / (Me * TWOPI)) * (1. - Ge)
+                    * floor(nesheath, 1e-10) / floor(ion_sum[i], 1e-5));
 
           const BoutReal phi_wall = wall_potential[i];
           phi[i] += phi_wall; // Add bias potential


### PR DESCRIPTION
When `phi` is not set, `phisheath` is calculated from the ion flux. If `nesheath` or `ion_sum` go to zero then phisheath becomes NaN. That caused vesheath to be NaN, then the electron heat flux. Simulations would fail due to an invalid value being assigned to `e:energy_source`.

This applies floors to `nesheath` and `ion_sum` in the calculation of phi. [Note: Possibly should be `softFloor`?]

Replaces #478

Not covered by unit tests but fixes an issue with production simulations. The sheath boundary components are being consolidated and tested by @ZedThree .