### PR TITLE
CI: Add clang-format for changes

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,33 @@
+name: clang-format-command
+
+on:
+  pull_request:
+    paths:
+      - '**.cxx'
+      - '**.hxx'
+
+jobs:
+  clang-format:
+    # Release candidate branches tend to have big PRs which causes all sorts of problems
+    if: ${{ !endsWith(github.head_ref, '-rc') }}
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the pull request branch, also include all history
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      # This also installs git-clang-format
+      - name: Install clang-format
+        run: sudo apt install clang-format
+
+      - name: Run clang-format
+        id: format
+        run:
+          while ! git clang-format origin/${{ github.base_ref }} ; do git add . ; done
+
+      - name: Commit to the PR branch
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Apply clang-format changes"


### PR DESCRIPTION
The file is copied from the BOUT-dev repo.

Co-Author: Peter Hill <peter.hill@york.ac.uk>

Resolves: #360 