### PR TITLE
Add workflow to close stale PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   pull-requests: write
-  issues: write
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,15 +22,8 @@ jobs:
             It will be closed in 28 days unless there is new activity.
             Remove the `stale` label or comment to keep it open.
           exempt-pr-labels: 'keep,pinned,security'
-          days-before-issue-stale: 365
-          days-before-issue-close: 28
-          stale-issue-label: stale
-          stale-issue-message: >
-            This issue has had no activity for a year and is marked stale.
-            It will be closed in 28 days unless there is new activity.
-            Remove the `stale` label, comment, or assign it to the
-            "long-term" milestone to keep it open.
-          exempt-issue-milestones: 'long-term'
+          # Never mark issues as stale (-1 disables issue processing).
+          days-before-issue-stale: -1
           # Conservative limit while starting out; raise once behaviour is trusted.
           operations-per-run: 5
           # Dry run: logs what it *would* do without acting. Disable to go live.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Close stale PRs
 on:
   schedule:
-    - cron: '30 1 1 * *'   # monthly, 1st of the month at 01:30 UTC
+    - cron: '30 1 */3 * *'   # run every 3 days at 01:30 UTC
   workflow_dispatch:        # allow manual runs
 
 permissions:
@@ -15,26 +15,23 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-stale: 90
-          days-before-close: 14
+          days-before-close: 28
           stale-pr-label: stale
           stale-pr-message: >
             This PR has had no activity for 90 days and is marked stale.
-            It will be closed in 14 days unless there is new activity.
+            It will be closed in 28 days unless there is new activity.
             Remove the `stale` label or comment to keep it open.
           exempt-pr-labels: 'keep,pinned,security'
-          # Issues: mark stale after a year of inactivity, close 14 days later.
           days-before-issue-stale: 365
-          days-before-issue-close: 14
+          days-before-issue-close: 28
           stale-issue-label: stale
           stale-issue-message: >
             This issue has had no activity for a year and is marked stale.
-            It will be closed in 14 days unless there is new activity.
+            It will be closed in 28 days unless there is new activity.
             Remove the `stale` label, comment, or assign it to the
-            "long-term development" milestone to keep it open.
-          # Never touch issues in the long-term development milestone.
-          exempt-issue-milestones: 'long-term development'
-          # Process more items per run to clear the existing backlog faster
-          # (default is 30). Can be lowered once the backlog is drained.
-          operations-per-run: 100
-          # Uncomment for a dry run: logs what it *would* do without acting.
-          # debug-only: true
+            "long-term" milestone to keep it open.
+          exempt-issue-milestones: 'long-term'
+          # Conservative limit while starting out; raise once behaviour is trusted.
+          operations-per-run: 5
+          # Dry run: logs what it *would* do without acting. Disable to go live.
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Close stale PRs
+on:
+  schedule:
+    - cron: '30 1 1 * *'   # monthly, 1st of the month at 01:30 UTC
+  workflow_dispatch:        # allow manual runs
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 90
+          days-before-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for 90 days and is marked stale.
+            It will be closed in 14 days unless there is new activity.
+            Remove the `stale` label or comment to keep it open.
+          exempt-pr-labels: 'keep,pinned,security'
+          # Issues: mark stale after a year of inactivity, close 14 days later.
+          days-before-issue-stale: 365
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has had no activity for a year and is marked stale.
+            It will be closed in 14 days unless there is new activity.
+            Remove the `stale` label, comment, or assign it to the
+            "long-term development" milestone to keep it open.
+          # Never touch issues in the long-term development milestone.
+          exempt-issue-milestones: 'long-term development'
+          # Process more items per run to clear the existing backlog faster
+          # (default is 30). Can be lowered once the backlog is drained.
+          operations-per-run: 100
+          # Uncomment for a dry run: logs what it *would* do without acting.
+          # debug-only: true


### PR DESCRIPTION
### Purpose
The GitHub PRs list has accumulated stale branches that are no longer relevant.
Many of these were opened by me, and I feel bad about it. This PR adds a scheduled
GitHub Action to automatically flag and close them.

### Change Summary
Adds `.github/workflows/stale.yml`, using `actions/stale@v9` on a schedule
(every 3 days, 01:30 UTC) with manual `workflow_dispatch` support:
- **Pull requests:** marked stale after 90 days of inactivity, closed 28 days later.
  Exempt if labeled `keep`, `pinned`, or `security`. Warned via a comment and can be
  kept open by removing the `stale` label or commenting.
- **Issues:** not processed. `days-before-issue-stale: -1` disables issue handling
  entirely, so issues are never marked stale or closed.

### Validation
Workflow YAML reviewed for correct `actions/stale` inputs. It currently runs with
`debug-only: true`, so it only logs what it *would* mark or close without acting —
this lets us confirm behaviour safely before going live. Remove `debug-only: true`
to enable actual closing.

### AI Assistance
Claude Code was used to draft the workflow file and this description. Output was
reviewed for correct `actions/stale` configuration keys and schedule syntax.

### Documentation
No documentation changes needed — the workflow is self-contained.

### Review Notes
- `actions/stale` **closes** items; it does not delete them (deletion isn't supported
  by the action and is recoverable this way).
- "Inactive for 90 days" is measured from last activity (`updated_at`), not creation date.
- Starting conservatively with `operations-per-run: 5` and `debug-only: true` so the
  change is easy to revert if anything goes wrong. Both can be raised/removed once
  behaviour is trusted. An operation is any of fetching PRs, adding the stale label,
  posting a warning, and closing an item, so it can take several operations to process
  a single stale PR.
