### PR TITLE
Fix format test for PRs from forks

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -9,10 +9,7 @@ jobs:
     if: ${{ !endsWith(github.head_ref, '-rc') }}
     runs-on: ubuntu-latest
     steps:
-      # Checkout the pull request branch, also include all history.
-      # Need to specify the head repository explicitly, otherwise checkout
-      # defaults to this repository, which fails to find the branch when the
-      # pull request comes from a fork.
+      # Checkout the pull request branch, also include all history
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -9,9 +9,13 @@ jobs:
     if: ${{ !endsWith(github.head_ref, '-rc') }}
     runs-on: ubuntu-latest
     steps:
-      # Checkout the pull request branch, also include all history
+      # Checkout the pull request branch, also include all history.
+      # Need to specify the head repository explicitly, otherwise checkout
+      # defaults to this repository, which fails to find the branch when the
+      # pull request comes from a fork.
       - uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 


### PR DESCRIPTION
actions/checkout defaulted to https://github.com/boutproject/hermes-3, so it fails to find the PR's head branch when the PR was opened from a fork (e.g. #232).

Need to specify the head repository explicitly, otherwise checkout defaults to this repository, which fails to find the branch when the pull request comes from a fork.