### PR TITLE
sheath_closure: fix permissions typo

### DIFF
--- a/src/sheath_closure.cxx
+++ b/src/sheath_closure.cxx
@@ -39,7 +39,7 @@ SheathClosure::SheathClosure(std::string name, Options& alloptions, Solver*)
     setPermissions(readOnly("species:{non_electrons}:{inputs}"));
     setPermissions(readWrite("species:{non_electrons}:{outputs}"));
     substitutePermissions("inputs", {"AA", "density", "temperature"});
-    substitutePermissions("output", {"density_source", "energy_source"});
+    substitutePermissions("outputs", {"density_source", "energy_source"});
   } else {
     setPermissions(readIfSet("species:e:temperature"));
   }


### PR DESCRIPTION
Solves https://github.com/boutproject/hermes-3/issues/503.

I also wanted to fix https://github.com/boutproject/hermes-3/issues/498 but I can't seem to reproduce it for some reason.