### PR TITLE
Add reaction classes to hermes namespace

### DIFF
--- a/include/adas_reaction.hxx
+++ b/include/adas_reaction.hxx
@@ -37,7 +37,7 @@ struct OpenADASRateCoefficient {
 ///
 /// Uses the JSON files produced by:
 ///   https://github.com/TBody/OpenADAS_to_JSON
-struct OpenADAS : public ReactionBase {
+struct OpenADAS : public hermes::ReactionBase {
   ///
   /// Inputs
   /// ------
@@ -57,10 +57,10 @@ struct OpenADAS : public ReactionBase {
   OpenADAS(const Options& units, const std::string& rate_file,
            const std::string& radiation_file, std::string from_ion, std::string to_ion,
            std::size_t level, BoutReal electron_heating)
-      : ReactionBase({readIfSet("species:{sp}:charge"), readOnly("species:{sp}:AA"),
-                      readOnly("species:{from_ion}:{val}"), readOnly("species:e:{e_val}"),
-                      readWrite("species:{sp}:{w_val}"),
-                      readWrite("species:e:{ew_val}")}),
+      : hermes::ReactionBase(
+            {readIfSet("species:{sp}:charge"), readOnly("species:{sp}:AA"),
+             readOnly("species:{from_ion}:{val}"), readOnly("species:e:{e_val}"),
+             readWrite("species:{sp}:{w_val}"), readWrite("species:e:{ew_val}")}),
         rate_coef(std::string("json_database/") + rate_file, level),
         radiation_coef(std::string("json_database/") + radiation_file, level),
         electron_heating(electron_heating) {
@@ -94,13 +94,14 @@ private:
   BoutReal Tnorm, Nnorm, FreqNorm; ///< Normalisations
 };
 
-struct OpenADASChargeExchange : public ReactionBase {
+struct OpenADASChargeExchange : public hermes::ReactionBase {
   OpenADASChargeExchange(const Options& units, const std::string& rate_file,
                          std::string from_A, std::string from_B, std::string to_A,
                          std::string to_B, std::size_t level)
-      : ReactionBase({readIfSet("species:{sp}:charge"), readOnly("species:{sp}:AA"),
-                      readOnly("species:{from_ion}:{val}"), readOnly("species:e:{e_val}"),
-                      readWrite("species:{sp}:{w_val}")}),
+      : hermes::ReactionBase(
+            {readIfSet("species:{sp}:charge"), readOnly("species:{sp}:AA"),
+             readOnly("species:{from_ion}:{val}"), readOnly("species:e:{e_val}"),
+             readWrite("species:{sp}:{w_val}")}),
         rate_coef(std::string("json_database/") + rate_file, level) {
     // Get the units
     Tnorm = get<BoutReal>(units["eV"]);

--- a/include/amjuel_helium.hxx
+++ b/include/amjuel_helium.hxx
@@ -4,6 +4,8 @@
 
 #include "amjuel_reaction.hxx"
 
+namespace hermes {
+
 /**
  * @brief Component for Helium ionisation (e + he -> he+ + 2e) based on Amjuel
  * reaction 2.3.9a, page 161. Not resolving metastables, only transporting ground state.
@@ -62,3 +64,5 @@ RegisterComponent<AmjuelHeRecombination10> register_recombination_10("he+ + e ->
 } // namespace
 
 #endif // AMJUEL_HELIUM_H
+
+} // namespace hermes

--- a/include/amjuel_hydrogen.hxx
+++ b/include/amjuel_hydrogen.hxx
@@ -6,6 +6,8 @@
 
 #include "amjuel_reaction.hxx"
 
+namespace hermes {
+
 static std::map<std::string, std::string> long_reaction_types_map = {
     {"cx", "charge exchange"}, {"iz", "ionisation"}, {"rec", "recombination"}};
 
@@ -124,23 +126,25 @@ struct AmjuelHydIonisationIsotope : public AmjuelHydIsotopeReaction<Isotope> {
   }
 };
 
+}; // namespace hermes
+
 namespace {
 /// Register three ionisation components, one for each hydrogen isotope
 /// so no isotope dependence included.
-RegisterComponent<AmjuelHydIonisationIsotope<'h'>>
+RegisterComponent<hermes::AmjuelHydIonisationIsotope<'h'>>
     registerionisation_h("h + e -> h+ + 2e");
-RegisterComponent<AmjuelHydIonisationIsotope<'d'>>
+RegisterComponent<hermes::AmjuelHydIonisationIsotope<'d'>>
     registerionisation_d("d + e -> d+ + 2e");
-RegisterComponent<AmjuelHydIonisationIsotope<'t'>>
+RegisterComponent<hermes::AmjuelHydIonisationIsotope<'t'>>
     registerionisation_t("t + e -> t+ + 2e");
 
 /// Register three recombination components, one for each hydrogen isotope
 /// so no isotope dependence included.
-RegisterComponent<AmjuelHydRecombinationIsotope<'h'>>
+RegisterComponent<hermes::AmjuelHydRecombinationIsotope<'h'>>
     register_recombination_h("h+ + e -> h");
-RegisterComponent<AmjuelHydRecombinationIsotope<'d'>>
+RegisterComponent<hermes::AmjuelHydRecombinationIsotope<'d'>>
     register_recombination_d("d+ + e -> d");
-RegisterComponent<AmjuelHydRecombinationIsotope<'t'>>
+RegisterComponent<hermes::AmjuelHydRecombinationIsotope<'t'>>
     register_recombination_t("t+ + e -> t");
 
 } // namespace

--- a/include/amjuel_reaction.hxx
+++ b/include/amjuel_reaction.hxx
@@ -8,6 +8,8 @@
 #include "amjueldata.hxx"
 #include "reaction.hxx"
 
+namespace hermes {
+
 /**
  * @brief Extract the json database location from options, or fall back to a standard
  * location in the repo (relative to this header).
@@ -82,4 +84,5 @@ private:
   std::filesystem::path json_db_dir;
 };
 
+} // namespace hermes
 #endif // AMJUEL_REACTION_H

--- a/include/amjueldata.hxx
+++ b/include/amjueldata.hxx
@@ -12,6 +12,8 @@
 #include <bout/boutexception.hxx>
 #include <bout/msg_stack.hxx>
 
+namespace hermes {
+
 /**
  * @brief Handle reading and storage of Amjuel reaction data.
  *
@@ -79,4 +81,5 @@ private:
   bool includes_sigma_v_e;
 };
 
+} // namespace hermes
 #endif

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -8,6 +8,8 @@
 #include "component.hxx"
 #include "reaction.hxx"
 
+namespace hermes {
+
 /**
 * @brief Reaction component to handle Hydrogen charge exchange.
 *
@@ -262,22 +264,33 @@ private:
   bool no_neutral_cx_mom_gain; ///< Make CX behave as in diffusive neutrals?
 };
 
+} // namespace hermes
+
 namespace {
 /// Register three components, one for each hydrogen isotope
 /// so no isotope dependence included.
-RegisterComponent<HydrogenChargeExchange<'h', 'h'>> register_cx_hh("h + h+ -> h+ + h");
-RegisterComponent<HydrogenChargeExchange<'d', 'd'>> register_cx_dd("d + d+ -> d+ + d");
-RegisterComponent<HydrogenChargeExchange<'t', 't'>> register_cx_tt("t + t+ -> t+ + t");
+RegisterComponent<hermes::HydrogenChargeExchange<'h', 'h'>>
+    register_cx_hh("h + h+ -> h+ + h");
+RegisterComponent<hermes::HydrogenChargeExchange<'d', 'd'>>
+    register_cx_dd("d + d+ -> d+ + d");
+RegisterComponent<hermes::HydrogenChargeExchange<'t', 't'>>
+    register_cx_tt("t + t+ -> t+ + t");
 
 // Charge exchange between different isotopes
-RegisterComponent<HydrogenChargeExchange<'h', 'd'>> register_cx_hd("h + d+ -> h+ + d");
-RegisterComponent<HydrogenChargeExchange<'d', 'h'>> register_cx_dh("d + h+ -> d+ + h");
+RegisterComponent<hermes::HydrogenChargeExchange<'h', 'd'>>
+    register_cx_hd("h + d+ -> h+ + d");
+RegisterComponent<hermes::HydrogenChargeExchange<'d', 'h'>>
+    register_cx_dh("d + h+ -> d+ + h");
 
-RegisterComponent<HydrogenChargeExchange<'h', 't'>> register_cx_ht("h + t+ -> h+ + t");
-RegisterComponent<HydrogenChargeExchange<'t', 'h'>> register_cx_th("t + h+ -> t+ + h");
+RegisterComponent<hermes::HydrogenChargeExchange<'h', 't'>>
+    register_cx_ht("h + t+ -> h+ + t");
+RegisterComponent<hermes::HydrogenChargeExchange<'t', 'h'>>
+    register_cx_th("t + h+ -> t+ + h");
 
-RegisterComponent<HydrogenChargeExchange<'d', 't'>> register_cx_dt("d + t+ -> d+ + t");
-RegisterComponent<HydrogenChargeExchange<'t', 'd'>> register_cx_td("t + d+ -> t+ + d");
+RegisterComponent<hermes::HydrogenChargeExchange<'d', 't'>>
+    register_cx_dt("d + t+ -> d+ + t");
+RegisterComponent<hermes::HydrogenChargeExchange<'t', 'd'>>
+    register_cx_td("t + d+ -> t+ + d");
 } // namespace
 
 #endif // HYDROGEN_CHARGE_EXCHANGE_H

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -14,6 +14,7 @@
 #include "integrate.hxx"
 
 BOUT_ENUM_CLASS(RateParamsTypes, T, ET, nT)
+namespace hermes {
 
 /// Struct to hold pre-averaged data for each cell
 struct CellData {
@@ -329,10 +330,10 @@ private:
 
     if (do_averaging) {
       if (result.left > 0) {
-        result.left /= cellLeft<hermes::Limiter>(dens[i], dens[ym], dens[yp]);
+        result.left /= cellLeft<Limiter>(dens[i], dens[ym], dens[yp]);
       }
       if (result.right > 0) {
-        result.right /= cellRight<hermes::Limiter>(dens[i], dens[ym], dens[yp]);
+        result.right /= cellRight<Limiter>(dens[i], dens[ym], dens[yp]);
       }
     }
 
@@ -354,8 +355,8 @@ private:
     for (const auto& [sp_name, dens] : this->reactant_densities) {
       result.centre *= (*dens)[i];
       if (do_averaging) {
-        result.left *= cellLeft<hermes::Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
-        result.right *= cellRight<hermes::Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
+        result.left *= cellLeft<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
+        result.right *= cellRight<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
       }
     }
     return result;
@@ -377,11 +378,13 @@ private:
     CellData result;
     result.centre = field[i];
     if (do_averaging) {
-      result.left = cellLeft<hermes::Limiter>(field[i], field[ym], field[yp]);
-      result.right = cellRight<hermes::Limiter>(field[i], field[ym], field[yp]);
+      result.left = cellLeft<Limiter>(field[i], field[ym], field[yp]);
+      result.right = cellRight<Limiter>(field[i], field[ym], field[yp]);
     }
     return result;
   }
 };
+
+} // namespace hermes
 
 #endif

--- a/include/reaction.hxx
+++ b/include/reaction.hxx
@@ -7,6 +7,8 @@
 #include "reaction_diagnostic.hxx"
 #include "reaction_parser.hxx"
 
+namespace hermes {
+
 using OPTYPE = GuardedOptions && (GuardedOptions&&, Field3D);
 
 /**
@@ -265,4 +267,7 @@ private:
 
   void transform_impl(GuardedOptions& state) override final;
 };
+
+} // namespace hermes
+
 #endif

--- a/include/solkit_hydrogen_charge_exchange.hxx
+++ b/include/solkit_hydrogen_charge_exchange.hxx
@@ -6,16 +6,16 @@
 #include "reaction.hxx"
 /// SOL-KiT Hydrogen charge exchange total rate coefficient
 ///
-struct SOLKITHydrogenChargeExchange : public ReactionBase {
+struct SOLKITHydrogenChargeExchange : public hermes::ReactionBase {
   ///
   /// @param alloptions Settings, which should include:
   ///        - units
   ///          - inv_meters_cubed
   ///          - seconds
   SOLKITHydrogenChargeExchange(std::string, Options& alloptions, Solver*)
-      : ReactionBase({readIfSet("species:{sp}:velocity"),
-                      readOnly("species:{sp}:{readvals}"),
-                      readWrite("species:{sp}:momentum_source")}) {
+      : hermes::ReactionBase({readIfSet("species:{sp}:velocity"),
+                              readOnly("species:{sp}:{readvals}"),
+                              readWrite("species:{sp}:momentum_source")}) {
     // Get the units
     const auto& units = alloptions["units"];
     Nnorm = get<BoutReal>(units["inv_meters_cubed"]);

--- a/src/amjuel_reaction.cxx
+++ b/src/amjuel_reaction.cxx
@@ -1,6 +1,8 @@
 #include "amjuel_reaction.hxx"
 #include "hermes_utils.hxx"
 
+namespace hermes {
+
 /**
  * @brief Evaluate an Amjuel double polynomial fit in n and T, given a table of
  * coefficients (see page 20 of amjuel.pdf).
@@ -218,3 +220,5 @@ void AmjuelReaction::transform_additional(GuardedOptions& state,
   // update it in the state?!
   Field3D electron_frequency = rate_data.coll_freq("e");
 }
+
+} // namespace hermes

--- a/src/reaction.cxx
+++ b/src/reaction.cxx
@@ -10,6 +10,8 @@
 
 #include "integrate.hxx"
 
+namespace hermes {
+
 Reaction::Reaction(std::string name, Options& options)
     : ReactionBase({readOnly("species:{sp}:{r_val}"), readOnly("species:e:{e_val}"),
                     readWrite("species:{sp}:{w_val}")}),
@@ -328,3 +330,5 @@ void Reaction::zero_diagnostics(GuardedOptions& state) {
     }
   }
 }
+
+} // namespace hermes

--- a/tests/unit/test_amjuel_hyd_recombination.cxx
+++ b/tests/unit/test_amjuel_hyd_recombination.cxx
@@ -22,6 +22,8 @@ using namespace bout::globals;
 // Reuse the "standard" fixture for FakeMesh
 using HydrogenRCTest = FakeMeshFixture;
 
+namespace hermes {
+
 TEST_F(HydrogenRCTest, CreateComponent) {
   Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}}},
                   {"test", {{"type", "h+ + e -> h"}}}};
@@ -85,3 +87,5 @@ TEST_F(HydrogenRCTest, DensitySourceSigns) {
     ASSERT_TRUE(ion_energy_source[i] < 0.0);
   }
 }
+
+} // namespace hermes

--- a/tests/unit/test_amjuel_reactions.hxx
+++ b/tests/unit/test_amjuel_reactions.hxx
@@ -6,6 +6,8 @@
 #include "../../include/amjuel_helium.hxx"
 #include "../../include/amjuel_hydrogen.hxx"
 #include "../../include/hydrogen_charge_exchange.hxx"
+
+namespace hermes {
 /**
  * @brief Base fixture for tests of AmjuelReaction subclasses.
  *
@@ -116,4 +118,5 @@ public:
   DTpCXTest() : AmjuelCXTest<'d', 't'>("DTpCX", "d + t+ -> d+ + t") {}
 };
 
+} // namespace hermes
 #endif

--- a/tests/unit/test_amjueldata.cxx
+++ b/tests/unit/test_amjueldata.cxx
@@ -6,6 +6,8 @@
 
 #include "test_amjuel_reactions.hxx"
 
+namespace hermes {
+
 /*
  * N.B. AmjuelData is tested via parent AmjuelReaction instances. Testing it
  * directly would require intrusive 'friend' declarations)
@@ -71,3 +73,5 @@ TEST(AmjuelDataTest, ValidNoSigmavEData) {
                  << ", skipping!";
   }
 }
+
+} // namespace hermes

--- a/tests/unit/test_hydrogen_charge_exchange.cxx
+++ b/tests/unit/test_hydrogen_charge_exchange.cxx
@@ -22,6 +22,8 @@ using namespace bout::globals;
 // Reuse the "standard" fixture for FakeMesh
 using HydrogenCXTest = FakeMeshFixture;
 
+namespace hermes {
+
 TEST_F(HydrogenCXTest, CreateComponent) {
   Options options{{"units", {{"eV", 1.0}, {"inv_meters_cubed", 1.0}, {"seconds", 1.0}}},
                   {"test", {{"type", "h + h+ -> h+ + h"}}}};
@@ -65,3 +67,5 @@ TEST_F(HydrogenCXTest, RateAt1eV) {
   ASSERT_TRUE(IsFieldEqual(get<Field3D>(state["species"]["h"]["energy_source"]),
                            (3. / 2) * exp(-18.5028) * 1e-6, "RGN_NOBNDRY"));
 }
+
+} // namespace hermes

--- a/tests/unit/test_reactions.cxx
+++ b/tests/unit/test_reactions.cxx
@@ -1,6 +1,8 @@
 #include "test_adas_reactions.hxx"
 #include "test_amjuel_reactions.hxx"
 
+namespace hermes {
+
 // H isotopes ionization
 TEST_F(AmjuelHIznTest, SourcesRegression) { sources_regression_test(); }
 TEST_F(AmjuelDIznTest, SourcesRegression) { sources_regression_test(); }
@@ -69,3 +71,5 @@ TEST_F(ADASNe9pRecTest, SourcesRegression) { sources_regression_test(); }
 TEST_F(ADASNepHCXTest, SourcesRegression) { sources_regression_test(); }
 TEST_F(ADASNep5DCXTest, SourcesRegression) { sources_regression_test(); }
 TEST_F(ADASNep9TCXTest, SourcesRegression) { sources_regression_test(); }
+
+} // namespace hermes


### PR DESCRIPTION
Move classes using the new reaction framework into the 'hermes' namespace to avoid anticipated name clashes.