### PR TITLE
Add action to delete old or untagged images

### DIFF
--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -1,0 +1,83 @@
+name: Clean up old container images
+
+# Prunes ghcr.io/boutproject packages published by this repo:
+#   - untagged (dangling) digests, any age
+#   - sha- tags older than 6 months
+# Never touches semver, YYYY-MM, latest, or edge tags.
+# dataaxiom/ghcr-cleanup-action is manifest-aware, so pruning untagged digests
+# keeps the per-arch children of live multi-arch manifests.
+
+on:
+  # Monthly; offset from the builder build (23 1 1 * *) to avoid racing a push.
+  schedule:
+    - cron: '0 3 15 * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (report deletions without performing them)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cleanup-old-images
+  cancel-in-progress: false
+
+jobs:
+
+  cleanup-images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - hermes-3
+          - hermes-3-builder
+          - hermes-3-jupyter
+
+    steps:
+      - name: Delete untagged digests (${{ matrix.package }})
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: ${{ matrix.package }}
+          delete-untagged: true
+          dry-run: ${{ inputs.dry-run || false }}
+
+      # 6-month floor keeps the current master's sha- tag.
+      - name: Delete sha- tags older than 6 months (${{ matrix.package }})
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: ${{ matrix.package }}
+          delete-tags: sha-*
+          exclude-tags: latest,edge
+          older-than: 6 months
+          dry-run: ${{ inputs.dry-run || false }}
+
+  # Spack OCI build cache: high-churn, cheap to regenerate (delete = recompile
+  # next build). Prune untagged + entries >6 months, but keep the index tag so
+  # `spack buildcache push --update-index` state is not orphaned.
+  cleanup-spack-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged cache blobs (hermes-3-spack-cache)
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: hermes-3-spack-cache
+          delete-untagged: true
+          dry-run: ${{ inputs.dry-run || false }}
+
+      # index.spack is the Spack OCI index tag; must survive so --update-index state is intact.
+      - name: Delete cache entries older than 6 months (hermes-3-spack-cache)
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: hermes-3-spack-cache
+          older-than: 6 months
+          exclude-tags: index.spack
+          dry-run: ${{ inputs.dry-run || false }}

--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -16,7 +16,7 @@ on:
       dry-run:
         description: 'Dry run (report deletions without performing them)'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read


### PR DESCRIPTION
### Purpose
The Hermes-3 Docker builds publish four packages to ghcr.io/boutproject (hermes-3, hermes-3-builder, hermes-3-jupyter, and the Spack OCI cache hermes-3-spack-cache). Each build pushes multi-arch images by digest and rotating sha- / experimental_docker_build tags, so untagged digests and stale sha-tags accumulate indefinitely — there is currently no pruning. This adds a scheduled cleanup job to keep the registry tidy.

Key question to @bendudson and other project maintainers: is the retention policy too strict/too generous?

### Change Summary
Adds `.github/workflows/cleanup-old-images.yml`, a monthly (workflow_dispatch-able) job using `dataaxiom/ghcr-cleanup-action`:

- Deletes untagged (dangling) digests, any age.
- Deletes sha- tags older than 6 months.
- Never touches semver, monthly YYYY-MM, latest, or edge tags.
- hermes-3-spack-cache gets a dedicated job (prune untagged + entries >6 months) that preserves the Spack index tag (`index.spack`), since a deleted cache entry only costs a recompile on the next build.

bout-dev / bout-container-base are not published by this repo, so they're out of scope automatically. No changes to existing Dockerfiles or build workflows.

**Dry-run vs real:** both the scheduled monthly run and a default `workflow_dispatch` run perform real deletions (`dry-run` defaults to `false`). To preview what would be deleted without touching anything, run a dry run explicitly:

```
gh workflow run cleanup-old-images.yml -f dry-run=true
```

### Validation
Verified end-to-end via a temporary push-triggered dry run: https://github.com/boutproject/hermes-3/actions/runs/28800590720

- Workflow YAML parses cleanly and passes the repo's `Validate GitHub Workflows` pre-commit hook.
- All four jobs succeeded with **no 403s**, confirming the in-Actions `GITHUB_TOKEN` has delete rights on the org packages — **no PAT required**.
- **Manifest safety:** per-arch children of live multi-arch images are retained — the log shows `skipping ... as it's in use by another image`.
- **Current master preserved:** the digest tagged `sha-de17ace master edge latest` appears in **zero** delete lines.
- **6-month floor correct:** `older-than` resolved to `Wed, 07 Jan 2026` (exactly 6 months before the run); only old sha- tags were flagged (52 for hermes-3), recent ones kept.
- **Would-delete volume (dry run):** hermes-3 ~190 untagged + 52 old sha-tags; hermes-3-builder 207 + 12; hermes-3-jupyter 59 + 156; hermes-3-spack-cache 11 untagged, 0 tagged (cache is <6 months old).

### AI Assistance
The workflow was drafted with Claude Code — codebase exploration, tag-scheme analysis, and the workflow itself. Verified by reviewing the existing build workflows for the actual tagging scheme (docker/metadata-action tags), confirming the cleanup action's manifest-aware handling of multi-arch children via the dry-run logs above, and YAML-linting.

### Documentation
No documentation changes needed — this is CI infrastructure with intent captured in the workflow's header comments.

### Review Notes
- **Manifest safety:** the action is manifest-aware, so pruning untagged digests keeps the per-arch children of live multi-arch manifests. Confirmed in the dry run (see Validation); latest/edge/semver were untouched.
- **Spack index tag:** the dry run revealed the real index tag is `index.spack` (specs are `<name>-<version>-<hash>.spack`), not the `index.db`/`_catalog` originally guessed — now fixed in `exclude-tags`. It didn't bite the dry run because the cache is younger than 6 months, but it would have orphaned the index once entries aged.
- **Token scope:** confirmed working with the built-in `GITHUB_TOKEN`; no PAT needed.
- **First run:** `workflow_dispatch` defaults to real deletions, so a bare manual run deletes. To preview first, run `gh workflow run cleanup-old-images.yml -f dry-run=true` and review the logs before letting the monthly cron take over.
