### PR TITLE
Add Testing dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ spack-build*
 spack.lock
 .spack-env
 views
+
+# Tests
+**/Testing/**


### PR DESCRIPTION
Adds `**/Testing/**` to .gitignore. This is a directory created when tests are run locally.