### PR TITLE
Make neutral_mixed nonorthogonal operators optional 

### DIFF
--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -67,6 +67,7 @@ private:
 
   Field3D kappa_n, eta_n; ///< Neutral conduction and viscosity
 
+  bool nonorthogonal_operators;   ///< Use nonorthogonal operators for radial transport?
   bool precondition{true};        ///< Enable preconditioner?
   bool precon_laplacexy{false};   ///< Use LaplaceXY?
   bool lax_flux;                  ///< Use Lax flux for advection terms

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -50,6 +50,11 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
     Vn = 0.0;
   }
 
+  nonorthogonal_operators =
+      options["nonorthogonal_operators"]
+          .doc("Use nonorthogonal operators for radial transport? NOTE: may be broken")
+          .withDefault<bool>(false);
+
   sheath_ydown = options["sheath_ydown"]
                      .doc("Enable wall boundary conditions at ydown")
                      .withDefault<bool>(true);
@@ -483,10 +488,15 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral density
   TRACE("Neutral density");
   ddt(Nn) = -FV::Div_par_mod<ParLimiter>(Nn, Vn, sound_speed,
-                                         pf_adv_par_ylow) // Parallel advection
-            + Div_a_Grad_perp_nonorthog(DnnNn, logPnlim, pf_adv_perp_xlow,
-                                        pf_adv_perp_ylow); // Perpendicular diffusion
-  ;
+                                         pf_adv_par_ylow); // Parallel advection
+
+  // Perpendicular diffusion
+  if (nonorthogonal_operators) {
+    ddt(Nn) +=
+        Div_a_Grad_perp_nonorthog(DnnNn, logPnlim, pf_adv_perp_xlow, pf_adv_perp_ylow);
+  } else {
+    ddt(Nn) += Div_a_Grad_perp_flows(DnnNn, logPnlim, pf_adv_perp_xlow, pf_adv_perp_ylow);
+  }
 
   Sn = density_source; // Save for possible output
   if (localstate.isSet("density_source")) {
@@ -501,10 +511,18 @@ void NeutralMixed::finally(const Options& state) {
   ddt(Pn) = -(5. / 3)
                 * FV::Div_par_mod<ParLimiter>( // Parallel advection
                     Pn, Vn, sound_speed, ef_adv_par_ylow)
-            + (2. / 3) * Vn * Grad_par(Pn) // Work done
-            + (5. / 3)
-                  * Div_a_Grad_perp_nonorthog( // Perpendicular advection
-                      DnnPn, logPnlim, ef_adv_perp_xlow, ef_adv_perp_ylow);
+            + (2. / 3) * Vn * Grad_par(Pn); // Work done
+
+  // Perpendicular advection of pressure
+  if (nonorthogonal_operators) {
+    ddt(Pn) +=
+        (5. / 3)
+        * Div_a_Grad_perp_nonorthog(DnnPn, logPnlim, ef_adv_perp_xlow, ef_adv_perp_ylow);
+  } else {
+    ddt(Pn) +=
+        (5. / 3)
+        * Div_a_Grad_perp_flows(DnnPn, logPnlim, ef_adv_perp_xlow, ef_adv_perp_ylow);
+  }
 
   // The factor here is 5/2 as we're advecting internal energy and pressure.
   ef_adv_par_ylow *= 5. / 2;
@@ -512,16 +530,22 @@ void NeutralMixed::finally(const Options& state) {
   ef_adv_perp_ylow *= 5. / 2;
 
   if (neutral_conduction) {
-    ddt(Pn) +=
-        (2. / 3)
-            * Div_a_Grad_perp_nonorthog(kappa_n, Tn, // Perpendicular conduction
-                                        ef_cond_perp_xlow, ef_cond_perp_ylow)
+    ddt(Pn) += (2. / 3)
+               * Div_par_K_Grad_par_mod(kappa_n, Tn, // Parallel conduction
+                                        ef_cond_par_ylow,
+                                        false); // No conduction through target boundary
 
-        + (2. / 3)
-              * Div_par_K_Grad_par_mod(kappa_n, Tn, // Parallel conduction
-                                       ef_cond_par_ylow,
-                                       false) // No conduction through target boundary
-        ;
+    // Perpendicular conduction
+    if (nonorthogonal_operators) {
+      ddt(Pn) +=
+          (2. / 3)
+          * Div_a_Grad_perp_nonorthog(kappa_n, Tn, ef_cond_perp_xlow, ef_cond_perp_ylow);
+    } else {
+      ddt(Pn) +=
+          (2. / 3)
+          * Div_a_Grad_perp_flows(kappa_n, Tn, ef_cond_perp_xlow, ef_cond_perp_ylow);
+    }
+
     // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
     ef_cond_perp_xlow *= 3. / 2;
     ef_cond_perp_ylow *= 3. / 2;
@@ -544,14 +568,16 @@ void NeutralMixed::finally(const Options& state) {
                    * FV::Div_par_fvv<ParLimiter>( // Momentum flow
                        Nnlim, Vn, sound_speed)
 
-               - Grad_par(Pn) // Pressure gradient
+               - Grad_par(Pn); // Pressure gradient
 
-               + Div_a_Grad_perp_nonorthog(DnnNVn, logPnlim, mf_adv_perp_xlow,
-                                           mf_adv_perp_ylow) // Perpendicular diffusion
-        // + Div_a_Grad_perp_flows(DnnNVn, logPnlim,
-        //                              mf_adv_perp_xlow,
-        //                              mf_adv_perp_ylow) // Perpendicular advection
-        ;
+    // Perpendicular advection of momentum
+    if (nonorthogonal_operators) {
+      ddt(NVn) +=
+          Div_a_Grad_perp_nonorthog(DnnNVn, logPnlim, mf_adv_perp_xlow, mf_adv_perp_ylow);
+    } else {
+      ddt(NVn) +=
+          Div_a_Grad_perp_flows(DnnNVn, logPnlim, mf_adv_perp_xlow, mf_adv_perp_ylow);
+    }
 
     if (neutral_viscosity) {
       // NOTE: The following viscosity terms are not (yet) balanced
@@ -562,15 +588,19 @@ void NeutralMixed::finally(const Options& state) {
       // Transport Processes in Gases", 1972
       // eta_n = (2. / 5) * kappa_n;
 
-      Field3D viscosity_source =
-          Div_a_Grad_perp_nonorthog(eta_n, Vn, // Perpendicular viscosity
-                                    mf_visc_perp_xlow,
-                                    mf_visc_perp_ylow)
-
-          + Div_par_K_Grad_par_mod( // Parallel viscosity
-              eta_n, Vn, mf_visc_par_ylow,
-              false) // No viscosity through target boundary
+      Field3D viscosity_source = Div_par_K_Grad_par_mod( // Parallel viscosity
+          eta_n, Vn, mf_visc_par_ylow,
+          false) // No viscosity through target boundary
           ;
+
+      // Perpendicular viscosity
+      if (nonorthogonal_operators) {
+        viscosity_source +=
+            Div_a_Grad_perp_nonorthog(eta_n, Vn, mf_visc_perp_xlow, mf_visc_perp_ylow);
+      } else {
+        viscosity_source +=
+            Div_a_Grad_perp_flows(eta_n, Vn, mf_visc_perp_xlow, mf_visc_perp_ylow);
+      }
 
       ddt(NVn) += viscosity_source;
       ddt(Pn) += -(2. / 3) * Vn * viscosity_source;

--- a/tests/mms_operator/job_functions.py
+++ b/tests/mms_operator/job_functions.py
@@ -347,6 +347,8 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    neutral_conduction = {neutral_conduction}
    neutral_viscosity = {neutral_viscosity}
    normalise_sources = false
+   nonorthogonal_operators = true
+
    [Nd]
 
    function = {Nd_string}

--- a/tests/mms_operator/neutral_mixed_ddt_test.py
+++ b/tests/mms_operator/neutral_mixed_ddt_test.py
@@ -156,6 +156,7 @@ def neutral_mixed_equations(evolve_momentum=False,
         "interactive_plots" : False,
         "conservation_test" : conservation_test,
         "expected_convergence_order" : expected_convergence_order,
+        "nonorthogonal_operators" : True,
     }
     return test_input
 


### PR DESCRIPTION
This PR makes the new nonorthogonal operators optional. 
The old orthogonal operators are enabled by default.

Workaround for https://github.com/boutproject/hermes-3/issues/496.