### PR TITLE
Update enable_c.patch for Docker build

### DIFF
--- a/docker/image_ingredients/enable_c.patch
+++ b/docker/image_ingredients/enable_c.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 60d34e1ad..9dc804d50 100644
+index 194f97e84..8f5e8b65c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -51,7 +51,7 @@ message(STATUS "Configuring BOUT++ version ${BOUT_FULL_VERSION}")
- project(BOUT++
+@@ -61,7 +61,7 @@ project(
+   BOUT++
    DESCRIPTION "Fluid PDE solver framework"
    VERSION ${BOUT_CMAKE_ACCEPTABLE_VERSION}
--  LANGUAGES CXX)
-+  LANGUAGES C CXX)
- 
+-  LANGUAGES CXX
++  LANGUAGES C CXX
+ )
+
  include(CMakeDependentOption)
- 


### PR DESCRIPTION
`hermes-3.dockerfile` applies a patch to BOUT++ CMakeLists, adding C to the list of languages.

https://github.com/boutproject/hermes-3/blob/master/docker/hermes-3.dockerfile#L48

The previous patch no longer applies cleanly.