### PR TITLE
Fix build docker image action

### DIFF
--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -1,8 +1,9 @@
 # Build as "hermes-3-builder"
 # with sudo docker build -f docker/hermes-3-builder.dockerfile -t hermes-3-builder .
 
-# Base image is ubuntu 24.04 with spack 1.0 installed
-FROM spack/ubuntu-noble:1.0 AS builder
+# Use a spack image with a pinned SHA - currently points to develop between the 1.1 and 1.2 releases.
+# N.B. The spack 1.1 release has a bug in the PETSc package that causes this build to fail 
+FROM spack/ubuntu-noble@sha256:d7784a53424fda1c528d8afe837841a6947e46b55fd4380779656d4b276f63a0 AS builder
 # Make sure that spack is available if we need to launch a terminal in the image
 RUN spack_path=$(which spack) && \
     echo "alias spack=\"${spack_path}\"" >> /root/.bashrc

--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -1,8 +1,8 @@
 # Build as "hermes-3-builder"
 # with sudo docker build -f docker/hermes-3-builder.dockerfile -t hermes-3-builder .
 
-# Use a spack image with a pinned SHA
-FROM spack/ubuntu-jammy@sha256:d9acf9ed998cbde8d12bd302c5921291086bfe6f70d2d0e26908fdc48c272324 AS builder
+# Base image is ubuntu 24.04 with spack 1.0 installed
+FROM spack/ubuntu-noble:1.0 AS builder
 # Make sure that spack is available if we need to launch a terminal in the image
 RUN spack_path=$(which spack) && \
     echo "alias spack=\"${spack_path}\"" >> /root/.bashrc

--- a/docker/hermes-3.dockerfile
+++ b/docker/hermes-3.dockerfile
@@ -5,7 +5,7 @@ ARG BUILDER_TAG=latest
 FROM ghcr.io/boutproject/hermes-3-builder:${BUILDER_TAG} AS builder
 
 # Bare OS image to run the installed executables
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 COPY --from=builder /opt/spack-environment /opt/spack-environment
 COPY --from=builder /opt/software /opt/software

--- a/docker/image_ingredients/spack_config.yaml
+++ b/docker/image_ingredients/spack_config.yaml
@@ -1,3 +1,4 @@
 # Global configuration for spack. Save as ~/.spack/config.yaml
 config:
-  install_tree: /opt/software
+  install_tree:
+    root: /opt/software


### PR DESCRIPTION
The hermes-3 build was failing because the default apt cmake package in ubuntu 22.04 is 3.22.1 (min allowed is 3.25).

Updated the base image to ubuntu 24.04 for the bout and hermes builds.
Also updated the base image for the dependencies to spack/ubuntu-noble:1.0 for consistency.

N.B. The image build wasn't failing before the cmake min version was updated because it sets -DHERMES_BUILD_BOUT=OFF, which bypasses the unsupported add_subdirectory argument.