### PR TITLE
relax_potential: Fix a bug with radial BC.

### DIFF
--- a/src/relax_potential.cxx
+++ b/src/relax_potential.cxx
@@ -459,28 +459,8 @@ void RelaxPotential::transform_impl(GuardedOptions& state) {
     }
   }
 
-  // Outer boundary cells
-  if (mesh->firstX()) {
-    for (int i = mesh->xstart - 2; i >= 0; --i) {
-      for (int j = mesh->ystart; j <= mesh->yend; ++j) {
-        for (int k = 0; k < mesh->LocalNz; ++k) {
-          phi(i, j, k) = phi(i + 1, j, k);
-        }
-      }
-    }
-  }
-  if (mesh->lastX()) {
-    for (int i = mesh->xend + 2; i < mesh->LocalNx; ++i) {
-      for (int j = mesh->ystart; j <= mesh->yend; ++j) {
-        for (int k = 0; k < mesh->LocalNz; ++k) {
-          phi(i, j, k) = phi(i - 1, j, k);
-        }
-      }
-    }
-  }
-
   // Ensure that potential is set in the communication guard cells
-  mesh->communicate(phi, phi1, Vort); // NOTE(malamast): Should we include phi1?
+  mesh->communicate(phi, phi1, Vort); // Should we communicate phi1?
 
   // Vorticity equation
 


### PR DESCRIPTION
-We don't need to reapply BC at the radial boundaries since we do not invert the laplacian in the rhs as we do in the voricity component. 
-I copied that code from vorticity component but it doesn't apply for the relax_potential method.