### PR TITLE
CI: scope clang-format check to PR files for fork PRs

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -30,5 +30,15 @@ jobs:
       - name: Check prek versions are up-to-date
         run: uv tool run sync-with-uv --check --diff
 
+      # `origin` points at the (possibly forked) head repo, so `origin/<base>`
+      # may be missing or stale. Fetch the real base branch and diff against the
+      # merge-base so prek only checks files changed by this PR.
+      - name: Determine base ref
+        id: base
+        run: |
+          git remote add base "https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git"
+          git fetch --no-tags base "${{ github.base_ref }}"
+          echo "ref=$(git merge-base base/${{ github.base_ref }} HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run everything
-        run: uv tool run prek run --show-diff-on-failure --from-ref origin/${{ github.base_ref }}
+        run: uv tool run prek run --show-diff-on-failure --from-ref ${{ steps.base.outputs.ref }}


### PR DESCRIPTION
As a side-effect of #598, if merging from a fork, `prek` picks up all the changes between the branch and the *master branch of the fork*. If you're like me and forget to update your fork's master, then the diff is huge (see https://github.com/boutproject/hermes-3/actions/runs/28523398940/job/84553251817). One solution is to just remember to update your fork. The other solution is to explicitly set this repository as the base, as is done in this PR. Merge if you'd like to guard against this, discard if this is enough of a corner-case that we shouldn't complicate the actions to deal with it.