### PR TITLE
Set min CMake version to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required(VERSION 3.9...3.12)
-
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.12)
-endif()
+cmake_minimum_required(VERSION 3.25)
 
 project(hermes-3 LANGUAGES CXX C)
 


### PR DESCRIPTION
Set 3.25 as the minimum CMake version (required to use the SYSTEM keyword in add_subdirectory).