### PR TITLE
Run clang-format on several components

### DIFF
--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -23,15 +23,17 @@
 struct NeutralBoundary : public Component {
   NeutralBoundary(std::string name, Options& options, Solver*);
 
-  void outputVars(Options &state) override;
+  void outputVars(Options& state) override;
 
 private:
   std::string name; ///< Short name of species e.g "d"
 
   BoutReal Tnorm; // Temperature normalisation [eV]
 
-  BoutReal target_energy_refl_factor, sol_energy_refl_factor, pfr_energy_refl_factor; ///< Fraction of energy retained after reflection
-  BoutReal target_fast_refl_fraction, sol_fast_refl_fraction, pfr_fast_refl_fraction; ///< Fraction of neutrals undergoing fast reflection
+  BoutReal target_energy_refl_factor, sol_energy_refl_factor,
+      pfr_energy_refl_factor; ///< Fraction of energy retained after reflection
+  BoutReal target_fast_refl_fraction, sol_fast_refl_fraction,
+      pfr_fast_refl_fraction; ///< Fraction of neutrals undergoing fast reflection
 
   Field3D target_energy_source, wall_energy_source; ///< Diagnostic for power loss
 
@@ -39,8 +41,8 @@ private:
 
   bool lower_y; ///< Boundary condition at lower y?
   bool upper_y; ///< Boundary condition at upper y?
-  bool sol; ///< Boundary condition at sol?
-  bool pfr; ///< Boundary condition at pfr?
+  bool sol;     ///< Boundary condition at sol?
+  bool pfr;     ///< Boundary condition at pfr?
 
   ///
   /// state
@@ -57,8 +59,7 @@ private:
 };
 
 namespace {
-RegisterComponent<NeutralBoundary>
-    registercomponentneutralboundary("neutral_boundary");
+RegisterComponent<NeutralBoundary> registercomponentneutralboundary("neutral_boundary");
 }
 
 #endif // NEUTRAL_BOUNDARY_H

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -17,34 +17,36 @@ struct NeutralMixed : public Component {
   /// @param name     The name of the species e.g. "h"
   /// @param options  Top-level options. Settings will be taken from options[name]
   /// @param solver   Time-integration solver to be used
-  NeutralMixed(const std::string& name, Options& options, Solver *solver);
+  NeutralMixed(const std::string& name, Options& options, Solver* solver);
 
   /// Use the final simulation state to update internal state
   /// (e.g. time derivatives)
-  void finally(const Options &state) override;
+  void finally(const Options& state) override;
 
   /// Add extra fields for output, or set attributes e.g docstrings
-  void outputVars(Options &state) override;
+  void outputVars(Options& state) override;
 
   /// Preconditioner
-  void precon(const Options &state, BoutReal gamma) override;
-private:
-  std::string name;  ///< Species name
+  void precon(const Options& state, BoutReal gamma) override;
 
-  Field3D Nn, Pn, NVn; // Density, pressure and parallel momentum
-  Field3D Vn; ///< Neutral parallel velocity
-  Field3D Tn; ///< Neutral temperature
+private:
+  std::string name; ///< Species name
+
+  Field3D Nn, Pn, NVn;            // Density, pressure and parallel momentum
+  Field3D Vn;                     ///< Neutral parallel velocity
+  Field3D Tn;                     ///< Neutral temperature
   Field3D Nnlim, Pnlim, logPnlim; // Limited in regions of low density
 
   BoutReal AA; ///< Atomic mass (proton = 1)
 
   std::vector<std::string> collision_names; ///< Collisions used for collisionality
-  std::string diffusion_collisions_mode;  ///< Collision selection, either afn or multispecies
-  Field3D nu; ///< Collisionality to use for diffusion
-  Field3D Dnn; ///< Diffusion coefficient
+  std::string
+      diffusion_collisions_mode; ///< Collision selection, either afn or multispecies
+  Field3D nu;                    ///< Collisionality to use for diffusion
+  Field3D Dnn;                   ///< Diffusion coefficient
   Field3D DnnNn, DnnPn, DnnTn, DnnNVn; ///< Used for operators
-  BoutReal flux_limit; ///< Diffusive flux limit
-  BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
+  BoutReal flux_limit;                 ///< Diffusive flux limit
+  BoutReal diffusion_limit;            ///< Maximum diffusion coefficient
   BoutReal neutral_lmax;
 
   bool sheath_ydown, sheath_yup;
@@ -58,16 +60,16 @@ private:
   BoutReal density_norm, pressure_norm; ///< Normalisations
   BoutReal momentum_norm;               ///< Normalisations
 
-  bool neutral_viscosity; ///< include viscosity?
+  bool neutral_viscosity;  ///< include viscosity?
   bool neutral_conduction; ///< Include heat conduction?
-  bool evolve_momentum; ///< Evolve parallel momentum?
-  bool normalise_sources; ///< Normalise input sources?
+  bool evolve_momentum;    ///< Evolve parallel momentum?
+  bool normalise_sources;  ///< Normalise input sources?
 
   Field3D kappa_n, eta_n; ///< Neutral conduction and viscosity
 
-  bool precondition {true}; ///< Enable preconditioner?
-  bool precon_laplacexy {false}; ///< Use LaplaceXY?
-  bool lax_flux; ///< Use Lax flux for advection terms
+  bool precondition{true};        ///< Enable preconditioner?
+  bool precon_laplacexy{false};   ///< Use LaplaceXY?
+  bool lax_flux;                  ///< Use Lax flux for advection terms
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 
   Field3D density_source, pressure_source, momentum_source; ///< External input source
@@ -75,7 +77,7 @@ private:
   Field3D sound_speed; ///< Sound speed for use with Lax flux
 
   bool output_ddt; ///< Save time derivatives?
-  bool diagnose; ///< Save additional diagnostics?
+  bool diagnose;   ///< Save additional diagnostics?
 
   // Flow diagnostics
   Field3D pf_adv_perp_xlow, pf_adv_perp_ylow, pf_adv_par_ylow;

--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -8,11 +8,11 @@
 ///
 /// Since this must be calculated after boundary fluxes (e.g. sheath),
 /// it is included as a top-level component
-/// 
+///
 struct Recycling : public Component {
-  
+
   /// Inputs
-  /// 
+  ///
   ///   - <name>
   ///     - species    A comma-separated list of species to recycle
   ///   - <species>
@@ -20,22 +20,26 @@ struct Recycling : public Component {
   ///     - recycle_multiplier   The recycled flux multiplier, between 0 and 1
   ///     - recycle_energy       The energy of the recycled particles [eV]
   ///
-  Recycling(std::string name, Options &alloptions, Solver *);
+  Recycling(std::string name, Options& alloptions, Solver*);
 
-  void outputVars(Options &state) override;
+  void outputVars(Options& state) override;
 
 private:
-
   struct RecycleChannel {
     std::string from; ///< The species name to recycle
     std::string to;   ///< Species to recycle to
 
-    /// Flux multiplier (recycling fraction). 
-    /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5 multiplier
-    BoutReal target_multiplier, sol_multiplier, pfr_multiplier, pump_multiplier; 
-    BoutReal target_energy, sol_energy, pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
-    BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction;   ///< Fraction of ions undergoing fast reflection
-    BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor;   ///< Fraction of energy retained by fast recycled neutrals
+    /// Flux multiplier (recycling fraction).
+    /// Combination of recycling fraction and species change e.g h+ -> h2 results in 0.5
+    /// multiplier
+    BoutReal target_multiplier, sol_multiplier, pfr_multiplier, pump_multiplier;
+    BoutReal target_energy, sol_energy,
+        pfr_energy; ///< Energy of recycled particle (normalised to Tnorm)
+    BoutReal target_fast_recycle_fraction, pfr_fast_recycle_fraction,
+        sol_fast_recycle_fraction; ///< Fraction of ions undergoing fast reflection
+    BoutReal target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor,
+        pfr_fast_recycle_energy_factor; ///< Fraction of energy retained by fast recycled
+                                        ///< neutrals
 
     // Recycling particle and energy sources for the different sources of recycling
     // These sources are per-channel and added to the `to` species
@@ -55,16 +59,23 @@ private:
 
   std::vector<RecycleChannel> channels; // Recycling channels
 
-  bool target_recycle {false}, sol_recycle {false}, pfr_recycle {false}, neutral_pump {false};  ///< Flags for enabling recycling in different regions
-  bool diagnose; ///< Save additional post-processing variables?
+  bool target_recycle{false}, sol_recycle{false}, pfr_recycle{false},
+      neutral_pump{false}; ///< Flags for enabling recycling in different regions
+  bool diagnose;           ///< Save additional post-processing variables?
 
-  BoutReal density_floor, pressure_floor; ///< minimum values for Nn, Pn to avoid divide by zero
+  BoutReal density_floor,
+      pressure_floor; ///< minimum values for Nn, Pn to avoid divide by zero
 
-  Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
-  Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
-  Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity
+  Field3D density_source,
+      energy_source; ///< Recycling particle and energy sources for all locations
+  Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating
+                                              ///< fast recycling energy source
+  Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need
+                              ///< to get poloidal from here, it's calculated from sheath
+                              ///< velocity
 
-  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR. Provided by user in grid file.
+  Field2D is_pump; ///< 1 = pump, 0 = no pump. Works only in SOL/PFR. Provided by user in
+                   ///< grid file.
   /// Inputs
   ///
   /// - species

--- a/src/neutral_boundary.cxx
+++ b/src/neutral_boundary.cxx
@@ -17,36 +17,41 @@ NeutralBoundary::NeutralBoundary(std::string name, Options& alloptions,
   const Options& units = alloptions["units"];
   Tnorm = units["eV"];
 
-  diagnose = options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
-  lower_y = options["neutral_boundary_lower_y"].doc("Boundary on lower y?").withDefault<bool>(true);
-  upper_y = options["neutral_boundary_upper_y"].doc("Boundary on upper y?").withDefault<bool>(true);
+  diagnose =
+      options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
+  lower_y = options["neutral_boundary_lower_y"]
+                .doc("Boundary on lower y?")
+                .withDefault<bool>(true);
+  upper_y = options["neutral_boundary_upper_y"]
+                .doc("Boundary on upper y?")
+                .withDefault<bool>(true);
   sol = options["neutral_boundary_sol"].doc("Boundary on SOL?").withDefault<bool>(false);
   pfr = options["neutral_boundary_pfr"].doc("Boundary on PFR?").withDefault<bool>(false);
 
-  target_energy_refl_factor =
-        options["target_energy_refl_factor"]
-            .doc("Fraction of energy retained by neutral particles after wall reflection at target")
-            .withDefault<BoutReal>(0.75);
+  target_energy_refl_factor = options["target_energy_refl_factor"]
+                                  .doc("Fraction of energy retained by neutral particles "
+                                       "after wall reflection at target")
+                                  .withDefault<BoutReal>(0.75);
 
-  sol_energy_refl_factor =
-        options["sol_energy_refl_factor"]
-            .doc("Fraction of energy retained by neutral particles after wall reflection at SOL")
-            .withDefault<BoutReal>(0.75);
+  sol_energy_refl_factor = options["sol_energy_refl_factor"]
+                               .doc("Fraction of energy retained by neutral particles "
+                                    "after wall reflection at SOL")
+                               .withDefault<BoutReal>(0.75);
 
-  pfr_energy_refl_factor =
-        options["pfr_energy_refl_factor"]
-            .doc("Fraction of energy retained by neutral particles after wall reflection at PFR")
-            .withDefault<BoutReal>(0.75);
+  pfr_energy_refl_factor = options["pfr_energy_refl_factor"]
+                               .doc("Fraction of energy retained by neutral particles "
+                                    "after wall reflection at PFR")
+                               .withDefault<BoutReal>(0.75);
 
   target_fast_refl_fraction =
-        options["target_fast_refl_fraction"]
-            .doc("Fraction of neutrals that are undergoing fast reflection at the target")
-            .withDefault<BoutReal>(0.8);
+      options["target_fast_refl_fraction"]
+          .doc("Fraction of neutrals that are undergoing fast reflection at the target")
+          .withDefault<BoutReal>(0.8);
 
   sol_fast_refl_fraction =
-        options["sol_fast_refl_fraction"]
-            .doc("Fraction of neutrals that are undergoing fast reflection at the sol")
-            .withDefault<BoutReal>(0.8);
+      options["sol_fast_refl_fraction"]
+          .doc("Fraction of neutrals that are undergoing fast reflection at the sol")
+          .withDefault<BoutReal>(0.8);
 
   pfr_fast_refl_fraction =
       options["pfr_fast_refl_fraction"]
@@ -97,7 +102,7 @@ void NeutralBoundary::transform_impl(GuardedOptions& state) {
         // Pn[im] = SQ(Pn[i]) / Pn[ip];
         // Tn[im] = SQ(Tn[i]) / Tn[ip];
 
-        // Neumann boundary condition: do not extrapolate, but 
+        // Neumann boundary condition: do not extrapolate, but
         // assume the target value is same as the final cell centre.
         // Shouldn't affect results much and more resilient to positivity issues
         Nn[im] = Nn[i];
@@ -113,30 +118,35 @@ void NeutralBoundary::transform_impl(GuardedOptions& state) {
         const BoutReal tnsheath = 0.5 * (Tn[im] + Tn[i]);
 
         // Thermal speed
-        const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
+        const BoutReal v_th =
+            0.25 * sqrt(8 * tnsheath / (PI * AA)); // Stangeby p.69 eqns. 2.21, 2.24
 
         // Approach adapted from D. Power thesis 2023
         BoutReal T_FC = 3 / Tnorm; // Franck-Condon temp (hardcoded for now)
 
         // Outgoing neutral heat flux [W/m^2]
-        // This is rearranged from Power for clarity - note definition of v_th. 
-        // Uses standard Stangeby 1D static Maxwellian particle/heat fluxes for fast terms and simply Q = T * particle flux
-        // for the monoenergetic thermal reflected population.
-        BoutReal q = 
-                      2 * nnsheath * tnsheath * v_th                                                             // Incident energy
-                    - (target_energy_refl_factor * target_fast_refl_fraction ) * 2 * nnsheath * tnsheath * v_th  // Fast reflected energy
-                    - (1 - target_fast_refl_fraction) * T_FC * nnsheath * v_th;                                  // Thermal reflected energy
+        // This is rearranged from Power for clarity - note definition of v_th.
+        // Uses standard Stangeby 1D static Maxwellian particle/heat fluxes for fast terms
+        // and simply Q = T * particle flux for the monoenergetic thermal reflected
+        // population.
+        BoutReal q = 2 * nnsheath * tnsheath * v_th // Incident energy
+                     - (target_energy_refl_factor * target_fast_refl_fraction) * 2
+                           * nnsheath * tnsheath * v_th // Fast reflected energy
+                     - (1 - target_fast_refl_fraction) * T_FC * nnsheath
+                           * v_th; // Thermal reflected energy
 
-      
         // Cross-sectional area in XZ plane:
-        BoutReal da = (coord->J[i] + coord->J[im]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im]))
-                      * 0.5*(coord->dx[i] + coord->dx[im]) * 0.5*(coord->dz[i] + coord->dz[im]);   // [m^2]
+        BoutReal da = (coord->J[i] + coord->J[im])
+                      / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[im])) * 0.5
+                      * (coord->dx[i] + coord->dx[im]) * 0.5
+                      * (coord->dz[i] + coord->dz[im]); // [m^2]
 
         // Multiply by area to get energy flow (power)
-        BoutReal flow = q * da;  // [W]
-        
+        BoutReal flow = q * da; // [W]
+
         // Divide by cell volume to get source [W/m^3]
-        BoutReal cooling_source = flow / (coord->dx[i] * coord->dy[i] * coord->dz[i] * coord->J[i]);
+        BoutReal cooling_source =
+            flow / (coord->dx[i] * coord->dy[i] * coord->dz[i] * coord->J[i]);
 
         // Subtract from cell next to boundary
         energy_source[i] -= cooling_source;
@@ -157,7 +167,7 @@ void NeutralBoundary::transform_impl(GuardedOptions& state) {
         // Pn[ip] = SQ(Pn[i]) / Pn[im];
         // Tn[ip] = SQ(Tn[i]) / Tn[im];
 
-        // Neumann boundary condition: do not extrapolate, but 
+        // Neumann boundary condition: do not extrapolate, but
         // assume the target value is same as the final cell centre.
         // Shouldn't affect results much and more resilient to positivity issues
         Nn[ip] = Nn[i];
@@ -173,76 +183,88 @@ void NeutralBoundary::transform_impl(GuardedOptions& state) {
         const BoutReal tnsheath = 0.5 * (Tn[ip] + Tn[i]);
 
         // Thermal speed
-        const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
+        const BoutReal v_th =
+            0.25 * sqrt(8 * tnsheath / (PI * AA)); // Stangeby p.69 eqns. 2.21, 2.24
 
         // Approach adapted from D. Power thesis 2023
         BoutReal T_FC = 3 / Tnorm; // Franck-Condon temp (hardcoded for now)
 
         // Outgoing neutral heat flux [W/m^2]
-        // This is rearranged from Power for clarity - note definition of v_th. 
-        BoutReal q = 2 * nnsheath * tnsheath * v_th                                                              // Incident energy
-                    - (target_energy_refl_factor * target_fast_refl_fraction ) * 2 * nnsheath * tnsheath * v_th  // Fast reflected energy
-                    - (1 - target_fast_refl_fraction) * T_FC * nnsheath * v_th;                                  // Thermal reflected energy
+        // This is rearranged from Power for clarity - note definition of v_th.
+        BoutReal q = 2 * nnsheath * tnsheath * v_th // Incident energy
+                     - (target_energy_refl_factor * target_fast_refl_fraction) * 2
+                           * nnsheath * tnsheath * v_th // Fast reflected energy
+                     - (1 - target_fast_refl_fraction) * T_FC * nnsheath
+                           * v_th; // Thermal reflected energy
 
         // Cross-sectional area in XZ plane:
-        BoutReal da = (coord->J[i] + coord->J[ip]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]))
-                      * 0.5*(coord->dx[i] + coord->dx[ip]) * 0.5*(coord->dz[i] + coord->dz[ip]);   // [m^2]
+        BoutReal da = (coord->J[i] + coord->J[ip])
+                      / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip])) * 0.5
+                      * (coord->dx[i] + coord->dx[ip]) * 0.5
+                      * (coord->dz[i] + coord->dz[ip]); // [m^2]
 
         // Multiply by area to get energy flow (power)
-        BoutReal flow = q * da;  // [W]
+        BoutReal flow = q * da; // [W]
 
         // Divide by cell volume to get source [W/m^3]
-        BoutReal cooling_source = flow / (coord->dx[i] * coord->dy[i] * coord->dz[i] * coord->J[i]);
+        BoutReal cooling_source =
+            flow / (coord->dx[i] * coord->dy[i] * coord->dz[i] * coord->J[i]);
 
         // Subtract from cell next to boundary
         energy_source[i] -= cooling_source;
         target_energy_source[i] -= cooling_source;
-
       }
     }
   }
 
   // SOL edge
   if (sol) {
-    if (mesh->lastX()) {  // Only do this for the processor which has the edge region
+    if (mesh->lastX()) { // Only do this for the processor which has the edge region
       for (int iy = 0; iy < mesh->LocalNy; iy++) {
         for (int iz = 0; iz < mesh->LocalNz; iz++) {
 
-          auto i = indexAt(Nn, mesh->xend, iy, iz);  // Final domain cell
-          auto ig = indexAt(Nn, mesh->xend+1, iy, iz);  // Guard cell
-          
+          auto i = indexAt(Nn, mesh->xend, iy, iz);      // Final domain cell
+          auto ig = indexAt(Nn, mesh->xend + 1, iy, iz); // Guard cell
+
           // Calculate midpoint values at wall
           const BoutReal nnsheath = 0.5 * (Nn[ig] + Nn[i]);
           const BoutReal tnsheath = 0.5 * (Tn[ig] + Tn[i]);
 
           // Thermal speed of static Maxwellian in one direction
-          const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
+          const BoutReal v_th =
+              0.25 * sqrt(8 * tnsheath / (PI * AA)); // Stangeby p.69 eqns. 2.21, 2.24
 
           // Approach adapted from D. Power thesis 2023
           BoutReal T_FC = 3 / Tnorm; // Franck-Condon temp (hardcoded for now)
 
           // Outgoing neutral heat flux [W/m^2]
-          // This is rearranged from Power for clarity - note definition of v_th. 
-          BoutReal q = 2 * nnsheath * tnsheath * v_th                                                        // Incident energy
-                      - (sol_energy_refl_factor * sol_fast_refl_fraction ) * 2 * nnsheath * tnsheath * v_th  // Fast reflected energy
-                      - (1 - sol_fast_refl_fraction) * T_FC * nnsheath * v_th;                               // Thermal reflected energy
+          // This is rearranged from Power for clarity - note definition of v_th.
+          BoutReal q = 2 * nnsheath * tnsheath * v_th // Incident energy
+                       - (sol_energy_refl_factor * sol_fast_refl_fraction) * 2 * nnsheath
+                             * tnsheath * v_th // Fast reflected energy
+                       - (1 - sol_fast_refl_fraction) * T_FC * nnsheath
+                             * v_th; // Thermal reflected energy
 
           // Multiply by radial cell area to get power
           // Expanded form of the calculation for clarity
 
           // Converts dy to poloidal length: dl = dy / sqrt(g22) = dy * h_theta
-          BoutReal dpol = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
+          BoutReal dpol = 0.5 * (coord->dy[i] + coord->dy[ig]) * 1
+                          / (0.5 * (sqrt(coord->g22[i]) + sqrt(coord->g22[ig])));
 
           // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
-          BoutReal dtor = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+          BoutReal dtor = 0.5 * (coord->dz[i] + coord->dz[ig]) * 0.5
+                          * (sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
 
-          BoutReal da = dpol * dtor;  // [m^2]
+          BoutReal da = dpol * dtor; // [m^2]
 
           // Multiply by area to get energy flow (power)
-          BoutReal flow = q * da;  // [W]
+          BoutReal flow = q * da; // [W]
 
           // Divide by cell volume to get source [W/m^3]
-          BoutReal cooling_source = flow / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);   // [W m^-3]
+          BoutReal cooling_source =
+              flow
+              / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]); // [W m^-3]
 
           // Subtract from cell next to boundary
           energy_source[i] -= cooling_source;
@@ -254,45 +276,54 @@ void NeutralBoundary::transform_impl(GuardedOptions& state) {
 
   // PFR edge
   if (pfr) {
-    if ((mesh->firstX()) and (!mesh->periodicY(mesh->xstart))) {  // do loop if inner edge and not periodic (i.e. PFR)
-      for (int iy = 0; iy < mesh->LocalNy ; iy++) {
+    if ((mesh->firstX())
+        and (!mesh->periodicY(
+            mesh->xstart))) { // do loop if inner edge and not periodic (i.e. PFR)
+      for (int iy = 0; iy < mesh->LocalNy; iy++) {
         for (int iz = 0; iz < mesh->LocalNz; iz++) {
 
-          auto i = indexAt(Nn, mesh->xstart, iy, iz);  // Final domain cell
-          auto ig = indexAt(Nn, mesh->xstart-1, iy, iz);  // Guard cell
+          auto i = indexAt(Nn, mesh->xstart, iy, iz);      // Final domain cell
+          auto ig = indexAt(Nn, mesh->xstart - 1, iy, iz); // Guard cell
 
           // Calculate midpoint values at wall
           const BoutReal nnsheath = 0.5 * (Nn[ig] + Nn[i]);
           const BoutReal tnsheath = 0.5 * (Tn[ig] + Tn[i]);
 
           // Thermal speed of static Maxwellian in one direction
-          const BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AA) );   // Stangeby p.69 eqns. 2.21, 2.24
+          const BoutReal v_th =
+              0.25 * sqrt(8 * tnsheath / (PI * AA)); // Stangeby p.69 eqns. 2.21, 2.24
 
           // Approach adapted from D. Power thesis 2023
           BoutReal T_FC = 3 / Tnorm; // Franck-Condon temp (hardcoded for now)
 
           // Outgoing neutral heat flux [W/m^2]
-          // This is rearranged from Power for clarity - note definition of v_th. 
-          BoutReal q = 2 * nnsheath * tnsheath * v_th                                                        // Incident energy
-                      - (pfr_energy_refl_factor * pfr_fast_refl_fraction ) * 2 * nnsheath * tnsheath * v_th  // Fast reflected energy
-                      - (1 - pfr_fast_refl_fraction) * T_FC * nnsheath * v_th;                               // Thermal reflected energy
+          // This is rearranged from Power for clarity - note definition of v_th.
+          BoutReal q = 2 * nnsheath * tnsheath * v_th // Incident energy
+                       - (pfr_energy_refl_factor * pfr_fast_refl_fraction) * 2 * nnsheath
+                             * tnsheath * v_th // Fast reflected energy
+                       - (1 - pfr_fast_refl_fraction) * T_FC * nnsheath
+                             * v_th; // Thermal reflected energy
 
           // Multiply by radial cell area to get power
           // Expanded form of the calculation for clarity
 
           // Converts dy to poloidal length: dl = dy / sqrt(g22) = dy * h_theta
-          BoutReal dpol = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
+          BoutReal dpol = 0.5 * (coord->dy[i] + coord->dy[ig]) * 1
+                          / (0.5 * (sqrt(coord->g22[i]) + sqrt(coord->g22[ig])));
 
           // Converts dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
-          BoutReal dtor = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+          BoutReal dtor = 0.5 * (coord->dz[i] + coord->dz[ig]) * 0.5
+                          * (sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
 
-          BoutReal da = dpol * dtor;  // [m^2]
+          BoutReal da = dpol * dtor; // [m^2]
 
           // Multiply by area to get energy flow (power)
-          BoutReal flow = q * da;  // [W]
+          BoutReal flow = q * da; // [W]
 
           // Divide by cell volume to get source [W/m^3]
-          BoutReal cooling_source = flow / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]);   // [W m^-3]
+          BoutReal cooling_source =
+              flow
+              / (coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i]); // [W m^-3]
 
           // Subtract from cell next to boundary
           energy_source[i] -= cooling_source;
@@ -328,27 +359,30 @@ void NeutralBoundary::outputVars(Options& state) {
 
   if (diagnose) {
 
-      // Save particle and energy source for the species created during recycling
+    // Save particle and energy source for the species created during recycling
 
-      // Target recycling
+    // Target recycling
 
-      if ((sol) or (pfr)) {
-        set_with_attrs(state[{std::string("E") + name + std::string("_wall_refl")}], wall_energy_source,
-                        {{"time_dimension", "t"},
-                        {"units", "W m^-3"},
-                        {"conversion", Pnorm * Omega_ci},
-                        {"standard_name", "energy source"},
-                        {"long_name", std::string("Wall reflection energy source of ") + name},
-                        {"source", "neutral_boundary"}});
-      }
+    if ((sol) or (pfr)) {
+      set_with_attrs(
+          state[{std::string("E") + name + std::string("_wall_refl")}],
+          wall_energy_source,
+          {{"time_dimension", "t"},
+           {"units", "W m^-3"},
+           {"conversion", Pnorm * Omega_ci},
+           {"standard_name", "energy source"},
+           {"long_name", std::string("Wall reflection energy source of ") + name},
+           {"source", "neutral_boundary"}});
+    }
 
-      set_with_attrs(state[{std::string("E") + name + std::string("_target_refl")}], target_energy_source,
-                      {{"time_dimension", "t"},
-                      {"units", "W m^-3"},
-                      {"conversion", Pnorm * Omega_ci},
-                      {"standard_name", "energy source"},
-                      {"long_name", std::string("Wall reflection energy source of ") + name},
-                      {"source", "neutral_boundary"}});
+    set_with_attrs(
+        state[{std::string("E") + name + std::string("_target_refl")}],
+        target_energy_source,
+        {{"time_dimension", "t"},
+         {"units", "W m^-3"},
+         {"conversion", Pnorm * Omega_ci},
+         {"standard_name", "energy source"},
+         {"long_name", std::string("Wall reflection energy source of ") + name},
+         {"source", "neutral_boundary"}});
   }
 }
-

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -5,10 +5,9 @@
 #include <bout/fv_ops.hxx>
 #include <bout/output_bout_types.hxx>
 
-#include "../include/hermes_utils.hxx"
 #include "../include/div_ops.hxx"
-#include "../include/hermes_utils.hxx"
 #include "../include/hermes_build_config.hxx"
+#include "../include/hermes_utils.hxx"
 #include "../include/neutral_mixed.hxx"
 
 #include <algorithm>
@@ -60,16 +59,18 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                    .withDefault<bool>(true);
 
   density_floor = options["density_floor"]
-                 .doc("A minimum density used when dividing NVn by Nn. "
-                      "Normalised units.")
-                 .withDefault(1e-8);
+                      .doc("A minimum density used when dividing NVn by Nn. "
+                           "Normalised units.")
+                      .withDefault(1e-8);
 
   freeze_low_density = options["freeze_low_density"]
-    .doc("Freeze evolution in low density regions?")
-    .withDefault<bool>(false);
+                           .doc("Freeze evolution in low density regions?")
+                           .withDefault<bool>(false);
 
-  temperature_floor = options["temperature_floor"].doc("Low temperature scale for low_T_diffuse_perp")
-    .withDefault<BoutReal>(0.1) / get<BoutReal>(alloptions["units"]["eV"]);
+  temperature_floor = options["temperature_floor"]
+                          .doc("Low temperature scale for low_T_diffuse_perp")
+                          .withDefault<BoutReal>(0.1)
+                      / get<BoutReal>(alloptions["units"]["eV"]);
 
   pressure_floor = density_floor * temperature_floor;
 
@@ -77,9 +78,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                      .doc("Enable preconditioning in neutral model?")
                      .withDefault<bool>(false);
 
-  lax_flux = options["lax_flux"]
-                     .doc("Enable stabilising lax flux?")
-                     .withDefault<bool>(true);
+  lax_flux =
+      options["lax_flux"].doc("Enable stabilising lax flux?").withDefault<bool>(true);
 
   neutral_lmax = 0.1 / meters; // Normalised length
 
@@ -98,8 +98,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                           .withDefault<bool>(true);
 
   neutral_conduction = options["neutral_conduction"]
-                          .doc("Include neutral gas heat conduction?")
-                          .withDefault<bool>(true);
+                           .doc("Include neutral gas heat conduction?")
+                           .withDefault<bool>(true);
 
   collisionality_override =
       options["collisionality_override"]
@@ -111,8 +111,9 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
                           .doc("Normalise input sources?")
                           .withDefault<bool>(true);
   diffusion_collisions_mode = options["diffusion_collisions_mode"]
-      .doc("Can be multispecies: all enabled collisions excl. IZ, or afn: CX, IZ and NN collisions")
-      .withDefault<std::string>("multispecies");
+                                  .doc("Can be multispecies: all enabled collisions "
+                                       "excl. IZ, or afn: CX, IZ and NN collisions")
+                                  .withDefault<std::string>("multispecies");
 
   if (precondition) {
     inv = Laplacian::create(&options["precon_laplace"]);
@@ -328,8 +329,8 @@ void NeutralMixed::finally(const Options& state) {
   //
   //
 
-  Field3D Rnn =
-    sqrt(Tnlim / AA) / neutral_lmax; // Neutral-neutral collisions [normalised frequency]
+  Field3D Rnn = sqrt(Tnlim / AA)
+                / neutral_lmax; // Neutral-neutral collisions [normalised frequency]
   if (collisionality_override > 0.0) {
     // user has set an override for collision frequency
     Dnn = (Tn / AA) / collisionality_override;
@@ -405,7 +406,8 @@ void NeutralMixed::finally(const Options& state) {
   if (flux_limit > 0.0) {
     // Apply flux limit to diffusion,
     // using the local thermal speed and pressure gradient magnitude
-    Field3D Dmax = flux_limit * sqrt(Tnlim / AA) / (abs(Grad(logPnlim)) + 1. / neutral_lmax);
+    Field3D Dmax =
+        flux_limit * sqrt(Tnlim / AA) / (abs(Grad(logPnlim)) + 1. / neutral_lmax);
     BOUT_FOR(i, Dnn.getRegion("RGN_NOBNDRY")) {
       Dnn[i] = Dnn[i] * Dmax[i] / (Dnn[i] + Dmax[i]);
     }
@@ -505,9 +507,9 @@ void NeutralMixed::finally(const Options& state) {
                       DnnPn, logPnlim, ef_adv_perp_xlow, ef_adv_perp_ylow);
 
   // The factor here is 5/2 as we're advecting internal energy and pressure.
-  ef_adv_par_ylow  *= 5./2;
+  ef_adv_par_ylow *= 5. / 2;
   ef_adv_perp_xlow *= 5. / 2;
-  ef_adv_perp_ylow *= 5./2;
+  ef_adv_perp_ylow *= 5. / 2;
 
   if (neutral_conduction) {
     ddt(Pn) +=
@@ -521,9 +523,9 @@ void NeutralMixed::finally(const Options& state) {
                                        false) // No conduction through target boundary
         ;
     // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
-    ef_cond_perp_xlow *= 3./2;
-    ef_cond_perp_ylow *= 3./2;
-    ef_cond_par_ylow *= 3./2;
+    ef_cond_perp_xlow *= 3. / 2;
+    ef_cond_perp_ylow *= 3. / 2;
+    ef_cond_par_ylow *= 3. / 2;
   }
 
   Sp = pressure_source;
@@ -571,7 +573,7 @@ void NeutralMixed::finally(const Options& state) {
           ;
 
       ddt(NVn) += viscosity_source;
-      ddt(Pn)  += -(2. /3) * Vn * viscosity_source;
+      ddt(Pn) += -(2. / 3) * Vn * viscosity_source;
     }
     Snv = momentum_source;
     if (localstate.isSet("momentum_source")) {
@@ -616,9 +618,11 @@ void NeutralMixed::finally(const Options& state) {
 
     for (auto& i : Nn.getRegion("RGN_NOBNDRY")) {
       // Local average density.
-      // The purpose is to turn on evolution when nearby cells contain significant density.
-      const BoutReal meanNn = (1./6) * (2 * Nn[i] + Nn[i.xp()] + Nn[i.xm()] + Nn[i.yp()] + Nn[i.ym()]);
-      const BoutReal factor = exp(- density_floor / meanNn);
+      // The purpose is to turn on evolution when nearby cells contain significant
+      // density.
+      const BoutReal meanNn =
+          (1. / 6) * (2 * Nn[i] + Nn[i.xp()] + Nn[i.xm()] + Nn[i.yp()] + Nn[i.ym()]);
+      const BoutReal factor = exp(-density_floor / meanNn);
       ddt(Nn)[i] = factor * ddt(Nn)[i] + (1. - factor) * Nn_s[i];
       ddt(Pn)[i] = factor * ddt(Pn)[i] + (1. - factor) * Pn_s[i];
       ddt(NVn)[i] = factor * ddt(NVn)[i] + (1. - factor) * NVn_s[i];
@@ -675,12 +679,12 @@ void NeutralMixed::outputVars(Options& state) {
        {"source", "neutral_mixed"}});
 
   set_with_attrs(state[std::string("V") + name], Vn,
-                   {{"time_dimension", "t"},
-                    {"units", "m / s"},
-                    {"conversion", Cs0},
-                    {"standard_name", "velocity"},
-                    {"long_name", name + " parallel velocity"},
-                    {"source", "neutral_mixed"}});
+                 {{"time_dimension", "t"},
+                  {"units", "m / s"},
+                  {"conversion", Cs0},
+                  {"standard_name", "velocity"},
+                  {"long_name", name + " parallel velocity"},
+                  {"source", "neutral_mixed"}});
 
   if (output_ddt) {
     set_with_attrs(
@@ -759,56 +763,62 @@ void NeutralMixed::outputVars(Options& state) {
 
     // Particle flows due to advection
     if (pf_adv_perp_xlow.isAllocated()) {
-      set_with_attrs(state[fmt::format("pf{}_adv_perp_xlow", name)], pf_adv_perp_xlow,
-                   {{"time_dimension", "t"},
-                    {"units", "s^-1"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
-                    {"standard_name", "particle flow"},
-                    {"long_name", name + " radial component of perpendicular advection flow."},
-                    {"species", name},
-                    {"source", "neutral_mixed"}});
+      set_with_attrs(
+          state[fmt::format("pf{}_adv_perp_xlow", name)], pf_adv_perp_xlow,
+          {{"time_dimension", "t"},
+           {"units", "s^-1"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
+           {"standard_name", "particle flow"},
+           {"long_name", name + " radial component of perpendicular advection flow."},
+           {"species", name},
+           {"source", "neutral_mixed"}});
     }
     if (pf_adv_perp_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("pf{}_adv_perp_ylow", name)], pf_adv_perp_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "s^-1"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
-                    {"standard_name", "particle flow"},
-                    {"long_name", name + " poloidal component of perpendicular advection flow."},
-                    {"species", name},
-                    {"source", "evolve_density"}});
+      set_with_attrs(
+          state[fmt::format("pf{}_adv_perp_ylow", name)], pf_adv_perp_ylow,
+          {{"time_dimension", "t"},
+           {"units", "s^-1"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
+           {"standard_name", "particle flow"},
+           {"long_name", name + " poloidal component of perpendicular advection flow."},
+           {"species", name},
+           {"source", "evolve_density"}});
     }
     if (pf_adv_par_ylow.isAllocated()) {
       set_with_attrs(state[fmt::format("pf{}_adv_par_ylow", name)], pf_adv_par_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "s^-1"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
-                    {"standard_name", "particle flow"},
-                    {"long_name", name + " parallel advection flow."},
-                    {"species", name},
-                    {"source", "evolve_density"}});
+                     {{"time_dimension", "t"},
+                      {"units", "s^-1"},
+                      {"conversion", rho_s0 * SQ(rho_s0) * Nnorm * Omega_ci},
+                      {"standard_name", "particle flow"},
+                      {"long_name", name + " parallel advection flow."},
+                      {"species", name},
+                      {"source", "evolve_density"}});
     }
 
     // Momentum flows due to advection
     if (mf_adv_perp_xlow.isAllocated()) {
-      set_with_attrs(state[fmt::format("mf{}_adv_perp_xlow", name)], mf_adv_perp_xlow,
-                   {{"time_dimension", "t"},
-                    {"units", "N"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
-                    {"standard_name", "momentum flow"},
-                    {"long_name", name + " radial component of perpendicular momentum advection flow."},
-                    {"species", name},
-                    {"source", "evolve_momentum"}});
+      set_with_attrs(
+          state[fmt::format("mf{}_adv_perp_xlow", name)], mf_adv_perp_xlow,
+          {{"time_dimension", "t"},
+           {"units", "N"},
+           {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+           {"standard_name", "momentum flow"},
+           {"long_name",
+            name + " radial component of perpendicular momentum advection flow."},
+           {"species", name},
+           {"source", "evolve_momentum"}});
     }
     if (mf_adv_perp_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("mf{}_adv_perp_ylow", name)], mf_adv_perp_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "N"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
-                    {"standard_name", "momentum flow"},
-                    {"long_name", name + " poloidal component of perpendicular momentum advection flow."},
-                    {"species", name},
-                    {"source", "evolve_momentum"}});
+      set_with_attrs(
+          state[fmt::format("mf{}_adv_perp_ylow", name)], mf_adv_perp_ylow,
+          {{"time_dimension", "t"},
+           {"units", "N"},
+           {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+           {"standard_name", "momentum flow"},
+           {"long_name",
+            name + " poloidal component of perpendicular momentum advection flow."},
+           {"species", name},
+           {"source", "evolve_momentum"}});
     }
     // This one is awaiting flow implementation into Div_par_fvv
 
@@ -816,109 +826,116 @@ void NeutralMixed::outputVars(Options& state) {
     //   set_with_attrs(state[fmt::format("mf{}_adv_par_ylow", name)], mf_adv_par_ylow,
     //                {{"time_dimension", "t"},
     //                 {"units", "N"},
-    //                 {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+    //                 {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 *
+    //                 Omega_ci},
     //                 {"standard_name", "momentum flow"},
-    //                 {"long_name", name + " parallel momentum advection flow. Note: May be incomplete."},
+    //                 {"long_name", name + " parallel momentum advection flow. Note: May
+    //                 be incomplete."},
     //                 {"species", name},
     //                 {"source", "evolve_momentum"}});
     // }
 
-
     // Momentum flows due to viscosity
     if (mf_visc_perp_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("mf{}_visc_perp_ylow", name)], mf_visc_perp_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "N"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
-                    {"standard_name", "momentum flow"},
-                    {"long_name", name + " poloidal component of perpendicular viscosity."},
-                    {"species", name},
-                    {"source", "evolve_momentum"}});
+      set_with_attrs(
+          state[fmt::format("mf{}_visc_perp_ylow", name)], mf_visc_perp_ylow,
+          {{"time_dimension", "t"},
+           {"units", "N"},
+           {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+           {"standard_name", "momentum flow"},
+           {"long_name", name + " poloidal component of perpendicular viscosity."},
+           {"species", name},
+           {"source", "evolve_momentum"}});
     }
     if (mf_visc_perp_xlow.isAllocated()) {
-      set_with_attrs(state[fmt::format("mf{}_visc_perp_xlow", name)], mf_visc_perp_xlow,
-                   {{"time_dimension", "t"},
-                    {"units", "N"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
-                    {"standard_name", "momentum flow"},
-                    {"long_name", name + " radial component of perpendicular viscosity."},
-                    {"species", name},
-                    {"source", "evolve_momentum"}});
+      set_with_attrs(
+          state[fmt::format("mf{}_visc_perp_xlow", name)], mf_visc_perp_xlow,
+          {{"time_dimension", "t"},
+           {"units", "N"},
+           {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+           {"standard_name", "momentum flow"},
+           {"long_name", name + " radial component of perpendicular viscosity."},
+           {"species", name},
+           {"source", "evolve_momentum"}});
     }
     if (mf_visc_par_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("mf{}_visc_par_ylow", name)], mf_visc_par_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "N"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
-                    {"standard_name", "momentum flow"},
-                    {"long_name", name + " parallel viscosity."},
-                    {"species", name},
-                    {"source", "evolve_momentum"}});
+      set_with_attrs(
+          state[fmt::format("mf{}_visc_par_ylow", name)], mf_visc_par_ylow,
+          {{"time_dimension", "t"},
+           {"units", "N"},
+           {"conversion", rho_s0 * SQ(rho_s0) * SI::Mp * Nnorm * Cs0 * Omega_ci},
+           {"standard_name", "momentum flow"},
+           {"long_name", name + " parallel viscosity."},
+           {"species", name},
+           {"source", "evolve_momentum"}});
     }
-
 
     // Energy flows due to advection
     if (ef_adv_perp_xlow.isAllocated()) {
-      set_with_attrs(state[fmt::format("ef{}_adv_perp_xlow", name)], ef_adv_perp_xlow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " radial component of perpendicular energy advection."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+      set_with_attrs(
+          state[fmt::format("ef{}_adv_perp_xlow", name)], ef_adv_perp_xlow,
+          {{"time_dimension", "t"},
+           {"units", "W"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+           {"standard_name", "power"},
+           {"long_name", name + " radial component of perpendicular energy advection."},
+           {"species", name},
+           {"source", "evolve_pressure"}});
     }
     if (ef_adv_perp_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("ef{}_adv_perp_ylow", name)], ef_adv_perp_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " poloidal component of perpendicular energy advection."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+      set_with_attrs(
+          state[fmt::format("ef{}_adv_perp_ylow", name)], ef_adv_perp_ylow,
+          {{"time_dimension", "t"},
+           {"units", "W"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+           {"standard_name", "power"},
+           {"long_name", name + " poloidal component of perpendicular energy advection."},
+           {"species", name},
+           {"source", "evolve_pressure"}});
     }
     if (ef_adv_par_ylow.isAllocated()) {
       set_with_attrs(state[fmt::format("ef{}_adv_par_ylow", name)], ef_adv_par_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " parallel energy advection."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+                     {{"time_dimension", "t"},
+                      {"units", "W"},
+                      {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                      {"standard_name", "power"},
+                      {"long_name", name + " parallel energy advection."},
+                      {"species", name},
+                      {"source", "evolve_pressure"}});
     }
 
     // Energy flows due to conduction
     if (ef_cond_perp_xlow.isAllocated()) {
-      set_with_attrs(state[fmt::format("ef{}_cond_perp_xlow", name)], ef_cond_perp_xlow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " radial component of perpendicular conduction."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+      set_with_attrs(
+          state[fmt::format("ef{}_cond_perp_xlow", name)], ef_cond_perp_xlow,
+          {{"time_dimension", "t"},
+           {"units", "W"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+           {"standard_name", "power"},
+           {"long_name", name + " radial component of perpendicular conduction."},
+           {"species", name},
+           {"source", "evolve_pressure"}});
     }
     if (ef_cond_perp_ylow.isAllocated()) {
-      set_with_attrs(state[fmt::format("ef{}_cond_perp_ylow", name)], ef_cond_perp_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " poloidal component of perpendicular conduction."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+      set_with_attrs(
+          state[fmt::format("ef{}_cond_perp_ylow", name)], ef_cond_perp_ylow,
+          {{"time_dimension", "t"},
+           {"units", "W"},
+           {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+           {"standard_name", "power"},
+           {"long_name", name + " poloidal component of perpendicular conduction."},
+           {"species", name},
+           {"source", "evolve_pressure"}});
     }
     if (ef_cond_par_ylow.isAllocated()) {
       set_with_attrs(state[fmt::format("ef{}_cond_par_ylow", name)], ef_cond_par_ylow,
-                   {{"time_dimension", "t"},
-                    {"units", "W"},
-                    {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
-                    {"standard_name", "power"},
-                    {"long_name", name + " parallel conduction."},
-                    {"species", name},
-                    {"source", "evolve_pressure"}});
+                     {{"time_dimension", "t"},
+                      {"units", "W"},
+                      {"conversion", rho_s0 * SQ(rho_s0) * Pnorm * Omega_ci},
+                      {"standard_name", "power"},
+                      {"long_name", name + " parallel conduction."},
+                      {"species", name},
+                      {"source", "evolve_pressure"}});
     }
   }
 }
@@ -936,8 +953,7 @@ void NeutralMixed::precon([[maybe_unused]] const Options& state, BoutReal gamma)
   mesh->communicate(DTdtN);
   DTdtN.applyBoundary("dirichlet");
 
-  ddt(Pn) -= (gamma * 5./3) * FV::Div_a_Grad_perp(DTdtN,
-                                                  logPnlim);
+  ddt(Pn) -= (gamma * 5. / 3) * FV::Div_a_Grad_perp(DTdtN, logPnlim);
 
   // Second matrix: Invert Pshur
   //   (E^-1   0  )
@@ -945,12 +961,12 @@ void NeutralMixed::precon([[maybe_unused]] const Options& state, BoutReal gamma)
   //
   // d Laplace_perp(x) + a x + (1/c1)Grad(c2) dot Grad_perp(x) = b
   inv->setCoefA(1 - gamma * FV::Div_a_Grad_perp(Dnn, logPnlim));
-  inv->setCoefC1(-1. / ((gamma * 5./3) * Dnn));
+  inv->setCoefC1(-1. / ((gamma * 5. / 3) * Dnn));
   inv->setCoefC2(logPnlim);
-  inv->setCoefD((-gamma * 5./3) * Dnn);
+  inv->setCoefD((-gamma * 5. / 3) * Dnn);
 
-  //inv->setInnerBoundaryFlags(INVERT_DC_GRAD);
-  //inv->setOuterBoundaryFlags(INVERT_DC_GRAD);
+  // inv->setInnerBoundaryFlags(INVERT_DC_GRAD);
+  // inv->setOuterBoundaryFlags(INVERT_DC_GRAD);
 
   ddt(Pn) = inv->solve(ddt(Pn));
   mesh->communicate(ddt(Pn));

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -30,10 +30,11 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*)
 
   // Neutral pump
   // Mark cells as having a pump by setting the Field2D is_pump to 1 in the grid file
-  // Works only on SOL and PFR edges, where it locally modifies the recycle multiplier to the pump albedo
+  // Works only on SOL and PFR edges, where it locally modifies the recycle multiplier to
+  // the pump albedo
   is_pump = 0.0;
   mesh->get(is_pump, std::string("is_pump"));
-      
+
   for (const auto& species : species_list) {
     std::string from = trim(species, " \t\r()"); // The species name in the list
 
@@ -49,16 +50,18 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*)
     from_species.insert(from);
     to_species.insert(to);
 
-    density_floor = options["density_floor"].doc("Minimum density floor").withDefault(1e-7);
-    pressure_floor = density_floor * (1./get<BoutReal>(alloptions["units"]["eV"]));
+    density_floor =
+        options["density_floor"].doc("Minimum density floor").withDefault(1e-7);
+    pressure_floor = density_floor * (1. / get<BoutReal>(alloptions["units"]["eV"]));
 
-    diagnose =
-      from_options["diagnose"].doc("Save additional diagnostics?").withDefault<bool>(false);
+    diagnose = from_options["diagnose"]
+                   .doc("Save additional diagnostics?")
+                   .withDefault<bool>(false);
 
-    BoutReal target_recycle_multiplier =
-        from_options["target_recycle_multiplier"]
-            .doc("Multiply the target recycled flux by this factor. Should be >=0 and <= 1")
-            .withDefault<BoutReal>(1.0);
+    BoutReal target_recycle_multiplier = from_options["target_recycle_multiplier"]
+                                             .doc("Multiply the target recycled flux by "
+                                                  "this factor. Should be >=0 and <= 1")
+                                             .withDefault<BoutReal>(1.0);
 
     BoutReal sol_recycle_multiplier =
         from_options["sol_recycle_multiplier"]
@@ -71,24 +74,28 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*)
             .withDefault<BoutReal>(1.0);
 
     BoutReal pump_recycle_multiplier =
-      from_options["pump_recycle_multiplier"]
-          .doc("Multiply the pump boundary recycling flux by this factor (like albedo). Should be >=0 and <= 1")
-          .withDefault<BoutReal>(1.0);
+        from_options["pump_recycle_multiplier"]
+            .doc("Multiply the pump boundary recycling flux by this factor (like "
+                 "albedo). Should be >=0 and <= 1")
+            .withDefault<BoutReal>(1.0);
 
-    BoutReal target_recycle_energy = from_options["target_recycle_energy"]
-                                  .doc("Fixed energy of the recycled particles at target [eV]")
-                                  .withDefault<BoutReal>(3.0)
-                              / Tnorm; // Normalise from eV
+    BoutReal target_recycle_energy =
+        from_options["target_recycle_energy"]
+            .doc("Fixed energy of the recycled particles at target [eV]")
+            .withDefault<BoutReal>(3.0)
+        / Tnorm; // Normalise from eV
 
-    BoutReal sol_recycle_energy = from_options["sol_recycle_energy"]
-                                  .doc("Fixed energy of the recycled particles at sol [eV]")
-                                  .withDefault<BoutReal>(3.0)
-                              / Tnorm; // Normalise from eV
+    BoutReal sol_recycle_energy =
+        from_options["sol_recycle_energy"]
+            .doc("Fixed energy of the recycled particles at sol [eV]")
+            .withDefault<BoutReal>(3.0)
+        / Tnorm; // Normalise from eV
 
-    BoutReal pfr_recycle_energy = from_options["pfr_recycle_energy"]
-                                  .doc("Fixed energy of the recycled particles at pfr [eV]")
-                                  .withDefault<BoutReal>(3.0)
-                              / Tnorm; // Normalise from eV
+    BoutReal pfr_recycle_energy =
+        from_options["pfr_recycle_energy"]
+            .doc("Fixed energy of the recycled particles at pfr [eV]")
+            .withDefault<BoutReal>(3.0)
+        / Tnorm; // Normalise from eV
 
     BoutReal target_fast_recycle_fraction =
         from_options["target_fast_recycle_fraction"]
@@ -121,38 +128,38 @@ Recycling::Recycling(std::string name, Options& alloptions, Solver*)
             .withDefault<BoutReal>(0);
 
     if ((target_recycle_multiplier < 0.0) or (target_recycle_multiplier > 1.0)
-    or (sol_recycle_multiplier < 0.0) or (sol_recycle_multiplier > 1.0)
-    or (pfr_recycle_multiplier < 0.0) or (pfr_recycle_multiplier > 1.0)
-    or (pump_recycle_multiplier < 0.0) or (pump_recycle_multiplier > 1.0)) {
+        or (sol_recycle_multiplier < 0.0) or (sol_recycle_multiplier > 1.0)
+        or (pfr_recycle_multiplier < 0.0) or (pfr_recycle_multiplier > 1.0)
+        or (pump_recycle_multiplier < 0.0) or (pump_recycle_multiplier > 1.0)) {
       throw BoutException("All recycle multipliers must be betweeen 0 and 1");
     }
 
     // Populate recycling channel vector
-    channels.push_back({
-      from, to, 
-      target_recycle_multiplier, sol_recycle_multiplier, pfr_recycle_multiplier, pump_recycle_multiplier,
-      target_recycle_energy, sol_recycle_energy, pfr_recycle_energy,
-      target_fast_recycle_fraction, pfr_fast_recycle_fraction, sol_fast_recycle_fraction,
-      target_fast_recycle_energy_factor, sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor});
+    channels.push_back({from, to, target_recycle_multiplier, sol_recycle_multiplier,
+                        pfr_recycle_multiplier, pump_recycle_multiplier,
+                        target_recycle_energy, sol_recycle_energy, pfr_recycle_energy,
+                        target_fast_recycle_fraction, pfr_fast_recycle_fraction,
+                        sol_fast_recycle_fraction, target_fast_recycle_energy_factor,
+                        sol_fast_recycle_energy_factor, pfr_fast_recycle_energy_factor});
     // FIXME: These are global settings, but are being overwritten by each particular
     // recycling channel
 
     // Boolean flags for enabling recycling in different regions
     target_recycle = from_options["target_recycle"]
-                   .doc("Recycling in the targets?")
-                   .withDefault<bool>(false);
+                         .doc("Recycling in the targets?")
+                         .withDefault<bool>(false);
 
     sol_recycle = from_options["sol_recycle"]
-                   .doc("Recycling in the SOL edge?")
-                   .withDefault<bool>(false);
+                      .doc("Recycling in the SOL edge?")
+                      .withDefault<bool>(false);
 
     pfr_recycle = from_options["pfr_recycle"]
-                   .doc("Recycling in the PFR edge?")
-                   .withDefault<bool>(false);
+                      .doc("Recycling in the PFR edge?")
+                      .withDefault<bool>(false);
 
     neutral_pump = from_options["neutral_pump"]
-                   .doc("Neutral pump enabled? Note, need location in grid file")
-                   .withDefault<bool>(false);                 
+                       .doc("Neutral pump enabled? Note, need location in grid file")
+                       .withDefault<bool>(false);
   }
 
   if (target_recycle) {
@@ -185,7 +192,7 @@ void Recycling::transform_impl(GuardedOptions& state) {
     const GuardedOptions species_from = state["species"][channel.from];
 
     const Field3D N = get<Field3D>(species_from["density"]);
-    const Field3D V = get<Field3D>(species_from["velocity"]); // Parallel flow velocity
+    const Field3D V = get<Field3D>(species_from["velocity"]);    // Parallel flow velocity
     const Field3D T = get<Field3D>(species_from["temperature"]); // Ion temperature
 
     GuardedOptions species_to = state["species"][channel.to];
@@ -198,25 +205,28 @@ void Recycling::transform_impl(GuardedOptions& state) {
     const Field3D Pnlim = floor(Pn, pressure_floor);
     const Field3D Tnlim = Pnlim / Nnlim;
 
-    // Recycling particle and energy sources will be added to these global sources 
+    // Recycling particle and energy sources will be added to these global sources
     // which are then passed to the density and pressure equations
     density_source = species_to.isSet("density_source")
-                                 ? getNonFinal<Field3D>(species_to["density_source"])
-                                 : 0.0;
+                         ? getNonFinal<Field3D>(species_to["density_source"])
+                         : 0.0;
     energy_source = species_to.isSet("energy_source")
-                                ? getNonFinal<Field3D>(species_to["energy_source"])
-                                : 0.0;
+                        ? getNonFinal<Field3D>(species_to["energy_source"])
+                        : 0.0;
 
     // Recycling at the divertor target plates
     if (target_recycle) {
 
-      // Fast recycling needs to know how much energy the "from" species is losing to the boundary
+      // Fast recycling needs to know how much energy the "from" species is losing to the
+      // boundary
       if (species_from.isSet("energy_flow_ylow")) {
         energy_flow_ylow = get<Field3D>(species_from["energy_flow_ylow"]);
       } else {
         energy_flow_ylow = 0;
         if (channel.target_fast_recycle_fraction > 0) {
-          throw BoutException("Target fast recycle enabled but no sheath heat flow available in energy_flow_ylow! \nCurrently only sheath_boundary_simple is supported for fast recycling.");
+          throw BoutException("Target fast recycle enabled but no sheath heat flow "
+                              "available in energy_flow_ylow! \nCurrently only "
+                              "sheath_boundary_simple is supported for fast recycling.");
         }
       }
 
@@ -238,26 +248,36 @@ void Recycling::transform_impl(GuardedOptions& state) {
           // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
               channel.target_multiplier * flux
-              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1)) / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)))
-              * 0.5*(dx(r.ind, mesh->ystart) + dx(r.ind, mesh->ystart - 1)) * 0.5*(dz(r.ind, mesh->ystart) + dz(r.ind, mesh->ystart - 1));  
+              * (J(r.ind, mesh->ystart) + J(r.ind, mesh->ystart - 1))
+              / (sqrt(g_22(r.ind, mesh->ystart)) + sqrt(g_22(r.ind, mesh->ystart - 1)))
+              * 0.5 * (dx(r.ind, mesh->ystart) + dx(r.ind, mesh->ystart - 1)) * 0.5
+              * (dz(r.ind, mesh->ystart) + dz(r.ind, mesh->ystart - 1));
 
-          BoutReal volume  = J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart) * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart);
+          BoutReal volume = J(r.ind, mesh->ystart) * dx(r.ind, mesh->ystart)
+                            * dy(r.ind, mesh->ystart) * dz(r.ind, mesh->ystart);
 
           // Calculate sources in the final cell [m^-3 s^-1]
-          channel.target_recycle_density_source(r.ind, mesh->ystart, jz) += flow / volume;    // For diagnostic
-          density_source(r.ind, mesh->ystart, jz) += flow / volume;         // For use in solver
+          channel.target_recycle_density_source(r.ind, mesh->ystart, jz) +=
+              flow / volume;                                        // For diagnostic
+          density_source(r.ind, mesh->ystart, jz) += flow / volume; // For use in solver
 
           // Energy of recycled particles
-          BoutReal ion_energy_flow = energy_flow_ylow(r.ind, mesh->ystart, jz) * -1;   // This is ylow end so take first domain cell and flip sign
+          BoutReal ion_energy_flow =
+              energy_flow_ylow(r.ind, mesh->ystart, jz)
+              * -1; // This is ylow end so take first domain cell and flip sign
 
-          // Blend fast (ion energy) and thermal (constant energy) recycling 
+          // Blend fast (ion energy) and thermal (constant energy) recycling
           // Calculate returning neutral heat flow in [W]
-          BoutReal recycle_energy_flow = 
-            ion_energy_flow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
-            + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
+          BoutReal recycle_energy_flow =
+              ion_energy_flow * channel.target_multiplier
+                  * channel.target_fast_recycle_energy_factor
+                  * channel.target_fast_recycle_fraction // Fast recycling part
+              + flow * (1 - channel.target_fast_recycle_fraction)
+                    * channel.target_energy; // Thermal recycling part
 
           // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
-          channel.target_recycle_energy_source(r.ind, mesh->ystart, jz) += recycle_energy_flow / volume;
+          channel.target_recycle_energy_source(r.ind, mesh->ystart, jz) +=
+              recycle_energy_flow / volume;
           energy_source(r.ind, mesh->ystart, jz) += recycle_energy_flow / volume;
         }
       }
@@ -271,34 +291,44 @@ void Recycling::transform_impl(GuardedOptions& state) {
         for (int jz = 0; jz < mesh->LocalNz; jz++) {
           // Flux through surface [normalised m^-2 s^-1], should be positive
           BoutReal flux = 0.5 * (N(r.ind, mesh->yend, jz) + N(r.ind, mesh->yend + 1, jz))
-                          * 0.5 * (V(r.ind, mesh->yend, jz) + V(r.ind, mesh->yend + 1, jz));
+                          * 0.5
+                          * (V(r.ind, mesh->yend, jz) + V(r.ind, mesh->yend + 1, jz));
 
           flux = std::max(flux, 0.0);
 
           // Flow of recycled neutrals into domain [s-1]
           BoutReal flow =
-              channel.target_multiplier * flux 
-              * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1)) / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1)))
-              * 0.5*(dx(r.ind, mesh->yend) + dx(r.ind, mesh->yend + 1)) * 0.5*(dz(r.ind, mesh->yend) + dz(r.ind, mesh->yend + 1)); 
+              channel.target_multiplier * flux
+              * (J(r.ind, mesh->yend) + J(r.ind, mesh->yend + 1))
+              / (sqrt(g_22(r.ind, mesh->yend)) + sqrt(g_22(r.ind, mesh->yend + 1))) * 0.5
+              * (dx(r.ind, mesh->yend) + dx(r.ind, mesh->yend + 1)) * 0.5
+              * (dz(r.ind, mesh->yend) + dz(r.ind, mesh->yend + 1));
 
-          BoutReal volume  = J(r.ind, mesh->yend) * dx(r.ind, mesh->yend) * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend);
+          BoutReal volume = J(r.ind, mesh->yend) * dx(r.ind, mesh->yend)
+                            * dy(r.ind, mesh->yend) * dz(r.ind, mesh->yend);
 
           // Calculate sources in the final cell [m^-3 s^-1]
-          channel.target_recycle_density_source(r.ind, mesh->yend, jz) += flow / volume;    // For diagnostic
-          density_source(r.ind, mesh->yend, jz) += flow / volume;         // For use in solver
+          channel.target_recycle_density_source(r.ind, mesh->yend, jz) +=
+              flow / volume;                                      // For diagnostic
+          density_source(r.ind, mesh->yend, jz) += flow / volume; // For use in solver
 
           // Energy of recycled particles
-          BoutReal ion_energy_flow = energy_flow_ylow(r.ind, mesh->yend + 1, jz);   // Ion heat flow to wall in [W]. This is yup end so take guard cell
+          BoutReal ion_energy_flow = energy_flow_ylow(
+              r.ind, mesh->yend + 1,
+              jz); // Ion heat flow to wall in [W]. This is yup end so take guard cell
 
-          // Blend fast (ion energy) and thermal (constant energy) recycling 
+          // Blend fast (ion energy) and thermal (constant energy) recycling
           // Calculate returning neutral heat flow in [W]
-          BoutReal recycle_energy_flow = 
-            ion_energy_flow * channel.target_multiplier * channel.target_fast_recycle_energy_factor * channel.target_fast_recycle_fraction   // Fast recycling part
-            + flow * (1 - channel.target_fast_recycle_fraction) * channel.target_energy;   // Thermal recycling part
-
+          BoutReal recycle_energy_flow =
+              ion_energy_flow * channel.target_multiplier
+                  * channel.target_fast_recycle_energy_factor
+                  * channel.target_fast_recycle_fraction // Fast recycling part
+              + flow * (1 - channel.target_fast_recycle_fraction)
+                    * channel.target_energy; // Thermal recycling part
 
           // Divide heat flow in [W] by cell volume to get source in [m^-3 s^-1]
-          channel.target_recycle_energy_source(r.ind, mesh->yend, jz) += recycle_energy_flow / volume;
+          channel.target_recycle_energy_source(r.ind, mesh->yend, jz) +=
+              recycle_energy_flow / volume;
           energy_source(r.ind, mesh->yend, jz) += recycle_energy_flow / volume;
         }
       }
@@ -315,14 +345,18 @@ void Recycling::transform_impl(GuardedOptions& state) {
 
       if (species_from.isSet("energy_flow_xlow")) {
         energy_flow_xlow = get<Field3D>(species_from["energy_flow_xlow"]);
-      } else if ((channel.sol_fast_recycle_fraction > 0) or (channel.pfr_fast_recycle_fraction > 0)) {
-        throw BoutException("SOL/PFR fast recycle enabled but no cell edge heat flow available, check your wall BC choice");
+      } else if ((channel.sol_fast_recycle_fraction > 0)
+                 or (channel.pfr_fast_recycle_fraction > 0)) {
+        throw BoutException("SOL/PFR fast recycle enabled but no cell edge heat flow "
+                            "available, check your wall BC choice");
       };
 
       if (species_from.isSet("particle_flow_xlow")) {
         particle_flow_xlow = get<Field3D>(species_from["particle_flow_xlow"]);
-      } else if ((channel.sol_fast_recycle_fraction > 0) or (channel.pfr_fast_recycle_fraction > 0)) {
-        throw BoutException("SOL/PFR fast recycle enabled but no cell edge particle flow available, check your wall BC choice");
+      } else if ((channel.sol_fast_recycle_fraction > 0)
+                 or (channel.pfr_fast_recycle_fraction > 0)) {
+        throw BoutException("SOL/PFR fast recycle enabled but no cell edge particle flow "
+                            "available, check your wall BC choice");
       };
     }
 
@@ -333,13 +367,13 @@ void Recycling::transform_impl(GuardedOptions& state) {
       Field3D radial_particle_outflow = particle_flow_xlow;
       Field3D radial_energy_outflow = energy_flow_xlow;
 
-      if (mesh->lastX()) {  // Only do this for the processor which has the edge region
-        for (int iy=0; iy < mesh->LocalNy ; iy++) {
-          for (int iz=0; iz < mesh->LocalNz; iz++) {
+      if (mesh->lastX()) { // Only do this for the processor which has the edge region
+        for (int iy = 0; iy < mesh->LocalNy; iy++) {
+          for (int iz = 0; iz < mesh->LocalNz; iz++) {
 
             // Volume of cell adjacent to wall which will receive source
-            BoutReal volume = J(mesh->xend, iy) * dx(mesh->xend, iy)
-                 * dy(mesh->xend, iy) * dz(mesh->xend, iy);
+            BoutReal volume = J(mesh->xend, iy) * dx(mesh->xend, iy) * dy(mesh->xend, iy)
+                              * dz(mesh->xend, iy);
 
             // If cell is a pump, overwrite multiplier with pump multiplier
             BoutReal multiplier = channel.sol_multiplier;
@@ -349,19 +383,26 @@ void Recycling::transform_impl(GuardedOptions& state) {
 
             // Flow of recycled species back from the edge due to recycling
             // SOL edge = LHS flow of inner guard cells on the high X side (mesh->xend+1)
-            // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
+            // Recycling source is 0 for each cell where the flow goes into instead of out
+            // of the domain
             BoutReal recycle_particle_flow = 0;
-            if (radial_particle_outflow(mesh->xend+1, iy, iz) > 0) {
-              recycle_particle_flow = multiplier * radial_particle_outflow(mesh->xend+1, iy, iz); 
-            } 
+            if (radial_particle_outflow(mesh->xend + 1, iy, iz) > 0) {
+              recycle_particle_flow =
+                  multiplier * radial_particle_outflow(mesh->xend + 1, iy, iz);
+            }
 
-            BoutReal ion_energy_flow = radial_energy_outflow(mesh->xend+1, iy, iz);   // Ion heat flow to wall in [W]. This is on xlow edge so take guard cell
+            BoutReal ion_energy_flow = radial_energy_outflow(
+                mesh->xend + 1, iy, iz); // Ion heat flow to wall in [W]. This is on xlow
+                                         // edge so take guard cell
 
-            // Blend fast (ion energy) and thermal (constant energy) recycling 
+            // Blend fast (ion energy) and thermal (constant energy) recycling
             // Calculate returning neutral heat flow in [W]
-            BoutReal recycle_energy_flow = 
-              ion_energy_flow * channel.sol_multiplier * channel.sol_fast_recycle_energy_factor * channel.sol_fast_recycle_fraction   // Fast recycling part
-              + recycle_particle_flow * (1 - channel.sol_fast_recycle_fraction) * channel.sol_energy;   // Thermal recycling part
+            BoutReal recycle_energy_flow =
+                ion_energy_flow * channel.sol_multiplier
+                    * channel.sol_fast_recycle_energy_factor
+                    * channel.sol_fast_recycle_fraction // Fast recycling part
+                + recycle_particle_flow * (1 - channel.sol_fast_recycle_fraction)
+                      * channel.sol_energy; // Thermal recycling part
 
             // Calculate neutral pump neutral sinks due to neutral impingement
             BoutReal pump_neutral_particle_sink = 0.0;
@@ -370,54 +411,71 @@ void Recycling::transform_impl(GuardedOptions& state) {
             // These are additional to particle sinks due to recycling
             if ((is_pump(mesh->xend, iy) == 1.0) and (neutral_pump)) {
 
-              auto i = indexAt(Nn, mesh->xend, iy, iz);   // Final domain cell
-              auto is = i.xm();   // Second to final domain cell
-              auto ig = i.xp();   // First guard cell
+              auto i = indexAt(Nn, mesh->xend, iy, iz); // Final domain cell
+              auto is = i.xm();                         // Second to final domain cell
+              auto ig = i.xp();                         // First guard cell
 
               // Free boundary condition on Nn, Pn, Tn
-              // These are NOT communicated back into state and will exist only in this component
-              // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
-              // While enabling us to still calculate radial wall fluxes separately here
+              // These are NOT communicated back into state and will exist only in this
+              // component This will prevent neutrals leaking through cross-field
+              // transport from neutral_mixed or other components While enabling us to
+              // still calculate radial wall fluxes separately here
               BoutReal nnguard = SQ(Nn[i]) / Nnlim[is];
               BoutReal tnguard = SQ(Tn[i]) / Tnlim[is];
 
               // Calculate wall conditions
               BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
               BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
-              BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
+              BoutReal v_th =
+                  0.25
+                  * sqrt(8 * tnsheath / (PI * AAn)); // Stangeby p.69 eqns. 2.21, 2.24
 
               // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
               // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
               // Calculate radial wall area in [m^2]
               // Calculate final cell volume [m^3]
-              BoutReal dpolsheath = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
-              BoutReal dtorsheath = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
-              BoutReal dasheath = dpolsheath * dtorsheath;  // [m^2]
+              BoutReal dpolsheath =
+                  0.5 * (coord->dy[i] + coord->dy[ig]) * 1
+                  / (0.5 * (sqrt(coord->g22[i]) + sqrt(coord->g22[ig])));
+              BoutReal dtorsheath = 0.5 * (coord->dz[i] + coord->dz[ig]) * 0.5
+                                    * (sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+              BoutReal dasheath = dpolsheath * dtorsheath; // [m^2]
               BoutReal dv = coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i];
 
               // Calculate particle and energy fluxes of neutrals hitting the pump
-              // Assume thermal velocity greater than perpendicular velocity and use it for flux calc
-              BoutReal pump_neutral_particle_flow = v_th * nnsheath * dasheath;   // [s^-1]
-              pump_neutral_particle_sink = pump_neutral_particle_flow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
+              // Assume thermal velocity greater than perpendicular velocity and use it
+              // for flux calc
+              BoutReal pump_neutral_particle_flow = v_th * nnsheath * dasheath; // [s^-1]
+              pump_neutral_particle_sink =
+                  pump_neutral_particle_flow / dv
+                  * (1 - multiplier); // Particle sink [s^-1 m^-3]
 
               // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
-              BoutReal pump_neutral_energy_flow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
-              pump_neutral_energy_sink = pump_neutral_energy_flow / dv * (1 - multiplier);   // heatsink [W m^-3]
+              BoutReal pump_neutral_energy_flow =
+                  2.0 * tnsheath * v_th * nnsheath * dasheath; // [W]
+              pump_neutral_energy_sink =
+                  pump_neutral_energy_flow / dv * (1 - multiplier); // heatsink [W m^-3]
 
               // Divide flows by volume to get sources
               // Save to pump diagnostic
-              channel.pump_density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
-              channel.pump_energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;
+              channel.pump_density_source(mesh->xend, iy, iz) +=
+                  recycle_particle_flow / volume - pump_neutral_particle_sink;
+              channel.pump_energy_source(mesh->xend, iy, iz) +=
+                  recycle_energy_flow / volume - pump_neutral_energy_sink;
 
             } else {
               // Save to wall diagnostic (pump sinks are 0 if not on pump)
-              channel.wall_recycle_density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume ;
-              channel.wall_recycle_energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume;
+              channel.wall_recycle_density_source(mesh->xend, iy, iz) +=
+                  recycle_particle_flow / volume;
+              channel.wall_recycle_energy_source(mesh->xend, iy, iz) +=
+                  recycle_energy_flow / volume;
             }
 
             // Save to solver
-            density_source(mesh->xend, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
-            energy_source(mesh->xend, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink; 
+            density_source(mesh->xend, iy, iz) +=
+                recycle_particle_flow / volume - pump_neutral_particle_sink;
+            energy_source(mesh->xend, iy, iz) +=
+                recycle_energy_flow / volume - pump_neutral_energy_sink;
           }
         }
       }
@@ -426,18 +484,20 @@ void Recycling::transform_impl(GuardedOptions& state) {
     // Recycling at the PFR edge (2D/3D only)
     if (pfr_recycle) {
 
-      // PFR is flipped compared to edge: x=0 is at the PFR edge. Therefore outflow is in the negative coordinate direction.
+      // PFR is flipped compared to edge: x=0 is at the PFR edge. Therefore outflow is in
+      // the negative coordinate direction.
       Field3D radial_particle_outflow = particle_flow_xlow * -1;
       Field3D radial_energy_outflow = energy_flow_xlow * -1;
 
-      if(mesh->firstX()){   // Only do this for the processor which has the core region
-        if (!mesh->periodicY(mesh->xstart)) {   // Only do this for the processor with a periodic Y, i.e. the PFR
-          for(int iy=0; iy < mesh->LocalNy ; iy++){
-            for(int iz=0; iz < mesh->LocalNz; iz++){
-            
+      if (mesh->firstX()) { // Only do this for the processor which has the core region
+        if (!mesh->periodicY(mesh->xstart)) { // Only do this for the processor with a
+                                              // periodic Y, i.e. the PFR
+          for (int iy = 0; iy < mesh->LocalNy; iy++) {
+            for (int iz = 0; iz < mesh->LocalNz; iz++) {
+
               // Volume of cell adjacent to wall which will receive source
               BoutReal volume = J(mesh->xstart, iy) * dx(mesh->xstart, iy)
-                  * dy(mesh->xstart, iy) * dz(mesh->xstart, iy);
+                                * dy(mesh->xstart, iy) * dz(mesh->xstart, iy);
 
               // If cell is a pump, overwrite multiplier with pump multiplier
               BoutReal multiplier = channel.pfr_multiplier;
@@ -446,20 +506,27 @@ void Recycling::transform_impl(GuardedOptions& state) {
               }
 
               // Flow of recycled species back from the edge due to recycling
-              // PFR edge = LHS flow of the first domain cell on the low X side (mesh->xstart)
-              // Recycling source is 0 for each cell where the flow goes into instead of out of the domain
+              // PFR edge = LHS flow of the first domain cell on the low X side
+              // (mesh->xstart) Recycling source is 0 for each cell where the flow goes
+              // into instead of out of the domain
               BoutReal recycle_particle_flow = 0;
-              if (radial_particle_outflow(mesh->xstart, iy, iz) > 0) { 
-                recycle_particle_flow = multiplier * radial_particle_outflow(mesh->xstart, iy, iz); 
+              if (radial_particle_outflow(mesh->xstart, iy, iz) > 0) {
+                recycle_particle_flow =
+                    multiplier * radial_particle_outflow(mesh->xstart, iy, iz);
               }
 
-              BoutReal ion_energy_flow = radial_energy_outflow(mesh->xstart, iy, iz);   // Ion heat flow to wall in [W]. This is on xlow edge so take first domain cell
+              BoutReal ion_energy_flow = radial_energy_outflow(
+                  mesh->xstart, iy, iz); // Ion heat flow to wall in [W]. This is on xlow
+                                         // edge so take first domain cell
 
-              // Blend fast (ion energy) and thermal (constant energy) recycling 
+              // Blend fast (ion energy) and thermal (constant energy) recycling
               // Calculate returning neutral heat flow in [W]
-              BoutReal recycle_energy_flow = 
-                ion_energy_flow * channel.pfr_multiplier * channel.pfr_fast_recycle_energy_factor * channel.pfr_fast_recycle_fraction   // Fast recycling part
-                + recycle_particle_flow * (1 - channel.pfr_fast_recycle_fraction) * channel.pfr_energy;   // Thermal recycling part
+              BoutReal recycle_energy_flow =
+                  ion_energy_flow * channel.pfr_multiplier
+                      * channel.pfr_fast_recycle_energy_factor
+                      * channel.pfr_fast_recycle_fraction // Fast recycling part
+                  + recycle_particle_flow * (1 - channel.pfr_fast_recycle_fraction)
+                        * channel.pfr_energy; // Thermal recycling part
 
               // Calculate neutral pump neutral sinks due to neutral impingement
               // These are additional to particle sinks due to recycling
@@ -467,57 +534,74 @@ void Recycling::transform_impl(GuardedOptions& state) {
               BoutReal pump_neutral_energy_sink = 0.0;
 
               // Add to appropriate diagnostic field depending if pump or not
-              if ((is_pump(mesh->xstart, iy) == 1.0) and (neutral_pump))  {
+              if ((is_pump(mesh->xstart, iy) == 1.0) and (neutral_pump)) {
 
-                auto i = indexAt(Nn, mesh->xstart, iy, iz);   // Final domain cell
-                auto is = i.xp();   // Second to final domain cell
-                auto ig = i.xm();   // First guard cell
+                auto i = indexAt(Nn, mesh->xstart, iy, iz); // Final domain cell
+                auto is = i.xp();                           // Second to final domain cell
+                auto ig = i.xm();                           // First guard cell
 
                 // Free boundary condition on Nn, Pn, Tn
-                // These are NOT communicated back into state and will exist only in this component
-                // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
-                // While enabling us to still calculate radial wall fluxes separately here
+                // These are NOT communicated back into state and will exist only in this
+                // component This will prevent neutrals leaking through cross-field
+                // transport from neutral_mixed or other components While enabling us to
+                // still calculate radial wall fluxes separately here
                 BoutReal nnguard = SQ(Nn[i]) / Nnlim[is];
                 BoutReal tnguard = SQ(Tn[i]) / Tnlim[is];
 
                 // Calculate wall conditions
                 BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
                 BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
-                BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
+                BoutReal v_th =
+                    0.25
+                    * sqrt(8 * tnsheath / (PI * AAn)); // Stangeby p.69 eqns. 2.21, 2.24
 
                 // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
                 // Convert dz to toroidal length:  = dz*sqrt(g_33) = dz * R = 2piR
                 // Calculate radial wall area in [m^2]
                 // Calculate final cell volume [m^3]
-                BoutReal dpolsheath = 0.5*(coord->dy[i] + coord->dy[ig]) *  1/( 0.5*(sqrt(coord->g22[i]) + sqrt(coord->g22[ig])) );
-                BoutReal dtorsheath = 0.5*(coord->dz[i] + coord->dz[ig]) * 0.5*(sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
-                BoutReal dasheath = dpolsheath * dtorsheath;  // [m^2]
+                BoutReal dpolsheath =
+                    0.5 * (coord->dy[i] + coord->dy[ig]) * 1
+                    / (0.5 * (sqrt(coord->g22[i]) + sqrt(coord->g22[ig])));
+                BoutReal dtorsheath = 0.5 * (coord->dz[i] + coord->dz[ig]) * 0.5
+                                      * (sqrt(coord->g_33[i]) + sqrt(coord->g_33[ig]));
+                BoutReal dasheath = dpolsheath * dtorsheath; // [m^2]
                 BoutReal dv = coord->J[i] * coord->dx[i] * coord->dy[i] * coord->dz[i];
 
                 // Calculate particle and energy fluxes of neutrals hitting the pump
-                // Assume thermal velocity greater than perpendicular velocity and use it for flux calc
-                BoutReal pump_neutral_particle_flow = v_th * nnsheath * dasheath;   // [s^-1]
-                pump_neutral_particle_sink = pump_neutral_particle_flow / dv * (1 - multiplier);   // Particle sink [s^-1 m^-3]
+                // Assume thermal velocity greater than perpendicular velocity and use it
+                // for flux calc
+                BoutReal pump_neutral_particle_flow =
+                    v_th * nnsheath * dasheath; // [s^-1]
+                pump_neutral_particle_sink =
+                    pump_neutral_particle_flow / dv
+                    * (1 - multiplier); // Particle sink [s^-1 m^-3]
 
                 // Use gamma=2.0 as per Stangeby p.69, total energy of static Maxwellian
-                BoutReal pump_neutral_energy_flow = 2.0 * tnsheath * v_th * nnsheath * dasheath;   // [W]
-                pump_neutral_energy_sink = pump_neutral_energy_flow / dv * (1 - multiplier);   // heatsink [W m^-3]
+                BoutReal pump_neutral_energy_flow =
+                    2.0 * tnsheath * v_th * nnsheath * dasheath; // [W]
+                pump_neutral_energy_sink =
+                    pump_neutral_energy_flow / dv * (1 - multiplier); // heatsink [W m^-3]
 
                 // Divide flows by volume to get sources
                 // Save to pump diagnostic
-                channel.pump_density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
-                channel.pump_energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;
+                channel.pump_density_source(mesh->xstart, iy, iz) +=
+                    recycle_particle_flow / volume - pump_neutral_particle_sink;
+                channel.pump_energy_source(mesh->xstart, iy, iz) +=
+                    recycle_energy_flow / volume - pump_neutral_energy_sink;
 
               } else {
                 // Save to wall diagnostic (pump sinks are 0 if not on pump)
-                channel.wall_recycle_density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
-                channel.wall_recycle_energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink;
+                channel.wall_recycle_density_source(mesh->xstart, iy, iz) +=
+                    recycle_particle_flow / volume - pump_neutral_particle_sink;
+                channel.wall_recycle_energy_source(mesh->xstart, iy, iz) +=
+                    recycle_energy_flow / volume - pump_neutral_energy_sink;
               }
 
               // Save to solver
-              density_source(mesh->xstart, iy, iz) += recycle_particle_flow/volume - pump_neutral_particle_sink;
-              energy_source(mesh->xstart, iy, iz) += recycle_energy_flow/volume - pump_neutral_energy_sink; 
-
+              density_source(mesh->xstart, iy, iz) +=
+                  recycle_particle_flow / volume - pump_neutral_particle_sink;
+              energy_source(mesh->xstart, iy, iz) +=
+                  recycle_energy_flow / volume - pump_neutral_energy_sink;
             }
           }
         }
@@ -552,75 +636,84 @@ void Recycling::outputVars(Options& state) {
 
       // Target recycling
       if (target_recycle) {
-        set_with_attrs(state[{std::string("S") + channel.to + std::string("_target_recycle")}],
-                       channel.target_recycle_density_source,
-                       {{"time_dimension", "t"},
-                        {"units", "m^-3 s^-1"},
-                        {"conversion", Nnorm * Omega_ci},
-                        {"standard_name", "particle source"},
-                        {"long_name", std::string("Target recycling particle source of ") + channel.to},
-                        {"source", "recycling"}});
+        set_with_attrs(
+            state[{std::string("S") + channel.to + std::string("_target_recycle")}],
+            channel.target_recycle_density_source,
+            {{"time_dimension", "t"},
+             {"units", "m^-3 s^-1"},
+             {"conversion", Nnorm * Omega_ci},
+             {"standard_name", "particle source"},
+             {"long_name",
+              std::string("Target recycling particle source of ") + channel.to},
+             {"source", "recycling"}});
 
-        set_with_attrs(state[{std::string("E") + channel.to + std::string("_target_recycle")}],
-                       channel.target_recycle_energy_source,
-                       {{"time_dimension", "t"},
-                        {"units", "W m^-3"},
-                        {"conversion", Pnorm * Omega_ci},
-                        {"standard_name", "energy source"},
-                        {"long_name", std::string("Target recycling energy source of ") + channel.to},
-                        {"source", "recycling"}});
+        set_with_attrs(
+            state[{std::string("E") + channel.to + std::string("_target_recycle")}],
+            channel.target_recycle_energy_source,
+            {{"time_dimension", "t"},
+             {"units", "W m^-3"},
+             {"conversion", Pnorm * Omega_ci},
+             {"standard_name", "energy source"},
+             {"long_name",
+              std::string("Target recycling energy source of ") + channel.to},
+             {"source", "recycling"}});
       }
 
       // Wall recycling
       if ((sol_recycle) or (pfr_recycle)) {
-        set_with_attrs(state[{std::string("S") + channel.to + std::string("_wall_recycle")}],
-                       channel.wall_recycle_density_source,
-                       {{"time_dimension", "t"},
-                        {"units", "m^-3 s^-1"},
-                        {"conversion", Nnorm * Omega_ci},
-                        {"standard_name", "particle source"},
-                        {"long_name", std::string("Wall recycling particle source of ") + channel.to},
-                        {"source", "recycling"}});
+        set_with_attrs(
+            state[{std::string("S") + channel.to + std::string("_wall_recycle")}],
+            channel.wall_recycle_density_source,
+            {{"time_dimension", "t"},
+             {"units", "m^-3 s^-1"},
+             {"conversion", Nnorm * Omega_ci},
+             {"standard_name", "particle source"},
+             {"long_name",
+              std::string("Wall recycling particle source of ") + channel.to},
+             {"source", "recycling"}});
 
-        set_with_attrs(state[{std::string("E") + channel.to + std::string("_wall_recycle")}],
-                       channel.wall_recycle_energy_source,
-                       {{"time_dimension", "t"},
-                        {"units", "W m^-3"},
-                        {"conversion", Pnorm * Omega_ci},
-                        {"standard_name", "energy source"},
-                        {"long_name", std::string("Wall recycling energy source of ") + channel.to},
-                        {"source", "recycling"}});
+        set_with_attrs(
+            state[{std::string("E") + channel.to + std::string("_wall_recycle")}],
+            channel.wall_recycle_energy_source,
+            {{"time_dimension", "t"},
+             {"units", "W m^-3"},
+             {"conversion", Pnorm * Omega_ci},
+             {"standard_name", "energy source"},
+             {"long_name", std::string("Wall recycling energy source of ") + channel.to},
+             {"source", "recycling"}});
       }
 
       // Neutral pump
       if (neutral_pump) {
 
-        if (channel.pump_density_source.isAllocated()) { 
+        if (channel.pump_density_source.isAllocated()) {
           set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}],
-                        channel.pump_density_source,
-                        {{"time_dimension", "t"},
+                         channel.pump_density_source,
+                         {{"time_dimension", "t"},
                           {"units", "m^-3 s^-1"},
                           {"conversion", Nnorm * Omega_ci},
                           {"standard_name", "particle source"},
-                          {"long_name", std::string("Pump recycling particle source of ") + channel.to},
+                          {"long_name", std::string("Pump recycling particle source of ")
+                                            + channel.to},
                           {"source", "recycling"}});
 
           set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}],
-                        channel.pump_energy_source,
-                        {{"time_dimension", "t"},
+                         channel.pump_energy_source,
+                         {{"time_dimension", "t"},
                           {"units", "W m^-3"},
                           {"conversion", Pnorm * Omega_ci},
                           {"standard_name", "energy source"},
-                          {"long_name", std::string("Pump recycling energy source of ") + channel.to},
+                          {"long_name",
+                           std::string("Pump recycling energy source of ") + channel.to},
                           {"source", "recycling"}});
         } else {
-          throw BoutException("Error: neutral pump sources unallocated, likely because recycling " 
-            "on the relevant surface is disabled. Check that all boundaries with a neutral pump " 
-            "have recycling enabled!");
+          throw BoutException(
+              "Error: neutral pump sources unallocated, likely because recycling "
+              "on the relevant surface is disabled. Check that all boundaries with a "
+              "neutral pump "
+              "have recycling enabled!");
         }
-
       }
-
     }
   }
 }


### PR DESCRIPTION
Formatting neutral_mixed, recycling and neutral_boundary to make sure changes related to the neutral model are easier to see