### PR TITLE
Fix test failure on MPICH

### DIFF
--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -4,6 +4,7 @@ import numpy as np
 import shutil
 import zipfile
 import hashlib
+import os
 from pathlib import Path
 import urllib.request
 import xhermes
@@ -82,7 +83,11 @@ if verbose:
 if not Path("hermes-3").is_file():
     shell("ln -s ../../../hermes-3 hermes-3")
 
-runcmd = getmpirun().split(" ")[0] + " --oversubscribe -np"
+runcmd = getmpirun().split(" ")[0] + " -np"
+
+# Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,
+# which does not enforce slot limits and does not support --oversubscribe)
+os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "yes"
 
 s, out = launch_safe("./hermes-3 -d data", runcmd=runcmd, nproc=10, pipe=True)
 

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import shutil
 import zipfile
 import hashlib
+import os
 from pathlib import Path
 import urllib.request
 import xhermes
@@ -94,7 +95,11 @@ if not debug:
     if not Path("hermes-3").is_file():
         shell("ln -s ../../../hermes-3 hermes-3")
 
-    runcmd = getmpirun().split(" ")[0] + " --oversubscribe -np"
+    runcmd = getmpirun().split(" ")[0] + " -np"
+
+    # Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,
+    # which does not enforce slot limits and does not support --oversubscribe)
+    os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "yes"
 
     s, out = launch_safe("./hermes-3 -d data", runcmd=runcmd, nproc=10, pipe=True)
 


### PR DESCRIPTION
MPICH doesn't support --oversubscribe, and oversubscribes automatically instead. This was causing `2D-production` and `2D-recycling` to fail. 

The fix is to make sure openmpi oversubscribes by using an env variable flag which is safely ignored by MPICH. Thanks @dschwoerer for the suggestion. 

Fixes https://github.com/boutproject/hermes-3/issues/515