### PR TITLE
Add compatibility images

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,0 +1,109 @@
+name: Build image by digest
+description: >-
+  Build a single-platform image, push it to the registry by digest only, and
+  upload the digest as an artifact for a later manifest-merge step. The caller
+  must have checked out the repository first (this is a local action, and the
+  build context is the workspace).
+
+inputs:
+  image:
+    description: Fully-qualified image name (registry/namespace/name).
+    required: true
+  dockerfile:
+    description: Path to the Dockerfile.
+    required: true
+  platform:
+    description: Target platform, e.g. linux/amd64.
+    required: true
+  cache-scope:
+    description: gha cache scope; must be unique per image/variant/arch.
+    required: true
+  artifact-name:
+    description: Name for the uploaded digest artifact; unique per build leg.
+    required: true
+  build-args:
+    description: Newline-separated build-args for build-push-action.
+    required: false
+    default: ""
+  build-secrets:
+    description: Newline-separated secrets for build-push-action.
+    required: false
+    default: ""
+  require-avx512:
+    description: When 'true', fail fast unless the runner CPU has AVX-512.
+    required: false
+    default: "false"
+  registry:
+    description: Registry to log in to.
+    required: true
+  username:
+    description: Registry username.
+    required: true
+  password:
+    description: Registry password/token.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # x86_64_v4 targets AVX-512, but GitHub's runner fleet is mixed: on a CPU
+    # without it the v4-compiled Spack cmake SIGILLs during configure. Fail fast
+    # here (re-running the job re-rolls the runner) instead of deep in the build.
+    - name: Require AVX-512
+      if: inputs.require-avx512 == 'true'
+      shell: bash
+      run: |
+        if ! grep -qw avx512f /proc/cpuinfo; then
+          echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); this x86_64_v4 image would SIGILL. Re-run to land on an AVX-512-capable runner."
+          exit 1
+        fi
+        echo "AVX-512 present; proceeding."
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    # Labels only; tags are applied later by the merge step.
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image }}
+
+    - name: Build and push image by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=${{ inputs.cache-scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.build-secrets }}
+        outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+        # Names are unique per leg; overwrite lets a full re-run (the v4 retry)
+        # replace the prior attempt's artifact instead of 409-ing.
+        overwrite: true

--- a/.github/actions/merge-digests/action.yml
+++ b/.github/actions/merge-digests/action.yml
@@ -1,0 +1,89 @@
+name: Merge digests into a manifest
+description: >-
+  Download the per-arch digests for one variant and, when any exist, assemble
+  them into a manifest under the given tags and inspect the result. A variant
+  with no digests (a failed/skipped build leg) is skipped cleanly when tolerant.
+  The caller must have checked out the repository first (this is a local action).
+
+inputs:
+  image:
+    description: Fully-qualified image name (registry/namespace/name).
+    required: true
+  artifact-pattern:
+    description: download-artifact pattern selecting this variant's digests.
+    required: true
+  tags:
+    description: Newline-separated full image refs to tag the manifest with.
+    required: true
+  inspect-tag:
+    description: One full image ref to inspect after creating the manifest.
+    required: true
+  tolerant:
+    description: When 'true', skip cleanly if no digests are present.
+    required: false
+    default: "true"
+  registry:
+    description: Registry to log in to.
+    required: true
+  username:
+    description: Registry username.
+    required: true
+  password:
+    description: Registry password/token.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      continue-on-error: ${{ inputs.tolerant == 'true' }}
+      with:
+        path: /tmp/digests
+        pattern: ${{ inputs.artifact-pattern }}
+        merge-multiple: true
+
+    - name: Check for digests
+      id: digests
+      shell: bash
+      run: |
+        if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        elif [ "${{ inputs.tolerant }}" = "true" ]; then
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          echo "No digests match '${{ inputs.artifact-pattern }}'; nothing to merge."
+        else
+          echo "::error::No digests match '${{ inputs.artifact-pattern }}'."
+          exit 1
+        fi
+
+    - name: Set up Docker Buildx
+      if: steps.digests.outputs.present == 'true'
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to registry
+      if: steps.digests.outputs.present == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Create manifest
+      if: steps.digests.outputs.present == 'true'
+      shell: bash
+      working-directory: /tmp/digests
+      run: |
+        args=()
+        while IFS= read -r t; do
+          [ -n "$t" ] && args+=(-t "$t")
+        done <<'EOF'
+        ${{ inputs.tags }}
+        EOF
+        docker buildx imagetools create "${args[@]}" \
+          $(printf '${{ inputs.image }}@sha256:%s ' *)
+
+    - name: Inspect manifest
+      if: steps.digests.outputs.present == 'true'
+      shell: bash
+      run: docker buildx imagetools inspect ${{ inputs.inspect-tag }}

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -205,28 +205,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each final image is built FROM the matching-variant builder tag.
+        # Each final image is built FROM the matching-variant builder tag, and
+        # compiles BOUT++/Hermes-3 at the same microarch (`target`).
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
             variant: default
             builder_tag: edge
+            target: x86_64_v3
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
             variant: default
             builder_tag: edge
+            target: aarch64
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
             variant: x86_64_v2
             builder_tag: edge-x86_64_v2
+            target: x86_64_v2
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
             variant: x86_64_v1
             builder_tag: edge-x86_64_v1
+            target: x86_64
 
     runs-on: ${{ matrix.runner }}
 
@@ -264,6 +269,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
             BUILDER_TAG=${{ matrix.builder_tag }}
+            HERMES_TARGET=${{ matrix.target }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
 
-  # Compute the build matrices. Compat variants (x86_64_v2 / x86_64_v1) only
+  # Compute the build matrices. Compat variants only
   # ever carry the `latest` tag, which is published on the default branch only.
   # On events where `latest` won't be applied (releases, whose ref is a tag; a
   # dispatch from a non-default branch) the compat builds would produce no tag,
@@ -59,19 +59,16 @@ jobs:
           builder='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","target":"x86_64"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"}
           ]'
           final='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"edge","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"edge","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","builder_tag":"edge-x86_64_v1","target":"x86_64"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"}
           ]'
           merge='[
             {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
-            {"variant":"x86_64_v1","suffix":"-x86_64_v1"}
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"}
           ]'
 
           # Keep only the default variant when compat builds are skipped.

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -37,13 +37,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `variant` groups per-arch builds into one published manifest/tag
+        # family: the `default` variant becomes the multi-arch :latest/:edge
+        # tags; each compat variant is amd64-only and gets its own suffixed
+        # tags (e.g. :edge-x86_64_v2). `target` is the hard Spack microarch
+        # pin passed to the builder dockerfile.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
+            variant: default
+            target: x86_64_v3
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
+            variant: default
+            target: aarch64
+          # Older-arch-compatible amd64 variants (published as separate tags).
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v2
+            target: x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v1
+            target: x86_64
 
     runs-on: ${{ matrix.runner }}
 
@@ -78,12 +98,14 @@ jobs:
           file: ${{ env.BUILDER_DOCKERFILE }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=builder-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=builder-${{ matrix.arch }}
+          cache-from: type=gha,scope=builder-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=builder-${{ matrix.variant }}-${{ matrix.arch }}
           # Credentials for the self-hosted OCI Spack build cache, so the build
           # can pull previously-compiled binaries and push newly-built ones.
+          # HERMES_TARGET pins the microarch level for this variant.
           build-args: |
             SPACK_OCI_USER=${{ github.actor }}
+            HERMES_TARGET=${{ matrix.target }}
           secrets: |
             ghcr_token=${{ secrets.GITHUB_TOKEN }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -97,23 +119,36 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: builder-digests-${{ matrix.arch }}
+          name: builder-digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  # Combine the per-arch builder images into one multi-arch manifest and apply tags.
+  # Combine the per-arch builder images into one manifest per variant and apply
+  # tags. The `default` variant is multi-arch (amd64+arm64) under the primary
+  # tags; each compat variant is amd64-only under suffixed tags.
   merge-builder-image:
 
     needs: build-builder-image
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            suffix: ''
+          - variant: x86_64_v2
+            suffix: -x86_64_v2
+          - variant: x86_64_v1
+            suffix: -x86_64_v1
 
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: builder-digests-*
+          pattern: builder-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -131,6 +166,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          # Suffix every tag for compat variants (empty for the default variant).
+          # onlatest=true so :latest also becomes :latest-x86_64_v2, etc.
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
           tags: |
             # tag with date for scheduled jobs (YYYY-MM)
             type=schedule,pattern={{date 'YYYY-MM'}}
@@ -146,7 +185,7 @@ jobs:
             # tag with branch name
             type=ref,event=branch,enable={{is_default_branch}}
 
-      - name: Create multi-arch manifest
+      - name: Create manifest
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -154,7 +193,7 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:edge
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:edge${{ matrix.suffix }}
 
   # Build the final image per architecture, each FROM the matching-arch builder,
   # pushing by digest; then merge into a multi-arch manifest.
@@ -166,13 +205,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each final image is built FROM the matching-variant builder tag.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
+            variant: default
+            builder_tag: edge
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
+            variant: default
+            builder_tag: edge
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v2
+            builder_tag: edge-x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v1
+            builder_tag: edge-x86_64_v1
 
     runs-on: ${{ matrix.runner }}
 
@@ -206,10 +260,10 @@ jobs:
           file: ${{ env.FINAL_DOCKERFILE }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=final-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=final-${{ matrix.arch }}
+          cache-from: type=gha,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
-            BUILDER_TAG=edge
+            BUILDER_TAG=${{ matrix.builder_tag }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -221,7 +275,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: final-digests-${{ matrix.arch }}
+          name: final-digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -231,12 +285,23 @@ jobs:
     needs: build-final-image
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            suffix: ''
+          - variant: x86_64_v2
+            suffix: -x86_64_v2
+          - variant: x86_64_v1
+            suffix: -x86_64_v1
+
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: final-digests-*
+          pattern: final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -254,6 +319,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          # Suffix every tag for compat variants (empty for the default variant).
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
           tags: |
             # tag with date for scheduled jobs (YYYY-MM)
             type=schedule,pattern={{date 'YYYY-MM'}}
@@ -269,7 +337,7 @@ jobs:
             # tag with branch name
             type=ref,event=branch,enable={{is_default_branch}}
 
-      - name: Create multi-arch manifest
+      - name: Create manifest
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -277,4 +345,4 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:edge
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:edge${{ matrix.suffix }}

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -29,41 +29,70 @@ env:
 
 jobs:
 
+  # Compute the build matrices. Compat variants (x86_64_v2 / x86_64_v1) only
+  # ever carry the `latest` tag, which is published on the default branch only.
+  # On events where `latest` won't be applied (releases, whose ref is a tag; a
+  # dispatch from a non-default branch) the compat builds would produce no tag,
+  # so drop them and build the default variant alone.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      builder_matrix: ${{ steps.gen.outputs.builder_matrix }}
+      final_matrix: ${{ steps.gen.outputs.final_matrix }}
+      merge_matrix: ${{ steps.gen.outputs.merge_matrix }}
+    steps:
+      - name: Compute matrices (include compat variants only when publishing latest)
+        id: gen
+        run: |
+          case "${{ github.event_name }}" in
+            release)      compat=false ;;
+            schedule|push) compat=true ;;
+            *)  # workflow_dispatch etc.: only when on the default branch
+              if [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ]; then
+                compat=true
+              else
+                compat=false
+              fi ;;
+          esac
+          echo "Build compat variants: ${compat}"
+
+          builder='[
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","target":"x86_64_v3"},
+            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","target":"aarch64"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","target":"x86_64"}
+          ]'
+          final='[
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"edge","target":"x86_64_v3"},
+            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"edge","target":"aarch64"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","builder_tag":"edge-x86_64_v1","target":"x86_64"}
+          ]'
+          merge='[
+            {"variant":"default","suffix":""},
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
+            {"variant":"x86_64_v1","suffix":"-x86_64_v1"}
+          ]'
+
+          # Keep only the default variant when compat builds are skipped.
+          f='if $c=="true" then . else map(select(.variant=="default")) end'
+          {
+            echo "builder_matrix=$(jq -c --arg c "$compat" "$f" <<<"$builder")"
+            echo "final_matrix=$(jq -c --arg c "$compat" "$f" <<<"$final")"
+            echo "merge_matrix=$(jq -c --arg c "$compat" "$f" <<<"$merge")"
+          } >> "$GITHUB_OUTPUT"
+
   # Build the builder image once per architecture on a native runner, pushing
   # each by digest only. The merge job below assembles them into a single
-  # multi-arch manifest.
+  # multi-arch manifest. `variant` groups per-arch builds into one published
+  # manifest/tag family; `target` is the hard Spack microarch pin.
   build-builder-image:
 
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
-        # `variant` groups per-arch builds into one published manifest/tag
-        # family: the `default` variant becomes the multi-arch :latest/:edge
-        # tags; each compat variant is amd64-only and gets its own suffixed
-        # tags (e.g. :edge-x86_64_v2). `target` is the hard Spack microarch
-        # pin passed to the builder dockerfile.
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: default
-            target: x86_64_v3
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-            variant: default
-            target: aarch64
-          # Older-arch-compatible amd64 variants (published as separate tags).
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v2
-            target: x86_64_v2
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v1
-            target: x86_64
+        include: ${{ fromJSON(needs.setup.outputs.builder_matrix) }}
 
     runs-on: ${{ matrix.runner }}
 
@@ -129,19 +158,13 @@ jobs:
   # tags; each compat variant is amd64-only under suffixed tags.
   merge-builder-image:
 
-    needs: build-builder-image
+    needs: [setup, build-builder-image]
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: default
-            suffix: ''
-          - variant: x86_64_v2
-            suffix: -x86_64_v2
-          - variant: x86_64_v1
-            suffix: -x86_64_v1
+        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
 
     steps:
       - name: Download digests
@@ -170,20 +193,25 @@ jobs:
           # onlatest=true so :latest also becomes :latest-x86_64_v2, etc.
           flavor: |
             suffix=${{ matrix.suffix }},onlatest=true
+          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
+          # (edge, sha, branch, monthly schedule, version semver) is restricted to
+          # the default variant. The `variant=='default' && '{{is_default_branch}}'`
+          # form ANDs the existing default-branch gate with the variant restriction
+          # (a non-default variant short-circuits to `false`).
           tags: |
             # tag with date for scheduled jobs (YYYY-MM)
-            type=schedule,pattern={{date 'YYYY-MM'}}
-            # set "latest" tag
+            type=schedule,pattern={{date 'YYYY-MM'}},enable=${{ matrix.variant == 'default' }}
+            # set "latest" tag (the only tag compat variants receive)
             type=raw,value=latest,enable={{is_default_branch}}
             # always tag the most recent build as 'edge'
-            type=raw,value=edge
+            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
             # short sha tag
-            type=sha,enable={{is_default_branch}}
+            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
             # tag with semantic version
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
             # tag with branch name
-            type=ref,event=branch,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
 
       - name: Create manifest
         working-directory: /tmp/digests
@@ -199,7 +227,7 @@ jobs:
   # pushing by digest; then merge into a multi-arch manifest.
   build-final-image:
 
-    needs: merge-builder-image
+    needs: [setup, merge-builder-image]
     if: needs.merge-builder-image.result == 'success'
 
     strategy:
@@ -207,31 +235,7 @@ jobs:
       matrix:
         # Each final image is built FROM the matching-variant builder tag, and
         # compiles BOUT++/Hermes-3 at the same microarch (`target`).
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: default
-            builder_tag: edge
-            target: x86_64_v3
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-            variant: default
-            builder_tag: edge
-            target: aarch64
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v2
-            builder_tag: edge-x86_64_v2
-            target: x86_64_v2
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v1
-            builder_tag: edge-x86_64_v1
-            target: x86_64
+        include: ${{ fromJSON(needs.setup.outputs.final_matrix) }}
 
     runs-on: ${{ matrix.runner }}
 
@@ -288,19 +292,13 @@ jobs:
 
   merge-final-image:
 
-    needs: build-final-image
+    needs: [setup, build-final-image]
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: default
-            suffix: ''
-          - variant: x86_64_v2
-            suffix: -x86_64_v2
-          - variant: x86_64_v1
-            suffix: -x86_64_v1
+        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
 
     steps:
       - name: Download digests
@@ -328,20 +326,25 @@ jobs:
           # Suffix every tag for compat variants (empty for the default variant).
           flavor: |
             suffix=${{ matrix.suffix }},onlatest=true
+          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
+          # (edge, sha, branch, monthly schedule, version semver) is restricted to
+          # the default variant. The `variant=='default' && '{{is_default_branch}}'`
+          # form ANDs the existing default-branch gate with the variant restriction
+          # (a non-default variant short-circuits to `false`).
           tags: |
             # tag with date for scheduled jobs (YYYY-MM)
-            type=schedule,pattern={{date 'YYYY-MM'}}
-            # set "latest" tag
+            type=schedule,pattern={{date 'YYYY-MM'}},enable=${{ matrix.variant == 'default' }}
+            # set "latest" tag (the only tag compat variants receive)
             type=raw,value=latest,enable={{is_default_branch}}
             # always tag the most recent build as 'edge'
-            type=raw,value=edge
+            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
             # short sha tag
-            type=sha,enable={{is_default_branch}}
+            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
             # tag with semantic version
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
             # tag with branch name
-            type=ref,event=branch,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
 
       - name: Create manifest
         working-directory: /tmp/digests

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -240,6 +240,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # Fail fast (before checkout/build) if this runner can't run the code it is
+      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
+      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
+      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
+      - name: Require AVX-512 for x86_64_v4 build
+        if: matrix.target == 'x86_64_v4'
+        run: |
+          if ! grep -qw avx512f /proc/cpuinfo; then
+            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
+            exit 1
+          fi
+          echo "AVX-512 present; proceeding with x86_64_v4 build."
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -293,6 +306,11 @@ jobs:
   merge-final-image:
 
     needs: [setup, build-final-image]
+    # Run even when a compat build leg failed/was skipped (e.g. the x86_64_v4 leg
+    # lost the AVX-512 runner roll). Each variant is merged independently below,
+    # and a variant with no digests is skipped, so a missing v2/v4 image never
+    # blocks the default manifest.
+    if: always() && needs.setup.result == 'success'
     runs-on: ubuntu-latest
 
     strategy:
@@ -303,15 +321,31 @@ jobs:
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: /tmp/digests
           pattern: final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
+      # A compat variant whose build leg failed/was skipped has no digests. These
+      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
+      # rather than failing when there is nothing to assemble.
+      - name: Check for digests
+        id: digests
+        run: |
+          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.digests.outputs.present == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to registry ${{ env.REGISTRY }}
+        if: steps.digests.outputs.present == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -320,6 +354,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
+        if: steps.digests.outputs.present == 'true'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
@@ -347,6 +382,7 @@ jobs:
             type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
 
       - name: Create manifest
+        if: steps.digests.outputs.present == 'true'
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -354,4 +390,46 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
+        if: steps.digests.outputs.present == 'true'
         run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:edge${{ matrix.suffix }}
+
+  # Auto-retry when the x86_64_v4 final build fails purely because the job landed
+  # on a runner without AVX-512 (GitHub's fleet is mixed). Re-running the whole
+  # run re-rolls the runners; earlier stages (builder build/merge, default/v2
+  # final legs) restore from the gha layer cache. We use a FULL re-run rather
+  # than `--failed` because the latter's dependent-job rerun is unreliable for
+  # matrix jobs (actions/runner #2810), which would leave a retried v4 image
+  # built but never tagged. Bounded by github.run_attempt (3 attempts => 2
+  # automatic retries) so a genuinely-broken build can't loop; raise the `< 3` to
+  # allow more. A non-v4 failure is never retried, and once retries are exhausted
+  # the tolerant merge above still publishes the default/v2 images.
+  retry-v4-runner-lottery:
+    needs: build-final-image
+    if: failure() && fromJSON(github.run_attempt) < 6
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-run the workflow if only x86_64_v4 legs failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          failed=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
+            --paginate --jq '.jobs[] | select(.conclusion=="failure") | .name')
+          echo "Failed jobs on attempt ${{ github.run_attempt }}:"
+          printf '%s\n' "$failed"
+          if [ -z "$failed" ]; then
+            echo "No failed jobs detected; nothing to retry."
+            exit 0
+          fi
+          # Every matrix leg's job name embeds its matrix values, so an x86_64_v4
+          # leg's name contains "x86_64_v4". If any failed job does NOT, it's a
+          # real failure (default/v2), not the AVX-512 runner lottery.
+          if printf '%s\n' "$failed" | grep -qv 'x86_64_v4'; then
+            echo "A non-x86_64_v4 job failed; treating as a real failure and not retrying."
+            exit 0
+          fi
+          echo "Only x86_64_v4 leg(s) failed; re-running to re-roll the runner."
+          sleep 30
+          gh run rerun "${{ github.run_id }}"

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -1,6 +1,9 @@
 name: Build hermes-3-builder and hermes-3 Docker images
 
-# Configures this workflow to run when a release is released, or when manually triggered.
+# Runs on release, monthly schedule, or manual dispatch. Builds the builder
+# image then the final image on top of it. The default variant is multi-arch
+# with the full tag set; compat variants are built in separate jobs and only
+# carry a suffixed `latest`.
 on:
   workflow_dispatch:  # Allows manual triggering
   release:
@@ -13,8 +16,8 @@ permissions:
   contents: read
   packages: write
 
-# Serialize runs so overlapping push/schedule/dispatch builds don't race on
-# the shared image tags. Don't cancel an in-progress build (it may already be
+# Serialize runs so overlapping schedule/dispatch builds don't race on the
+# shared image tags. Don't cancel an in-progress build (it may already be
 # pushing binaries to the OCI cache).
 concurrency:
   group: build-builder-image
@@ -29,407 +32,276 @@ env:
 
 jobs:
 
-  # Compute the build matrices. Compat variants only
-  # ever carry the `latest` tag, which is published on the default branch only.
-  # On events where `latest` won't be applied (releases, whose ref is a tag; a
-  # dispatch from a non-default branch) the compat builds would produce no tag,
-  # so drop them and build the default variant alone.
+  # Compat variants only carry `latest` (default branch only), so skip them on
+  # events that won't publish it: releases (tag ref) or a dispatch off the
+  # default branch. Scheduled runs are on the default branch, so they build compat.
   setup:
     runs-on: ubuntu-latest
     outputs:
-      builder_matrix: ${{ steps.gen.outputs.builder_matrix }}
-      final_matrix: ${{ steps.gen.outputs.final_matrix }}
-      merge_matrix: ${{ steps.gen.outputs.merge_matrix }}
+      compat: ${{ steps.gen.outputs.compat }}
     steps:
-      - name: Compute matrices (include compat variants only when publishing latest)
+      - name: Decide whether to build compat variants
         id: gen
         run: |
           case "${{ github.event_name }}" in
-            release)      compat=false ;;
-            schedule|push) compat=true ;;
-            *)  # workflow_dispatch etc.: only when on the default branch
-              if [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ]; then
-                compat=true
-              else
-                compat=false
-              fi ;;
+            schedule) compat=true ;;
+            release)  compat=false ;;
+            *) [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ] \
+                 && compat=true || compat=false ;;
           esac
+          echo "compat=${compat}" >> "$GITHUB_OUTPUT"
           echo "Build compat variants: ${compat}"
 
-          builder='[
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","target":"x86_64_v3"},
-            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","target":"x86_64_v4"}
-          ]'
-          final='[
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"edge","target":"x86_64_v3"},
-            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"edge","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","builder_tag":"edge-x86_64_v4","target":"x86_64_v4"}
-          ]'
-          merge='[
-            {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
-            {"variant":"x86_64_v4","suffix":"-x86_64_v4"}
-          ]'
+  # ---- Builder image: default variant (multi-arch, full tag set) ----
 
-          # Keep only the default variant when compat builds are skipped.
-          f='if $c=="true" then . else map(select(.variant=="default")) end'
-          {
-            echo "builder_matrix=$(jq -c --arg c "$compat" "$f" <<<"$builder")"
-            echo "final_matrix=$(jq -c --arg c "$compat" "$f" <<<"$final")"
-            echo "merge_matrix=$(jq -c --arg c "$compat" "$f" <<<"$merge")"
-          } >> "$GITHUB_OUTPUT"
-
-  # Build the builder image once per architecture on a native runner, pushing
-  # each by digest only. The merge job below assembles them into a single
-  # multi-arch manifest. `variant` groups per-arch builds into one published
-  # manifest/tag family; `target` is the hard Spack microarch pin.
-  build-builder-image:
-
-    needs: setup
+  build-builder-default:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.setup.outputs.builder_matrix) }}
-
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            target: x86_64_v3
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            target: aarch64
     runs-on: ${{ matrix.runner }}
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+      - uses: ./.github/actions/build-image
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Labels for the per-arch image (tags are applied later in the merge job)
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
-
-      - name: Build and push image by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.BUILDER_DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=builder-${{ matrix.variant }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=builder-${{ matrix.variant }}-${{ matrix.arch }}
-          # Credentials for the self-hosted OCI Spack build cache, so the build
-          # can pull previously-compiled binaries and push newly-built ones.
-          # HERMES_TARGET pins the microarch level for this variant.
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          dockerfile: ${{ env.BUILDER_DOCKERFILE }}
+          platform: ${{ matrix.platform }}
+          cache-scope: builder-default-${{ matrix.arch }}
+          artifact-name: builder-digests-default-${{ matrix.arch }}
+          # SPACK_OCI_USER + ghcr_token give the build access to the self-hosted
+          # OCI Spack cache (pull prebuilt binaries, push newly-built ones).
           build-args: |
             SPACK_OCI_USER=${{ github.actor }}
             HERMES_TARGET=${{ matrix.target }}
-          secrets: |
+          build-secrets: |
             ghcr_token=${{ secrets.GITHUB_TOKEN }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: builder-digests-${{ matrix.variant }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Combine the per-arch builder images into one manifest per variant and apply
-  # tags. The `default` variant is multi-arch (amd64+arm64) under the primary
-  # tags; each compat variant is amd64-only under suffixed tags.
-  merge-builder-image:
-
-    needs: [setup, build-builder-image]
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: builder-digests-${{ matrix.variant }}-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
-        with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  merge-builder-default:
+    needs: build-builder-default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
-          # Suffix every tag for compat variants (empty for the default variant).
-          # onlatest=true so :latest also becomes :latest-x86_64_v2, etc.
-          flavor: |
-            suffix=${{ matrix.suffix }},onlatest=true
-          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
-          # (edge, sha, branch, monthly schedule, version semver) is restricted to
-          # the default variant. The `variant=='default' && '{{is_default_branch}}'`
-          # form ANDs the existing default-branch gate with the variant restriction
-          # (a non-default variant short-circuits to `false`).
           tags: |
-            # tag with date for scheduled jobs (YYYY-MM)
-            type=schedule,pattern={{date 'YYYY-MM'}},enable=${{ matrix.variant == 'default' }}
-            # set "latest" tag (the only tag compat variants receive)
+            type=schedule,pattern={{date 'YYYY-MM'}}
             type=raw,value=latest,enable={{is_default_branch}}
-            # always tag the most recent build as 'edge'
-            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
-            # short sha tag
-            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
-            # tag with semantic version
-            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
-            # tag with branch name
-            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
+            type=raw,value=edge
+            type=sha,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch,enable={{is_default_branch}}
+      - uses: ./.github/actions/merge-digests
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          artifact-pattern: builder-digests-default-*
+          tags: ${{ steps.meta.outputs.tags }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:edge
+          tolerant: 'false'
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}@sha256:%s ' *)
+  # ---- Builder image: compat variants (amd64-only, suffixed `latest`) ----
 
-      - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:edge${{ matrix.suffix }}
-
-  # Build the final image per architecture, each FROM the matching-arch builder,
-  # pushing by digest; then merge into a multi-arch manifest.
-  build-final-image:
-
-    needs: [setup, merge-builder-image]
-    if: needs.merge-builder-image.result == 'success'
-
+  build-builder-compat:
+    needs: setup
+    if: needs.setup.outputs.compat == 'true'
     strategy:
       fail-fast: false
       matrix:
-        # Each final image is built FROM the matching-variant builder tag, and
-        # compiles BOUT++/Hermes-3 at the same microarch (`target`).
-        include: ${{ fromJSON(needs.setup.outputs.final_matrix) }}
-
-    runs-on: ${{ matrix.runner }}
-
+        variant: [x86_64_v2, x86_64_v4]
+    runs-on: ubuntu-24.04
     steps:
-      # Fail fast (before checkout/build) if this runner can't run the code it is
-      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
-      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
-      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
-      - name: Require AVX-512 for x86_64_v4 build
-        if: matrix.target == 'x86_64_v4'
-        run: |
-          if ! grep -qw avx512f /proc/cpuinfo; then
-            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
-            exit 1
-          fi
-          echo "AVX-512 present; proceeding with x86_64_v4 build."
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+      # No AVX-512 preflight here: the builder build compiles the v4 Spack stack
+      # but never executes it, so it can't SIGILL on a non-AVX-512 runner. Only
+      # the final build (which runs the v4-compiled cmake) needs the check.
+      - uses: ./.github/actions/build-image
         with:
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          dockerfile: ${{ env.BUILDER_DOCKERFILE }}
+          platform: linux/amd64
+          cache-scope: builder-${{ matrix.variant }}-amd64
+          artifact-name: builder-digests-${{ matrix.variant }}-amd64
+          build-args: |
+            SPACK_OCI_USER=${{ github.actor }}
+            HERMES_TARGET=${{ matrix.variant }}
+          build-secrets: |
+            ghcr_token=${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
-
-      - name: Build and push image by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.FINAL_DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
-          build-args: |
-            BUILDER_TAG=${{ matrix.builder_tag }}
-            HERMES_TARGET=${{ matrix.target }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: final-digests-${{ matrix.variant }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-final-image:
-
-    needs: [setup, build-final-image]
-    # Run even when a compat build leg failed/was skipped (e.g. the x86_64_v4 leg
-    # lost the AVX-512 runner roll). Each variant is merged independently below,
-    # and a variant with no digests is skipped, so a missing v2/v4 image never
-    # blocks the default manifest.
-    if: always() && needs.setup.result == 'success'
+  merge-builder-compat:
+    needs: [setup, build-builder-compat]
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
-
+        variant: [x86_64_v2, x86_64_v4]
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        continue-on-error: true
+      - uses: actions/checkout@v4
         with:
-          path: /tmp/digests
-          pattern: final-digests-${{ matrix.variant }}-*
-          merge-multiple: true
-
-      # A compat variant whose build leg failed/was skipped has no digests. These
-      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
-      # rather than failing when there is nothing to assemble.
-      - name: Check for digests
-        id: digests
-        run: |
-          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/login-action@v3
+          fetch-depth: 1
+      - uses: ./.github/actions/merge-digests
         with:
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          artifact-pattern: builder-digests-${{ matrix.variant }}-*
+          tags: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:latest-${{ matrix.variant }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:latest-${{ matrix.variant }}
+          tolerant: 'false'
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  # ---- Final image: default variant (multi-arch, full tag set) ----
+
+  # Built FROM the builder just published under `edge` (always tagged, unlike
+  # `latest` which is default-branch-only, so this also works on releases).
+  build-final-default:
+    needs: merge-builder-default
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            target: x86_64_v3
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            target: aarch64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/build-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          dockerfile: ${{ env.FINAL_DOCKERFILE }}
+          platform: ${{ matrix.platform }}
+          cache-scope: final-default-${{ matrix.arch }}
+          artifact-name: final-digests-default-${{ matrix.arch }}
+          build-args: |
+            BUILDER_TAG=edge
+            HERMES_TARGET=${{ matrix.target }}
+            HERMES_BUILD_JOBS=2
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-final-default:
+    needs: build-final-default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Extract Docker metadata
         id: meta
-        if: steps.digests.outputs.present == 'true'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
-          # Suffix every tag for compat variants (empty for the default variant).
-          flavor: |
-            suffix=${{ matrix.suffix }},onlatest=true
-          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
-          # (edge, sha, branch, monthly schedule, version semver) is restricted to
-          # the default variant. The `variant=='default' && '{{is_default_branch}}'`
-          # form ANDs the existing default-branch gate with the variant restriction
-          # (a non-default variant short-circuits to `false`).
           tags: |
-            # tag with date for scheduled jobs (YYYY-MM)
-            type=schedule,pattern={{date 'YYYY-MM'}},enable=${{ matrix.variant == 'default' }}
-            # set "latest" tag (the only tag compat variants receive)
+            type=schedule,pattern={{date 'YYYY-MM'}}
             type=raw,value=latest,enable={{is_default_branch}}
-            # always tag the most recent build as 'edge'
-            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
-            # short sha tag
-            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
-            # tag with semantic version
-            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
-            # tag with branch name
-            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
+            type=raw,value=edge
+            type=sha,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch,enable={{is_default_branch}}
+      - uses: ./.github/actions/merge-digests
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          artifact-pattern: final-digests-default-*
+          tags: ${{ steps.meta.outputs.tags }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:edge
+          tolerant: 'false'
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest
-        if: steps.digests.outputs.present == 'true'
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
+  # ---- Final image: compat variants (amd64-only, suffixed `latest`) ----
 
-      - name: Inspect manifest
-        if: steps.digests.outputs.present == 'true'
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:edge${{ matrix.suffix }}
-
-  # Auto-retry when the x86_64_v4 final build fails purely because the job landed
-  # on a runner without AVX-512 (GitHub's fleet is mixed). Re-running the whole
-  # run re-rolls the runners; earlier stages (builder build/merge, default/v2
-  # final legs) restore from the gha layer cache. We use a FULL re-run rather
-  # than `--failed` because the latter's dependent-job rerun is unreliable for
-  # matrix jobs (actions/runner #2810), which would leave a retried v4 image
-  # built but never tagged. Bounded by github.run_attempt (3 attempts => 2
-  # automatic retries) so a genuinely-broken build can't loop; raise the `< 3` to
-  # allow more. A non-v4 failure is never retried, and once retries are exhausted
-  # the tolerant merge above still publishes the default/v2 images.
-  retry-v4-runner-lottery:
-    needs: build-final-image
-    if: failure() && fromJSON(github.run_attempt) < 6
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
+  # Built FROM the compat builder just published as `latest-<variant>` (compat
+  # builders only carry `latest`, and compat runs only on the default branch).
+  build-final-compat:
+    needs: [setup, merge-builder-compat]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [x86_64_v2, x86_64_v4]
+    runs-on: ubuntu-24.04
     steps:
-      - name: Re-run the workflow if only x86_64_v4 legs failed
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          failed=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
-            --paginate --jq '.jobs[] | select(.conclusion=="failure") | .name')
-          echo "Failed jobs on attempt ${{ github.run_attempt }}:"
-          printf '%s\n' "$failed"
-          if [ -z "$failed" ]; then
-            echo "No failed jobs detected; nothing to retry."
-            exit 0
-          fi
-          # Every matrix leg's job name embeds its matrix values, so an x86_64_v4
-          # leg's name contains "x86_64_v4". If any failed job does NOT, it's a
-          # real failure (default/v2), not the AVX-512 runner lottery.
-          if printf '%s\n' "$failed" | grep -qv 'x86_64_v4'; then
-            echo "A non-x86_64_v4 job failed; treating as a real failure and not retrying."
-            exit 0
-          fi
-          echo "Only x86_64_v4 leg(s) failed; re-running to re-roll the runner."
-          sleep 30
-          gh run rerun "${{ github.run_id }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/build-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          dockerfile: ${{ env.FINAL_DOCKERFILE }}
+          platform: linux/amd64
+          cache-scope: final-${{ matrix.variant }}-amd64
+          artifact-name: final-digests-${{ matrix.variant }}-amd64
+          require-avx512: ${{ matrix.variant == 'x86_64_v4' }}
+          build-args: |
+            BUILDER_TAG=latest-${{ matrix.variant }}
+            HERMES_TARGET=${{ matrix.variant }}
+            HERMES_BUILD_JOBS=2
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-final-compat:
+    needs: [setup, build-final-compat]
+    # Run even when a compat leg failed (e.g. the x86_64_v4 AVX-512 runner roll):
+    # merge-digests is tolerant, so a missing variant is skipped and the others
+    # still publish.
+    if: always() && needs.setup.outputs.compat == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [x86_64_v2, x86_64_v4]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/merge-digests
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          artifact-pattern: final-digests-${{ matrix.variant }}-*
+          tags: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:latest-${{ matrix.variant }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:latest-${{ matrix.variant }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  # NOTE: the x86_64_v4 AVX-512 runner-lottery auto-retry lives in the separate
+  # retry-v4.yml workflow (triggered on workflow_run: completed), because
+  # `gh run rerun` requires the target run to have finished — a job inside the
+  # run can't re-run its own still-in-progress run.

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -59,16 +59,19 @@ jobs:
           builder='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","target":"x86_64_v4"}
           ]'
           final='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"edge","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"edge","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"edge-x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","builder_tag":"edge-x86_64_v4","target":"x86_64_v4"}
           ]'
           merge='[
             {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"}
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
+            {"variant":"x86_64_v4","suffix":"-x86_64_v4"}
           ]'
 
           # Keep only the default variant when compat builds are skipped.

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,8 +1,8 @@
 name: Build hermes-3 Docker image
 
-# Configures this workflow to run every time a change is pushed to the master branch,
-# when a release is released (so versioned image tags are published), or when
-# manually triggered.
+# Runs on every push to master, on release, or when manually triggered. The
+# default variant is built multi-arch and gets the full tag set; the compat
+# variants are built in separate jobs and only ever carry a suffixed `latest`.
 on:
   push:
     branches:
@@ -29,255 +29,147 @@ env:
 
 jobs:
 
-  # Compute the build matrices. Compat variants only
-  # ever carry the `latest` tag, published on the default branch only. On events
-  # where `latest` won't be applied (releases, whose ref is a tag; a dispatch
-  # from a non-default branch) the compat builds would produce no tag, so drop
-  # them and build the default variant alone.
+  # Compat variants only carry `latest` (default branch only), so skip them on
+  # events that won't publish it: releases (tag ref) or a dispatch off the
+  # default branch.
   setup:
     runs-on: ubuntu-latest
     outputs:
-      final_matrix: ${{ steps.gen.outputs.final_matrix }}
-      merge_matrix: ${{ steps.gen.outputs.merge_matrix }}
+      compat: ${{ steps.gen.outputs.compat }}
     steps:
-      - name: Compute matrices (include compat variants only when publishing latest)
+      - name: Decide whether to build compat variants
         id: gen
         run: |
           case "${{ github.event_name }}" in
-            release)      compat=false ;;
-            schedule|push) compat=true ;;
-            *)  # workflow_dispatch etc.: only when on the default branch
-              if [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ]; then
-                compat=true
-              else
-                compat=false
-              fi ;;
+            push)    compat=true ;;
+            release) compat=false ;;
+            *) [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ] \
+                 && compat=true || compat=false ;;
           esac
+          echo "compat=${compat}" >> "$GITHUB_OUTPUT"
           echo "Build compat variants: ${compat}"
 
-          final='[
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"latest","target":"x86_64_v3"},
-            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"latest","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","builder_tag":"latest-x86_64_v4","target":"x86_64_v4"}
-          ]'
-          merge='[
-            {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
-            {"variant":"x86_64_v4","suffix":"-x86_64_v4"}
-          ]'
+  # ---- Default variant (multi-arch, full tag set) ----
 
-          # Keep only the default variant when compat builds are skipped.
-          f='if $c=="true" then . else map(select(.variant=="default")) end'
-          {
-            echo "final_matrix=$(jq -c --arg c "$compat" "$f" <<<"$final")"
-            echo "merge_matrix=$(jq -c --arg c "$compat" "$f" <<<"$merge")"
-          } >> "$GITHUB_OUTPUT"
-
-  # Build the final image once per architecture on a native runner, pushing each
-  # by digest only. The merge job assembles them into a manifest per variant.
-  # Each is built FROM the matching-variant builder tag.
-  build-final-image:
-
-    needs: setup
+  build-default:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.setup.outputs.final_matrix) }}
-
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            target: x86_64_v3
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+            target: aarch64
     runs-on: ${{ matrix.runner }}
-
     steps:
-      # Fail fast (before checkout/build) if this runner can't run the code it is
-      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
-      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
-      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
-      - name: Require AVX-512 for x86_64_v4 build
-        if: matrix.target == 'x86_64_v4'
-        run: |
-          if ! grep -qw avx512f /proc/cpuinfo; then
-            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
-            exit 1
-          fi
-          echo "AVX-512 present; proceeding with x86_64_v4 build."
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+      - uses: ./.github/actions/build-image
         with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          dockerfile: ${{ env.DOCKERFILE }}
+          platform: ${{ matrix.platform }}
+          cache-scope: final-default-${{ matrix.arch }}
+          artifact-name: final-digests-default-${{ matrix.arch }}
+          build-args: |
+            BUILDER_TAG=latest
+            HERMES_TARGET=${{ matrix.target }}
+            HERMES_BUILD_JOBS=2
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+  merge-default:
+    needs: build-default
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push image by digest
-        id: build
-        uses: docker/build-push-action@v6
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=edge
+            type=sha,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch,enable={{is_default_branch}}
+      - uses: ./.github/actions/merge-digests
         with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
-          build-args: |
-            BUILDER_TAG=${{ matrix.builder_tag }}
-            HERMES_TARGET=${{ matrix.target }}
-            HERMES_BUILD_JOBS=2
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          artifact-pattern: final-digests-default-*
+          tags: ${{ steps.meta.outputs.tags }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge
+          tolerant: 'false'
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+  # ---- Compat variants (amd64-only, suffixed `latest` only) ----
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: final-digests-${{ matrix.variant }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Combine the per-arch images into one manifest per variant and apply tags.
-  merge-final-image:
-
-    needs: [setup, build-final-image]
-    # Run even when a compat build leg failed/was skipped (e.g. the x86_64_v4 leg
-    # lost the AVX-512 runner roll). Each variant is merged independently below,
-    # and a variant with no digests is skipped, so a missing v2/v4 image never
-    # blocks the default manifest.
-    if: always() && needs.setup.result == 'success'
-    runs-on: ubuntu-latest
-
+  build-compat:
+    needs: setup
+    if: needs.setup.outputs.compat == 'true'
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
-
+        variant: [x86_64_v2, x86_64_v4]
+    runs-on: ubuntu-24.04
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        continue-on-error: true
+      - uses: actions/checkout@v4
         with:
-          path: /tmp/digests
-          pattern: final-digests-${{ matrix.variant }}-*
-          merge-multiple: true
-
-      # A compat variant whose build leg failed/was skipped has no digests. These
-      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
-      # rather than failing when there is nothing to assemble.
-      - name: Check for digests
-        id: digests
-        run: |
-          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/login-action@v3
+          fetch-depth: 1
+      - uses: ./.github/actions/build-image
         with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          dockerfile: ${{ env.DOCKERFILE }}
+          platform: linux/amd64
+          cache-scope: final-${{ matrix.variant }}-amd64
+          artifact-name: final-digests-${{ matrix.variant }}-amd64
+          require-avx512: ${{ matrix.variant == 'x86_64_v4' }}
+          build-args: |
+            BUILDER_TAG=latest-${{ matrix.variant }}
+            HERMES_TARGET=${{ matrix.variant }}
+            HERMES_BUILD_JOBS=2
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Suffix every tag for compat variants (empty for the default variant).
-          flavor: |
-            suffix=${{ matrix.suffix }},onlatest=true
-          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
-          # (edge, sha, branch, version semver) is restricted to the default
-          # variant. The `variant=='default' && '{{is_default_branch}}'` form ANDs
-          # the existing default-branch gate with the variant restriction (a
-          # non-default variant short-circuits to `false`).
-          tags: |
-            # set "latest" tag (the only tag compat variants receive)
-            type=raw,value=latest,enable={{is_default_branch}}
-            # always tag the most recent build as 'edge'
-            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
-            # short sha tag
-            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
-            # tag with semantic version
-            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
-            # tag with branch name
-            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
-
-      - name: Create manifest
-        if: steps.digests.outputs.present == 'true'
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect manifest
-        if: steps.digests.outputs.present == 'true'
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge${{ matrix.suffix }}
-
-  # Auto-retry when the x86_64_v4 build fails purely because the job landed on a
-  # runner without AVX-512 (GitHub's fleet is mixed). Re-running the whole run
-  # re-rolls the runners; the default/v2 legs restore from the gha layer cache so
-  # the re-run is cheap. We use a FULL re-run rather than `--failed` because the
-  # latter's dependent-job rerun is unreliable for matrix jobs (actions/runner
-  # #2810), which would leave a retried v4 image built but never tagged.
-  # Bounded by github.run_attempt (3 attempts => 2 automatic retries) so a
-  # genuinely-broken build can't loop; raise the `< 3` to allow more. A non-v4
-  # failure is never retried, and once retries are exhausted the tolerant merge
-  # above still publishes the default/v2 images.
-  retry-v4-runner-lottery:
-    needs: build-final-image
-    if: failure() && fromJSON(github.run_attempt) < 6
+  merge-compat:
+    needs: [setup, build-compat]
+    # Run even when a compat leg failed (e.g. the x86_64_v4 AVX-512 runner roll):
+    # merge-digests is tolerant, so a missing variant is skipped and the others
+    # still publish.
+    if: always() && needs.setup.outputs.compat == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [x86_64_v2, x86_64_v4]
     steps:
-      - name: Re-run the workflow if only x86_64_v4 legs failed
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          failed=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
-            --paginate --jq '.jobs[] | select(.conclusion=="failure") | .name')
-          echo "Failed jobs on attempt ${{ github.run_attempt }}:"
-          printf '%s\n' "$failed"
-          if [ -z "$failed" ]; then
-            echo "No failed jobs detected; nothing to retry."
-            exit 0
-          fi
-          # Every matrix leg's job name embeds its matrix values, so an x86_64_v4
-          # leg's name contains "x86_64_v4". If any failed job does NOT, it's a
-          # real failure (default/v2), not the AVX-512 runner lottery.
-          if printf '%s\n' "$failed" | grep -qv 'x86_64_v4'; then
-            echo "A non-x86_64_v4 job failed; treating as a real failure and not retrying."
-            exit 0
-          fi
-          echo "Only x86_64_v4 leg(s) failed; re-running to re-roll the runner."
-          sleep 30
-          gh run rerun "${{ github.run_id }}"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/merge-digests
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          artifact-pattern: final-digests-${{ matrix.variant }}-*
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.variant }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.variant }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  # NOTE: the x86_64_v4 AVX-512 runner-lottery auto-retry lives in the separate
+  # retry-v4.yml workflow (triggered on workflow_run: completed), because
+  # `gh run rerun` requires the target run to have finished — a job inside the
+  # run can't re-run its own still-in-progress run.

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -36,13 +36,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each final image is built FROM the matching-variant builder tag. The
+        # `default` variant is multi-arch; compat variants are amd64-only and
+        # get suffixed tags (e.g. :latest-x86_64_v2).
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
+            variant: default
+            builder_tag: latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
+            variant: default
+            builder_tag: latest
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v2
+            builder_tag: latest-x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v1
+            builder_tag: latest-x86_64_v1
 
     runs-on: ${{ matrix.runner }}
 
@@ -76,10 +93,10 @@ jobs:
           file: ${{ env.DOCKERFILE }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=final-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=final-${{ matrix.arch }}
+          cache-from: type=gha,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
-            BUILDER_TAG=latest
+            BUILDER_TAG=${{ matrix.builder_tag }}
             HERMES_BUILD_JOBS=2
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
@@ -92,23 +109,34 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: final-digests-${{ matrix.arch }}
+          name: final-digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  # Combine the per-arch images into one multi-arch manifest and apply tags.
+  # Combine the per-arch images into one manifest per variant and apply tags.
   merge-final-image:
 
     needs: build-final-image
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            suffix: ''
+          - variant: x86_64_v2
+            suffix: -x86_64_v2
+          - variant: x86_64_v1
+            suffix: -x86_64_v1
 
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: final-digests-*
+          pattern: final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -126,6 +154,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Suffix every tag for compat variants (empty for the default variant).
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
           tags: |
             # set "latest" tag
             type=raw,value=latest,enable={{is_default_branch}}
@@ -139,7 +170,7 @@ jobs:
             # tag with branch name
             type=ref,event=branch,enable={{is_default_branch}}
 
-      - name: Create multi-arch manifest
+      - name: Create manifest
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -147,4 +178,4 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge${{ matrix.suffix }}

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -58,11 +58,13 @@ jobs:
           final='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"latest","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"latest","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v4","builder_tag":"latest-x86_64_v4","target":"x86_64_v4"}
           ]'
           merge='[
             {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"}
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
+            {"variant":"x86_64_v4","suffix":"-x86_64_v4"}
           ]'
 
           # Keep only the default variant when compat builds are skipped.

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
 
-  # Compute the build matrices. Compat variants (x86_64_v2 / x86_64_v1) only
+  # Compute the build matrices. Compat variants only
   # ever carry the `latest` tag, published on the default branch only. On events
   # where `latest` won't be applied (releases, whose ref is a tag; a dispatch
   # from a non-default branch) the compat builds would produce no tag, so drop
@@ -58,13 +58,11 @@ jobs:
           final='[
             {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"latest","target":"x86_64_v3"},
             {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"latest","target":"aarch64"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"},
-            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","builder_tag":"latest-x86_64_v1","target":"x86_64"}
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"}
           ]'
           merge='[
             {"variant":"default","suffix":""},
-            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
-            {"variant":"x86_64_v1","suffix":"-x86_64_v1"}
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"}
           ]'
 
           # Keep only the default variant when compat builds are skipped.

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -45,21 +45,25 @@ jobs:
             arch: amd64
             variant: default
             builder_tag: latest
+            target: x86_64_v3
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
             variant: default
             builder_tag: latest
+            target: aarch64
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
             variant: x86_64_v2
             builder_tag: latest-x86_64_v2
+            target: x86_64_v2
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
             variant: x86_64_v1
             builder_tag: latest-x86_64_v1
+            target: x86_64
 
     runs-on: ${{ matrix.runner }}
 
@@ -97,6 +101,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=final-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
             BUILDER_TAG=${{ matrix.builder_tag }}
+            HERMES_TARGET=${{ matrix.target }}
             HERMES_BUILD_JOBS=2
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -29,41 +29,61 @@ env:
 
 jobs:
 
+  # Compute the build matrices. Compat variants (x86_64_v2 / x86_64_v1) only
+  # ever carry the `latest` tag, published on the default branch only. On events
+  # where `latest` won't be applied (releases, whose ref is a tag; a dispatch
+  # from a non-default branch) the compat builds would produce no tag, so drop
+  # them and build the default variant alone.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      final_matrix: ${{ steps.gen.outputs.final_matrix }}
+      merge_matrix: ${{ steps.gen.outputs.merge_matrix }}
+    steps:
+      - name: Compute matrices (include compat variants only when publishing latest)
+        id: gen
+        run: |
+          case "${{ github.event_name }}" in
+            release)      compat=false ;;
+            schedule|push) compat=true ;;
+            *)  # workflow_dispatch etc.: only when on the default branch
+              if [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ]; then
+                compat=true
+              else
+                compat=false
+              fi ;;
+          esac
+          echo "Build compat variants: ${compat}"
+
+          final='[
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"default","builder_tag":"latest","target":"x86_64_v3"},
+            {"platform":"linux/arm64","runner":"ubuntu-24.04-arm","arch":"arm64","variant":"default","builder_tag":"latest","target":"aarch64"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v2","builder_tag":"latest-x86_64_v2","target":"x86_64_v2"},
+            {"platform":"linux/amd64","runner":"ubuntu-24.04","arch":"amd64","variant":"x86_64_v1","builder_tag":"latest-x86_64_v1","target":"x86_64"}
+          ]'
+          merge='[
+            {"variant":"default","suffix":""},
+            {"variant":"x86_64_v2","suffix":"-x86_64_v2"},
+            {"variant":"x86_64_v1","suffix":"-x86_64_v1"}
+          ]'
+
+          # Keep only the default variant when compat builds are skipped.
+          f='if $c=="true" then . else map(select(.variant=="default")) end'
+          {
+            echo "final_matrix=$(jq -c --arg c "$compat" "$f" <<<"$final")"
+            echo "merge_matrix=$(jq -c --arg c "$compat" "$f" <<<"$merge")"
+          } >> "$GITHUB_OUTPUT"
+
   # Build the final image once per architecture on a native runner, pushing each
-  # by digest only. The merge job assembles them into a multi-arch manifest.
+  # by digest only. The merge job assembles them into a manifest per variant.
+  # Each is built FROM the matching-variant builder tag.
   build-final-image:
 
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
-        # Each final image is built FROM the matching-variant builder tag. The
-        # `default` variant is multi-arch; compat variants are amd64-only and
-        # get suffixed tags (e.g. :latest-x86_64_v2).
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: default
-            builder_tag: latest
-            target: x86_64_v3
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-            variant: default
-            builder_tag: latest
-            target: aarch64
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v2
-            builder_tag: latest-x86_64_v2
-            target: x86_64_v2
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v1
-            builder_tag: latest-x86_64_v1
-            target: x86_64
+        include: ${{ fromJSON(needs.setup.outputs.final_matrix) }}
 
     runs-on: ${{ matrix.runner }}
 
@@ -122,19 +142,13 @@ jobs:
   # Combine the per-arch images into one manifest per variant and apply tags.
   merge-final-image:
 
-    needs: build-final-image
+    needs: [setup, build-final-image]
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: default
-            suffix: ''
-          - variant: x86_64_v2
-            suffix: -x86_64_v2
-          - variant: x86_64_v1
-            suffix: -x86_64_v1
+        include: ${{ fromJSON(needs.setup.outputs.merge_matrix) }}
 
     steps:
       - name: Download digests
@@ -162,18 +176,23 @@ jobs:
           # Suffix every tag for compat variants (empty for the default variant).
           flavor: |
             suffix=${{ matrix.suffix }},onlatest=true
+          # Compat variants get ONLY the `latest` tag (suffixed). Every other tag
+          # (edge, sha, branch, version semver) is restricted to the default
+          # variant. The `variant=='default' && '{{is_default_branch}}'` form ANDs
+          # the existing default-branch gate with the variant restriction (a
+          # non-default variant short-circuits to `false`).
           tags: |
-            # set "latest" tag
+            # set "latest" tag (the only tag compat variants receive)
             type=raw,value=latest,enable={{is_default_branch}}
             # always tag the most recent build as 'edge'
-            type=raw,value=edge
+            type=raw,value=edge,enable=${{ matrix.variant == 'default' }}
             # short sha tag
-            type=sha,enable={{is_default_branch}}
+            type=sha,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
             # tag with semantic version
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{ matrix.variant == 'default' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.variant == 'default' }}
             # tag with branch name
-            type=ref,event=branch,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
 
       - name: Create manifest
         working-directory: /tmp/digests

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -88,6 +88,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # Fail fast (before checkout/build) if this runner can't run the code it is
+      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
+      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
+      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
+      - name: Require AVX-512 for x86_64_v4 build
+        if: matrix.target == 'x86_64_v4'
+        run: |
+          if ! grep -qw avx512f /proc/cpuinfo; then
+            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
+            exit 1
+          fi
+          echo "AVX-512 present; proceeding with x86_64_v4 build."
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -143,6 +156,11 @@ jobs:
   merge-final-image:
 
     needs: [setup, build-final-image]
+    # Run even when a compat build leg failed/was skipped (e.g. the x86_64_v4 leg
+    # lost the AVX-512 runner roll). Each variant is merged independently below,
+    # and a variant with no digests is skipped, so a missing v2/v4 image never
+    # blocks the default manifest.
+    if: always() && needs.setup.result == 'success'
     runs-on: ubuntu-latest
 
     strategy:
@@ -153,15 +171,31 @@ jobs:
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: /tmp/digests
           pattern: final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
+      # A compat variant whose build leg failed/was skipped has no digests. These
+      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
+      # rather than failing when there is nothing to assemble.
+      - name: Check for digests
+        id: digests
+        run: |
+          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.digests.outputs.present == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to registry ${{ env.REGISTRY }}
+        if: steps.digests.outputs.present == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -170,6 +204,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
+        if: steps.digests.outputs.present == 'true'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -195,6 +230,7 @@ jobs:
             type=ref,event=branch,enable=${{ matrix.variant == 'default' && '{{is_default_branch}}' }}
 
       - name: Create manifest
+        if: steps.digests.outputs.present == 'true'
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -202,4 +238,46 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
+        if: steps.digests.outputs.present == 'true'
         run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge${{ matrix.suffix }}
+
+  # Auto-retry when the x86_64_v4 build fails purely because the job landed on a
+  # runner without AVX-512 (GitHub's fleet is mixed). Re-running the whole run
+  # re-rolls the runners; the default/v2 legs restore from the gha layer cache so
+  # the re-run is cheap. We use a FULL re-run rather than `--failed` because the
+  # latter's dependent-job rerun is unreliable for matrix jobs (actions/runner
+  # #2810), which would leave a retried v4 image built but never tagged.
+  # Bounded by github.run_attempt (3 attempts => 2 automatic retries) so a
+  # genuinely-broken build can't loop; raise the `< 3` to allow more. A non-v4
+  # failure is never retried, and once retries are exhausted the tolerant merge
+  # above still publishes the default/v2 images.
+  retry-v4-runner-lottery:
+    needs: build-final-image
+    if: failure() && fromJSON(github.run_attempt) < 6
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-run the workflow if only x86_64_v4 legs failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          failed=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
+            --paginate --jq '.jobs[] | select(.conclusion=="failure") | .name')
+          echo "Failed jobs on attempt ${{ github.run_attempt }}:"
+          printf '%s\n' "$failed"
+          if [ -z "$failed" ]; then
+            echo "No failed jobs detected; nothing to retry."
+            exit 0
+          fi
+          # Every matrix leg's job name embeds its matrix values, so an x86_64_v4
+          # leg's name contains "x86_64_v4". If any failed job does NOT, it's a
+          # real failure (default/v2), not the AVX-512 runner lottery.
+          if printf '%s\n' "$failed" | grep -qv 'x86_64_v4'; then
+            echo "A non-x86_64_v4 job failed; treating as a real failure and not retrying."
+            exit 0
+          fi
+          echo "Only x86_64_v4 leg(s) failed; re-running to re-roll the runner."
+          sleep 30
+          gh run rerun "${{ github.run_id }}"

--- a/.github/workflows/retry-v4.yml
+++ b/.github/workflows/retry-v4.yml
@@ -1,0 +1,68 @@
+name: Retry x86_64_v4 runner lottery
+
+# The x86_64_v4 final image only runs on an AVX-512 CPU, and GitHub's runner
+# fleet is mixed, so a build run can fail purely because the v4 leg landed on a
+# runner without AVX-512. When a run of the build workflows fails with ONLY
+# x86_64_v4 leg(s) failing, re-run it to re-roll the runners.
+#
+# This is a separate workflow_run-triggered workflow rather than a job inside
+# the build run: `gh run rerun` requires the target run to have COMPLETED, so a
+# job cannot re-run its own still-in-progress run. workflow_run fires after the
+# run finishes, when the re-run API is valid. A FULL re-run (not `--failed`) is
+# used because `--failed`'s dependent-job rerun is unreliable for matrix jobs
+# (actions/runner #2810), which would leave a retried v4 image built but never
+# tagged; unaffected legs restore from the gha layer cache so it stays cheap.
+#
+# NOTE: workflow_run uses the workflow definition on the default branch, so this
+# only takes effect once merged to the default branch.
+on:
+  workflow_run:
+    workflows:
+      - "Build hermes-3 Docker image"
+      - "Build hermes-3-builder and hermes-3 Docker images"
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    # Only failed runs, and bounded so a genuinely-broken build can't loop
+    # (10 attempts => up to 9 automatic retries; raise the `< 10` to allow more).
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run the run if only x86_64_v4 legs failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          failed=$(gh api \
+            "repos/${GH_REPO}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/jobs" \
+            --paginate --jq '.jobs[] | select(.conclusion=="failure") | .name')
+          echo "Failed jobs on attempt ${ATTEMPT} of run ${RUN_ID}:"
+          printf '%s\n' "$failed"
+          if [ -z "$failed" ]; then
+            echo "Run failed but no failed jobs found (cancelled / startup failure?); not retrying."
+            exit 0
+          fi
+          # Each matrix leg's job name embeds its matrix values, so an x86_64_v4
+          # leg's name contains "x86_64_v4". If any failed job does NOT, it's a
+          # real failure (not the AVX-512 runner lottery), so don't retry.
+          if printf '%s\n' "$failed" | grep -qv 'x86_64_v4'; then
+            echo "A non-x86_64_v4 job failed; treating as a real failure and not retrying."
+            exit 0
+          fi
+          # The lottery only affects the FINAL image build (which runs the
+          # v4-compiled cmake). A v4 *builder* failure is deterministic, so
+          # retrying won't help; builder-stage job names contain "builder".
+          if printf '%s\n' "$failed" | grep -q 'builder'; then
+            echo "A builder-stage job failed; deterministic, not the runner lottery, not retrying."
+            exit 0
+          fi
+          echo "Only x86_64_v4 final leg(s) failed; re-running to re-roll the runner."
+          gh run rerun "${RUN_ID}"

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -27,6 +27,7 @@ on:
       - 'docker/**'
       - '.github/workflows/test_docker_build.yml'
       - '.github/workflows/build*image.yml'
+      - '.github/actions/**'
   workflow_dispatch:  # Allows manual triggering
 
 permissions:
@@ -74,6 +75,7 @@ jobs:
               - 'docker/image_ingredients/spack_config.yaml'
               - 'docker/image_ingredients/docker_entrypoint.sh'
               - '.github/workflows/test_docker_build.yml'
+              - '.github/actions/**'
             # Files that affect the final hermes-3 image build.
             final:
               - 'docker/hermes-3.dockerfile'
@@ -83,6 +85,7 @@ jobs:
               - 'docker/image_ingredients/docker_image_commands.sh'
               - 'docker/image_ingredients/docker_entrypoint.sh'
               - '.github/workflows/test_docker_build.yml'
+              - '.github/actions/**'
             # Files that affect the jupyter image build. This image is built
             # FROM jupyter/scipy-notebook and is independent of the
             # builder->final chain.
@@ -92,8 +95,8 @@ jobs:
 
   # ---- Builder image (only when the builder or its deps changed) ----
 
-  # Build the builder image once per architecture on a native runner, pushing
-  # each by digest only.
+  # Build the builder image once per architecture/variant, pushing each by
+  # digest only.
   build-builder:
     needs: changes
     # Publishing needs registry write access, which fork PRs don't have, so skip
@@ -106,8 +109,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Default (amd64 v3 + arm64) plus the compat variants,
-        # so the compat-variant build is exercised end to end here too.
+        # Default (amd64 v3 + arm64) plus the compat variants, so the
+        # compat-variant build is exercised end to end here too.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
@@ -131,59 +134,24 @@ jobs:
             target: x86_64_v4
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+      - uses: ./.github/actions/build-image
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
-
-      - name: Build and push builder image by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.BUILDER_DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=exp-builder-${{ matrix.variant }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=exp-builder-${{ matrix.variant }}-${{ matrix.arch }}
-          # Credentials for the self-hosted OCI Spack build cache, so the build
-          # can pull previously-compiled binaries and push newly-built ones.
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          dockerfile: ${{ env.BUILDER_DOCKERFILE }}
+          platform: ${{ matrix.platform }}
+          cache-scope: exp-builder-${{ matrix.variant }}-${{ matrix.arch }}
+          artifact-name: exp-builder-digests-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
             SPACK_OCI_USER=${{ github.actor }}
             HERMES_TARGET=${{ matrix.target }}
-          secrets: |
+          build-secrets: |
             ghcr_token=${{ secrets.GITHUB_TOKEN }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: exp-builder-digests-${{ matrix.variant }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   # Combine the per-arch builder images into the experimental tag(s): a
   # multi-arch 'default' tag plus the suffixed compat tags.
@@ -202,39 +170,26 @@ jobs:
           - variant: x86_64_v4
             suffix: -x86_64_v4
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
         with:
-          path: /tmp/digests
-          pattern: exp-builder-digests-${{ matrix.variant }}-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+          fetch-depth: 1
+      - uses: ./.github/actions/merge-digests
         with:
+          image: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}
+          artifact-pattern: exp-builder-digests-${{ matrix.variant }}-*
+          tags: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
+          tolerant: 'false'
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create experimental builder manifest
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }} \
-            $(printf '${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
-
   # ---- Final image ----
 
-  # Build the final image once per architecture, FROM the experimental builder,
-  # pushing each by digest only. Runs whenever the builder OR the final image is
-  # affected. If the builder changed, this waits for the experimental builder to
-  # be (re)published first; otherwise it uses the one from a previous run.
+  # Build the final image once per architecture/variant, FROM the experimental
+  # builder, pushing each by digest only. Runs whenever the builder OR the final
+  # image is affected. If the builder changed, this waits for the experimental
+  # builder to be (re)published first; otherwise it uses the one from a previous run.
   build-final:
     needs: [changes, merge-builder]
     # Runs when the builder changed (only after the experimental builder is
@@ -281,78 +236,31 @@ jobs:
             target: x86_64_v4
     runs-on: ${{ matrix.runner }}
     steps:
-      # Fail fast (before checkout/build) if this runner can't run the code it is
-      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
-      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
-      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
-      - name: Require AVX-512 for x86_64_v4 build
-        if: matrix.target == 'x86_64_v4'
-        run: |
-          if ! grep -qw avx512f /proc/cpuinfo; then
-            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
-            exit 1
-          fi
-          echo "AVX-512 present; proceeding with x86_64_v4 build."
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+      - uses: ./.github/actions/build-image
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
-
-      - name: Build and push final image by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.FINAL_DOCKERFILE }}
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=exp-final-${{ matrix.variant }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=exp-final-${{ matrix.variant }}-${{ matrix.arch }}
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          dockerfile: ${{ env.FINAL_DOCKERFILE }}
+          platform: ${{ matrix.platform }}
+          cache-scope: exp-final-${{ matrix.variant }}-${{ matrix.arch }}
+          artifact-name: exp-final-digests-${{ matrix.variant }}-${{ matrix.arch }}
+          require-avx512: ${{ matrix.variant == 'x86_64_v4' }}
           build-args: |
             BUILDER_TAG=${{ env.EXPERIMENTAL_TAG }}${{ matrix.builder_suffix }}
             HERMES_TARGET=${{ matrix.target }}
             HERMES_BUILD_JOBS=2
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: exp-final-digests-${{ matrix.variant }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   # Combine the per-arch final images into the experimental tag(s): a multi-arch
-  # 'default' tag plus the suffixed compat tags.
+  # 'default' tag plus the suffixed compat tags. Runs when build-final actually
+  # ran (success or partial failure such as the x86_64_v4 AVX-512 runner roll),
+  # but not when it was skipped; a variant with no digests is skipped.
   merge-final:
     needs: build-final
-    # Run when build-final actually ran (success OR a partial failure such as the
-    # x86_64_v4 leg losing the AVX-512 runner roll), but not when it was skipped.
-    # Each variant is merged independently and a variant with no digests is
-    # skipped, so a missing v2/v4 image never blocks the default manifest.
     if: always() && (needs.build-final.result == 'success' || needs.build-final.result == 'failure')
     runs-on: ubuntu-latest
     strategy:
@@ -366,50 +274,18 @@ jobs:
           - variant: x86_64_v4
             suffix: -x86_64_v4
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        continue-on-error: true
+      - uses: actions/checkout@v4
         with:
-          path: /tmp/digests
-          pattern: exp-final-digests-${{ matrix.variant }}-*
-          merge-multiple: true
-
-      # A compat variant whose build leg failed/was skipped has no digests. These
-      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
-      # rather than failing when there is nothing to assemble.
-      - name: Check for digests
-        id: digests
-        run: |
-          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to registry ${{ env.REGISTRY }}
-        if: steps.digests.outputs.present == 'true'
-        uses: docker/login-action@v3
+          fetch-depth: 1
+      - uses: ./.github/actions/merge-digests
         with:
+          image: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}
+          artifact-pattern: exp-final-digests-${{ matrix.variant }}-*
+          tags: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
+          inspect-tag: ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create experimental final manifest
-        if: steps.digests.outputs.present == 'true'
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }} \
-            $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Inspect manifest
-        if: steps.digests.outputs.present == 'true'
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
 
   # ---- Jupyter image (only when the jupyter dockerfile changed) ----
 

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -106,8 +106,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Default (amd64 v3 + arm64) plus the x86_64_v2 / x86_64_v1 amd64 compat
-        # legs, so the compat-variant build is exercised end to end here too.
+        # Default (amd64 v3 + arm64) plus the compat variants,
+        # so the compat-variant build is exercised end to end here too.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
@@ -124,11 +124,6 @@ jobs:
             arch: amd64
             variant: x86_64_v2
             target: x86_64_v2
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v1
-            target: x86_64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -199,8 +194,6 @@ jobs:
             suffix: ''
           - variant: x86_64_v2
             suffix: -x86_64_v2
-          - variant: x86_64_v1
-            suffix: -x86_64_v1
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -273,12 +266,6 @@ jobs:
             variant: x86_64_v2
             builder_suffix: -x86_64_v2
             target: x86_64_v2
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-            arch: amd64
-            variant: x86_64_v1
-            builder_suffix: -x86_64_v1
-            target: x86_64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -346,8 +333,6 @@ jobs:
             suffix: ''
           - variant: x86_64_v2
             suffix: -x86_64_v2
-          - variant: x86_64_v1
-            suffix: -x86_64_v1
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -124,6 +124,11 @@ jobs:
             arch: amd64
             variant: x86_64_v2
             target: x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v4
+            target: x86_64_v4
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -194,6 +199,8 @@ jobs:
             suffix: ''
           - variant: x86_64_v2
             suffix: -x86_64_v2
+          - variant: x86_64_v4
+            suffix: -x86_64_v4
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -266,6 +273,12 @@ jobs:
             variant: x86_64_v2
             builder_suffix: -x86_64_v2
             target: x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v4
+            builder_suffix: -x86_64_v4
+            target: x86_64_v4
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -333,6 +346,8 @@ jobs:
             suffix: ''
           - variant: x86_64_v2
             suffix: -x86_64_v2
+          - variant: x86_64_v4
+            suffix: -x86_64_v4
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -106,13 +106,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Default (amd64 v3 + arm64) plus the x86_64_v2 / x86_64_v1 amd64 compat
+        # legs, so the compat-variant build is exercised end to end here too.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
+            variant: default
+            target: x86_64_v3
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
+            variant: default
+            target: aarch64
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v2
+            target: x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v1
+            target: x86_64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -144,12 +160,13 @@ jobs:
           file: ${{ env.BUILDER_DOCKERFILE }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=exp-builder-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=exp-builder-${{ matrix.arch }}
+          cache-from: type=gha,scope=exp-builder-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=exp-builder-${{ matrix.variant }}-${{ matrix.arch }}
           # Credentials for the self-hosted OCI Spack build cache, so the build
           # can pull previously-compiled binaries and push newly-built ones.
           build-args: |
             SPACK_OCI_USER=${{ github.actor }}
+            HERMES_TARGET=${{ matrix.target }}
           secrets: |
             ghcr_token=${{ secrets.GITHUB_TOKEN }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -163,22 +180,33 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: exp-builder-digests-${{ matrix.arch }}
+          name: exp-builder-digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  # Combine the per-arch builder images into the experimental multi-arch tag.
+  # Combine the per-arch builder images into the experimental tag(s): a
+  # multi-arch 'default' tag plus the suffixed compat tags.
   merge-builder:
     needs: [changes, build-builder]
     if: needs.changes.outputs.builder == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            suffix: ''
+          - variant: x86_64_v2
+            suffix: -x86_64_v2
+          - variant: x86_64_v1
+            suffix: -x86_64_v1
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: exp-builder-digests-*
+          pattern: exp-builder-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -195,11 +223,11 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }} \
+            -t ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }} \
             $(printf '${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.BUILDER_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
 
   # ---- Final image ----
 
@@ -224,13 +252,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each final image is built FROM the matching-variant experimental
+        # builder tag and compiled at the same microarch.
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
             arch: amd64
+            variant: default
+            builder_suffix: ''
+            target: x86_64_v3
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
+            variant: default
+            builder_suffix: ''
+            target: aarch64
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v2
+            builder_suffix: -x86_64_v2
+            target: x86_64_v2
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+            variant: x86_64_v1
+            builder_suffix: -x86_64_v1
+            target: x86_64
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -262,10 +310,11 @@ jobs:
           file: ${{ env.FINAL_DOCKERFILE }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=exp-final-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=exp-final-${{ matrix.arch }}
+          cache-from: type=gha,scope=exp-final-${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=exp-final-${{ matrix.variant }}-${{ matrix.arch }}
           build-args: |
-            BUILDER_TAG=${{ env.EXPERIMENTAL_TAG }}
+            BUILDER_TAG=${{ env.EXPERIMENTAL_TAG }}${{ matrix.builder_suffix }}
+            HERMES_TARGET=${{ matrix.target }}
             HERMES_BUILD_JOBS=2
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
@@ -278,22 +327,33 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: exp-final-digests-${{ matrix.arch }}
+          name: exp-final-digests-${{ matrix.variant }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-  # Combine the per-arch final images into the experimental multi-arch tag.
+  # Combine the per-arch final images into the experimental tag(s): a multi-arch
+  # 'default' tag plus the suffixed compat tags.
   merge-final:
     needs: build-final
     if: always() && needs.build-final.result == 'success'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            suffix: ''
+          - variant: x86_64_v2
+            suffix: -x86_64_v2
+          - variant: x86_64_v1
+            suffix: -x86_64_v1
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: exp-final-digests-*
+          pattern: exp-final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -310,11 +370,11 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }} \
+            -t ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }} \
             $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
 
   # ---- Jupyter image (only when the jupyter dockerfile changed) ----
 

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -281,6 +281,19 @@ jobs:
             target: x86_64_v4
     runs-on: ${{ matrix.runner }}
     steps:
+      # Fail fast (before checkout/build) if this runner can't run the code it is
+      # about to build. The x86_64_v4 variant targets AVX-512, and GitHub-hosted
+      # runners are a mixed fleet: on a CPU without AVX-512 the v4-compiled Spack
+      # cmake SIGILLs during configure. Re-running the job re-rolls the runner.
+      - name: Require AVX-512 for x86_64_v4 build
+        if: matrix.target == 'x86_64_v4'
+        run: |
+          if ! grep -qw avx512f /proc/cpuinfo; then
+            echo "::error::Runner CPU lacks AVX-512 (no avx512f in /proc/cpuinfo); the x86_64_v4 image built here would SIGILL. Re-run this job to land on an AVX-512-capable runner, or build it on AVX-512 hardware."
+            exit 1
+          fi
+          echo "AVX-512 present; proceeding with x86_64_v4 build."
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -336,7 +349,11 @@ jobs:
   # 'default' tag plus the suffixed compat tags.
   merge-final:
     needs: build-final
-    if: always() && needs.build-final.result == 'success'
+    # Run when build-final actually ran (success OR a partial failure such as the
+    # x86_64_v4 leg losing the AVX-512 runner roll), but not when it was skipped.
+    # Each variant is merged independently and a variant with no digests is
+    # skipped, so a missing v2/v4 image never blocks the default manifest.
+    if: always() && (needs.build-final.result == 'success' || needs.build-final.result == 'failure')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -351,15 +368,31 @@ jobs:
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           path: /tmp/digests
           pattern: exp-final-digests-${{ matrix.variant }}-*
           merge-multiple: true
 
+      # A compat variant whose build leg failed/was skipped has no digests. These
+      # single-arch variants aren't actually multi-arch-merged, so skip cleanly
+      # rather than failing when there is nothing to assemble.
+      - name: Check for digests
+        id: digests
+        run: |
+          if [ -n "$(ls -A /tmp/digests 2>/dev/null)" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No final-image digests for variant '${{ matrix.variant }}'; nothing to merge."
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.digests.outputs.present == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to registry ${{ env.REGISTRY }}
+        if: steps.digests.outputs.present == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -367,6 +400,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create experimental final manifest
+        if: steps.digests.outputs.present == 'true'
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
@@ -374,6 +408,7 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect manifest
+        if: steps.digests.outputs.present == 'true'
         run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.FINAL_IMAGE_NAME }}:${{ env.EXPERIMENTAL_TAG }}${{ matrix.suffix }}
 
   # ---- Jupyter image (only when the jupyter dockerfile changed) ----

--- a/docker/README.md
+++ b/docker/README.md
@@ -119,10 +119,9 @@ Each published image is compiled for a fixed microarchitecture, and that
 | --- | --- |
 | `hermes-3:latest` | `x86-64-v3` on amd64, `armv8-a` on arm64 |
 | `hermes-3:latest-x86_64_v2` | `x86-64-v2` (pre-Haswell / older amd64) |
-| `hermes-3:latest-x86_64_v1` | `x86-64` (maximally portable amd64 baseline) |
 
-The default `latest` targets `x86_64_v3` (AVX2/FMA); the `-x86_64_v2` and
-`-x86_64_v1` variants trade performance for compatibility with older CPUs. The
+The default `latest` targets `x86_64_v3` (AVX2/FMA); the `-x86_64_v2`
+variant trades performance for compatibility with older CPUs. The
 same `-march` applies to both the initial build *and* any in-container rebuild
 (`build_boutpp`, `build_hermes`, `build_both`), so a rebuild stays consistent
 with the image by default — you don't have to set anything.

--- a/docker/README.md
+++ b/docker/README.md
@@ -109,6 +109,34 @@ The same variable is also a build-arg for the image build itself
 (`docker build --build-arg HERMES_BUILD_JOBS=8 ...`), where it likewise defaults
 to `4`.
 
+## Compiler flags and the per-image `-march`
+
+Each published image is compiled for a fixed microarchitecture, and that
+`-march` is **baked into the image** at build time (recorded in
+`/etc/hermes-march`). The level depends on which tag you pull:
+
+| Image tag | Baked `-march` |
+| --- | --- |
+| `hermes-3:latest` | `x86-64-v3` on amd64, `armv8-a` on arm64 |
+| `hermes-3:latest-x86_64_v2` | `x86-64-v2` (pre-Haswell / older amd64) |
+| `hermes-3:latest-x86_64_v1` | `x86-64` (maximally portable amd64 baseline) |
+
+The default `latest` targets `x86_64_v3` (AVX2/FMA); the `-x86_64_v2` and
+`-x86_64_v1` variants trade performance for compatibility with older CPUs. The
+same `-march` applies to both the initial build *and* any in-container rebuild
+(`build_boutpp`, `build_hermes`, `build_both`), so a rebuild stays consistent
+with the image by default — you don't have to set anything.
+
+To add flags or retarget a rebuild, set `CMAKE_CXX_FLAGS` / `CMAKE_C_FLAGS`;
+they are **appended after** the baked `-march`. Because a later `-march` wins,
+this both adds flags and lets you change the target:
+
+* **Tune for your own CPU**: `CMAKE_CXX_FLAGS=-march=native ./run.sh build_both`
+* **Extra optimisation flags**: `CMAKE_CXX_FLAGS=-funroll-loops`
+* **Persistent value**: edit `.env` (`setup.sh` seeds both empty).
+
+Leave them empty (the default) to match the image you pulled.
+
 ## Overriding Default Builds using the `work` Folder
 
 The `work` folder on your local machine is mounted to the `/hermes_project/work` directory inside the Docker container. This allows you to override the default builds of BOUT++ and Hermes-3 that are included in the image by placing your own source code and configuration files within the `work` folder. The build scripts inside the container are designed to prioritize these files if they exist.

--- a/docker/README.md
+++ b/docker/README.md
@@ -119,9 +119,12 @@ Each published image is compiled for a fixed microarchitecture, and that
 | --- | --- |
 | `hermes-3:latest` | `x86-64-v3` on amd64, `armv8-a` on arm64 |
 | `hermes-3:latest-x86_64_v2` | `x86-64-v2` (pre-Haswell / older amd64) |
+| `hermes-3:latest-x86_64_v4` | `x86-64-v4` (AVX-512; Skylake-SP / Zen 4 and newer) |
 
 The default `latest` targets `x86_64_v3` (AVX2/FMA); the `-x86_64_v2`
-variant trades performance for compatibility with older CPUs. The
+variant trades performance for compatibility with older CPUs, while the
+`-x86_64_v4` variant adds AVX-512 for newer CPUs and will fault with an
+illegal instruction on hardware that lacks it. The
 same `-march` applies to both the initial build *and* any in-container rebuild
 (`build_boutpp`, `build_hermes`, `build_both`), so a rebuild stays consistent
 with the image by default — you don't have to set anything.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -33,6 +33,8 @@ services:
       - ${PWD}/work:/hermes_project/work
     environment:
     - HERMES_BUILD_JOBS=${HERMES_BUILD_JOBS:-4}
+    - CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS:-}
+    - CMAKE_C_FLAGS=${CMAKE_C_FLAGS:-}
     command: ["image", "build_hermes"]
   build_boutpp:
     # Rebuild BOUT++, using ./work/BOUT-dev if available
@@ -41,6 +43,8 @@ services:
       - ${PWD}/work:/hermes_project/work
     environment:
     - HERMES_BUILD_JOBS=${HERMES_BUILD_JOBS:-4}
+    - CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS:-}
+    - CMAKE_C_FLAGS=${CMAKE_C_FLAGS:-}
     command: ["image", "build_boutpp"]
   build_both:
     # Rebuild both hermes and BOUT++, using overrides
@@ -50,6 +54,8 @@ services:
       - ${PWD}/work:/hermes_project/work
     environment:
     - HERMES_BUILD_JOBS=${HERMES_BUILD_JOBS:-4}
+    - CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS:-}
+    - CMAKE_C_FLAGS=${CMAKE_C_FLAGS:-}
     command: ['image', "build_both"]
   hermes:
     # Run a hermes-3 case in

--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -76,19 +76,25 @@ RUN if [ -n "${GNU_MIRROR_URL}" ]; then \
 # exit code (so a late failure still caches most packages for the next run),
 # re-propagating the exit code so a failed build still fails CI. Without
 # credentials, build from source (plus any SPACK_INSTALL_EXTRA_ARGS).
+#
+# Compat (non-default HERMES_TARGET) builds concretize --fresh: reusing the
+# cache's default-target specs makes the compat target unsatisfiable. Binary
+# install/push still work, so repeat builds stay fast.
 RUN --mount=type=secret,id=ghcr_token \
     spack env activate . && \
+    INSTALL_ARGS="${SPACK_INSTALL_EXTRA_ARGS}" && \
+    if [ -n "${HERMES_TARGET}" ]; then INSTALL_ARGS="${INSTALL_ARGS} --fresh"; fi && \
     if [ -n "${SPACK_OCI_USER}" ] && [ -s /run/secrets/ghcr_token ]; then \
       export SPACK_OCI_TOKEN="$(cat /run/secrets/ghcr_token)" && \
       spack mirror add --unsigned \
         --oci-username-variable SPACK_OCI_USER \
         --oci-password-variable SPACK_OCI_TOKEN \
         hermes-oci "${SPACK_OCI_CACHE}" && \
-      { spack install ; rc=$? ; \
+      { spack install ${INSTALL_ARGS} ; rc=$? ; \
         spack buildcache push --unsigned --update-index --without-build-dependencies hermes-oci || true ; \
         exit $rc ; } ; \
     else \
-      spack install ${SPACK_INSTALL_EXTRA_ARGS} --fail-fast ; \
+      spack install ${INSTALL_ARGS} --fail-fast ; \
     fi
 
 # Make an 'entrypoint.sh' script which activates the spack environment

--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -43,11 +43,19 @@ WORKDIR /opt/spack-environment
 # older hardware. A `require: target=...` is a hard constraint reuse cannot
 # override; we enforce it here because the shared spack.yaml can't branch on
 # architecture.
-RUN case "$(uname -m)" in \
-      aarch64) HERMES_TARGET=aarch64 ;; \
-      x86_64)  HERMES_TARGET=x86_64_v3 ;; \
-      *)       HERMES_TARGET="$(uname -m)" ;; \
-    esac && \
+#
+# HERMES_TARGET overrides the microarch level explicitly; this is how the CI
+# matrix builds older-arch-compatible variants (e.g. x86_64_v2). When left
+# empty we derive a sensible portable default from `uname -m`.
+ARG HERMES_TARGET=""
+RUN if [ -z "${HERMES_TARGET}" ]; then \
+      case "$(uname -m)" in \
+        aarch64) HERMES_TARGET=aarch64 ;; \
+        x86_64)  HERMES_TARGET=x86_64_v3 ;; \
+        *)       HERMES_TARGET="$(uname -m)" ;; \
+      esac ; \
+    fi && \
+    echo "Pinning Spack microarch target: ${HERMES_TARGET}" && \
     spack -e . config add "packages:all:require:target=${HERMES_TARGET}"
 # Install the environment. With OCI credentials, add the self-hosted cache,
 # then install without --fail-fast and push whatever installed regardless of

--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -43,10 +43,8 @@ WORKDIR /opt/spack-environment
 # older hardware. A `require: target=...` is a hard constraint reuse cannot
 # override; we enforce it here because the shared spack.yaml can't branch on
 # architecture.
-#
-# HERMES_TARGET overrides the microarch level explicitly; this is how the CI
-# matrix builds older-arch-compatible variants (e.g. x86_64_v2). When left
-# empty we derive a sensible portable default from `uname -m`.
+# HERMES_TARGET overrides the microarch (CI builds compat variants, e.g.
+# x86_64_v2); empty => portable default from `uname -m`.
 ARG HERMES_TARGET=""
 RUN if [ -z "${HERMES_TARGET}" ]; then \
       case "$(uname -m)" in \

--- a/docker/hermes-3-builder.dockerfile
+++ b/docker/hermes-3-builder.dockerfile
@@ -6,12 +6,21 @@
 FROM spack/ubuntu-noble:1.2.0@sha256:dafccd1a2e77c61b5b6f81c06bbdabd999e6886daa405b3ac9011c5e4d98f8fa AS builder
 
 # Self-hosted OCI Spack build cache and the registry user. When SPACK_OCI_USER
-# is empty (local builds or fork PRs) the OCI cache is skipped, leaving only the
-# public mirror.
+# is empty (local builds or fork PRs) the OCI cache is skipped and the stack
+# builds from source.
 ARG SPACK_OCI_CACHE=oci://ghcr.io/boutproject/hermes-3-spack-cache
 ARG SPACK_OCI_USER=""
 ENV SPACK_OCI_CACHE=${SPACK_OCI_CACHE} \
     SPACK_OCI_USER=${SPACK_OCI_USER}
+
+# Extra flags for the no-credentials (source-build) `spack install`; empty in
+# CI, local builds pass e.g. "--fresh --verbose".
+ARG SPACK_INSTALL_EXTRA_ARGS=""
+
+# GNU mirror(s) to seed readline patches from (space-separated, tried in order).
+# ftpmirror.gnu.org, which Spack fetches these patches from, is unreachable from
+# our build network. Set to "" to disable.
+ARG GNU_MIRROR_URL="https://ftp.gnu.org/gnu https://mirrors.kernel.org/gnu"
 
 # Make sure that spack is available if we need to launch a terminal in the image
 RUN spack_path=$(which spack) && \
@@ -26,11 +35,10 @@ COPY docker/image_ingredients/spack_config.yaml /root/.spack/config.yaml
 # `spack compiler find`).
 RUN spack external find gcc
 
-# Add Spack's signed public binary mirror and trust its keys. --yes-to-all
-# avoids the interactive [y/N] key-trust prompt, which would EOF in a
-# non-interactive build.
-RUN spack mirror add --scope site spack-public https://binaries.spack.io/develop \
- && spack buildcache keys --install --trust --yes-to-all
+# The public Spack binary mirror is intentionally not added: some of its
+# packages (e.g. python) are built with intel-oneapi, and reusing those leaks
+# the Intel-only `-fp-model=strict` flag into gcc source builds. The stack
+# builds from source with gcc instead.
 
 RUN mkdir -p /opt/spack-environment
 COPY docker/image_ingredients/spack.yaml /opt/spack-environment/spack.yaml
@@ -55,11 +63,19 @@ RUN if [ -z "${HERMES_TARGET}" ]; then \
     fi && \
     echo "Pinning Spack microarch target: ${HERMES_TARGET}" && \
     spack -e . config add "packages:all:require:target=${HERMES_TARGET}"
+
+# Seed readline patches into a local Spack source mirror (see GNU_MIRROR_URL).
+COPY docker/image_ingredients/seed_gnu_mirror.sh /tmp/seed_gnu_mirror.sh
+RUN if [ -n "${GNU_MIRROR_URL}" ]; then \
+      sh /tmp/seed_gnu_mirror.sh "${GNU_MIRROR_URL}" /opt/gnu-mirror && \
+      spack mirror add --scope site local-gnu file:///opt/gnu-mirror ; \
+    fi
+
 # Install the environment. With OCI credentials, add the self-hosted cache,
 # then install without --fail-fast and push whatever installed regardless of
 # exit code (so a late failure still caches most packages for the next run),
 # re-propagating the exit code so a failed build still fails CI. Without
-# credentials, just install from the public mirror + source.
+# credentials, build from source (plus any SPACK_INSTALL_EXTRA_ARGS).
 RUN --mount=type=secret,id=ghcr_token \
     spack env activate . && \
     if [ -n "${SPACK_OCI_USER}" ] && [ -s /run/secrets/ghcr_token ]; then \
@@ -72,7 +88,7 @@ RUN --mount=type=secret,id=ghcr_token \
         spack buildcache push --unsigned --update-index --without-build-dependencies hermes-oci || true ; \
         exit $rc ; } ; \
     else \
-      spack install --fail-fast ; \
+      spack install ${SPACK_INSTALL_EXTRA_ARGS} --fail-fast ; \
     fi
 
 # Make an 'entrypoint.sh' script which activates the spack environment

--- a/docker/hermes-3.dockerfile
+++ b/docker/hermes-3.dockerfile
@@ -10,12 +10,9 @@ FROM ubuntu:24.04
 # Number of parallel compile jobs. Overridable per-build (CI/local).
 ARG HERMES_BUILD_JOBS=4
 
-# Microarch level for the BOUT++/Hermes-3 application code, mirroring the Spack
-# dependency pin in the builder image. Without it these (the physics hot loops)
-# would compile at GCC's generic baseline regardless of the builder's target, so
-# an "optimized" image would gain nothing over a compat one. Empty => derive the
-# same portable default as the builder from `uname -m`. Mapped to a GCC -march
-# string below (Spack spells it x86_64_v3; GCC wants x86-64-v3).
+# Microarch for the BOUT++/Hermes-3 code, matching the builder's Spack pin;
+# without it the physics hot loops compile at GCC's generic baseline. Empty =>
+# same `uname -m` default as the builder. Mapped to a -march string below.
 ARG HERMES_TARGET=""
 
 COPY --from=builder /opt/spack-environment /opt/spack-environment
@@ -61,10 +58,8 @@ RUN git -C ${HERMES_SRC_DIR} submodule update --init --recursive --depth 1 --sin
 COPY docker/image_ingredients/boutpp_config.cmake ${BOUTPP_CONFIG}
 COPY docker/image_ingredients/hermes_config.cmake ${HERMES_CONFIG}
 
-# Resolve HERMES_TARGET (Spack name) to a GCC -march string, deriving the same
-# portable default as the builder when unset. Emitted to /etc/hermes-march so
-# both CMake builds below reuse it without duplicating the mapping. An unknown
-# target yields an empty file, and the builds fall back to GCC's default -march.
+# Map HERMES_TARGET (Spack name) -> GCC -march, into /etc/hermes-march so both
+# builds below and in-container rebuilds reuse it. Unknown => empty (GCC default).
 RUN hermes_target="${HERMES_TARGET}" && \
     if [ -z "${hermes_target}" ]; then \
       case "$(uname -m)" in \

--- a/docker/hermes-3.dockerfile
+++ b/docker/hermes-3.dockerfile
@@ -10,6 +10,14 @@ FROM ubuntu:24.04
 # Number of parallel compile jobs. Overridable per-build (CI/local).
 ARG HERMES_BUILD_JOBS=4
 
+# Microarch level for the BOUT++/Hermes-3 application code, mirroring the Spack
+# dependency pin in the builder image. Without it these (the physics hot loops)
+# would compile at GCC's generic baseline regardless of the builder's target, so
+# an "optimized" image would gain nothing over a compat one. Empty => derive the
+# same portable default as the builder from `uname -m`. Mapped to a GCC -march
+# string below (Spack spells it x86_64_v3; GCC wants x86-64-v3).
+ARG HERMES_TARGET=""
+
 COPY --from=builder /opt/spack-environment /opt/spack-environment
 COPY --from=builder /opt/software /opt/software
 
@@ -53,12 +61,36 @@ RUN git -C ${HERMES_SRC_DIR} submodule update --init --recursive --depth 1 --sin
 COPY docker/image_ingredients/boutpp_config.cmake ${BOUTPP_CONFIG}
 COPY docker/image_ingredients/hermes_config.cmake ${HERMES_CONFIG}
 
+# Resolve HERMES_TARGET (Spack name) to a GCC -march string, deriving the same
+# portable default as the builder when unset. Emitted to /etc/hermes-march so
+# both CMake builds below reuse it without duplicating the mapping. An unknown
+# target yields an empty file, and the builds fall back to GCC's default -march.
+RUN hermes_target="${HERMES_TARGET}" && \
+    if [ -z "${hermes_target}" ]; then \
+      case "$(uname -m)" in \
+        aarch64) hermes_target=aarch64 ;; \
+        x86_64)  hermes_target=x86_64_v3 ;; \
+      esac ; \
+    fi && \
+    case "${hermes_target}" in \
+      x86_64)    march=x86-64 ;; \
+      x86_64_v2) march=x86-64-v2 ;; \
+      x86_64_v3) march=x86-64-v3 ;; \
+      x86_64_v4) march=x86-64-v4 ;; \
+      aarch64)   march=armv8-a ;; \
+      *)         march="" ;; \
+    esac && \
+    printf '%s' "${march:+-march=${march}}" > /etc/hermes-march && \
+    echo "BOUT++/Hermes-3 -march flag: '$(cat /etc/hermes-march)'"
+
 # Configure and build BOUT++
 RUN . /opt/spack-environment/activate.sh \
 &&  cmake -B ${BOUTPP_BUILD_DIR} \
           -S ${BOUTPP_SRC_DIR} \
           -C ${BOUTPP_CONFIG} \
           -Wno-dev \
+          -DCMAKE_CXX_FLAGS="$(cat /etc/hermes-march)" \
+          -DCMAKE_C_FLAGS="$(cat /etc/hermes-march)" \
 && cmake --build ${BOUTPP_BUILD_DIR} --parallel ${HERMES_BUILD_JOBS}
 
 # Configure and build Hermes
@@ -68,6 +100,8 @@ RUN . /opt/spack-environment/activate.sh \
           -C ${HERMES_CONFIG} \
           -DCMAKE_PREFIX_PATH=${BOUTPP_BUILD_DIR} \
           -Wno-dev \
+          -DCMAKE_CXX_FLAGS="$(cat /etc/hermes-march)" \
+          -DCMAKE_C_FLAGS="$(cat /etc/hermes-march)" \
 && cmake --build ${HERMES_BUILD_DIR} --parallel ${HERMES_BUILD_JOBS}
 
 # Copy in some helpful commands which can be used in

--- a/docker/image_ingredients/docker_image_commands.sh
+++ b/docker/image_ingredients/docker_image_commands.sh
@@ -19,6 +19,14 @@ notice() { print_message "${LIGHTGREEN}" "$1"; }
 info() { print_message "${LIGHTBLUE}" "$1"; }
 status() { print_message "" "$1"; } # No color for status messages
 
+# The -march flag the image was built with (written to /etc/hermes-march by
+# hermes-3.dockerfile). Reused for in-container rebuilds so build_boutpp /
+# build_hermes match the image's microarch instead of falling back to GCC's
+# generic baseline. Override with HERMES_MARCH (e.g. HERMES_MARCH="-march=native"
+# or "" to disable) for a manual rebuild at a different level.
+default_march="$(cat /etc/hermes-march 2>/dev/null || true)"
+MARCH_FLAG="${HERMES_MARCH-$default_march}"
+
 # Helper function to check exit codes and exit on failure
 check_exit_code() {
     local exit_code=$?
@@ -74,8 +82,9 @@ build_boutpp () {
         info "Build directory ${build_dir} is empty."
     fi
 
-    notice "Configuring BOUT++ from ${source_dir} using the config file ${config_file}"
-    cmake -Wno-dev -B "${build_dir}" -S "${source_dir}" -C "${config_file}"
+    notice "Configuring BOUT++ from ${source_dir} using the config file ${config_file} (march: '${MARCH_FLAG}')"
+    cmake -Wno-dev -B "${build_dir}" -S "${source_dir}" -C "${config_file}" \
+          -DCMAKE_CXX_FLAGS="${MARCH_FLAG}" -DCMAKE_C_FLAGS="${MARCH_FLAG}"
     check_exit_code "BOUT++ configuration failed"
 
     local jobs="${HERMES_BUILD_JOBS:-4}"
@@ -104,9 +113,10 @@ build_hermes () {
         info "Build directory ${build_dir} is empty."
     fi
 
-    notice "Configuring Hermes-3 from ${source_dir} using the config file ${config_file}"
+    notice "Configuring Hermes-3 from ${source_dir} using the config file ${config_file} (march: '${MARCH_FLAG}')"
     cmake -Wno-dev -B "${build_dir}" -S "${source_dir}" -C "${config_file}" \
-           -DCMAKE_PREFIX_PATH="${boutpp_dir}"
+           -DCMAKE_PREFIX_PATH="${boutpp_dir}" \
+           -DCMAKE_CXX_FLAGS="${MARCH_FLAG}" -DCMAKE_C_FLAGS="${MARCH_FLAG}"
     check_exit_code "Hermes-3 configuration failed"
 
     local jobs="${HERMES_BUILD_JOBS:-4}"

--- a/docker/image_ingredients/docker_image_commands.sh
+++ b/docker/image_ingredients/docker_image_commands.sh
@@ -19,13 +19,12 @@ notice() { print_message "${LIGHTGREEN}" "$1"; }
 info() { print_message "${LIGHTBLUE}" "$1"; }
 status() { print_message "" "$1"; } # No color for status messages
 
-# The -march flag the image was built with (written to /etc/hermes-march by
-# hermes-3.dockerfile). Reused for in-container rebuilds so build_boutpp /
-# build_hermes match the image's microarch instead of falling back to GCC's
-# generic baseline. Override with HERMES_MARCH (e.g. HERMES_MARCH="-march=native"
-# or "" to disable) for a manual rebuild at a different level.
-default_march="$(cat /etc/hermes-march 2>/dev/null || true)"
-MARCH_FLAG="${HERMES_MARCH-$default_march}"
+# -march baked into the image (from /etc/hermes-march) so rebuilds match its
+# microarch. Env CMAKE_CXX_FLAGS/CMAKE_C_FLAGS are appended; a later -march
+# wins, so users can add flags or retarget.
+image_march="$(cat /etc/hermes-march 2>/dev/null || true)"
+CXX_BUILD_FLAGS="${image_march}${CMAKE_CXX_FLAGS:+ ${CMAKE_CXX_FLAGS}}"
+C_BUILD_FLAGS="${image_march}${CMAKE_C_FLAGS:+ ${CMAKE_C_FLAGS}}"
 
 # Helper function to check exit codes and exit on failure
 check_exit_code() {
@@ -82,9 +81,9 @@ build_boutpp () {
         info "Build directory ${build_dir} is empty."
     fi
 
-    notice "Configuring BOUT++ from ${source_dir} using the config file ${config_file} (march: '${MARCH_FLAG}')"
+    notice "Configuring BOUT++ from ${source_dir} using the config file ${config_file} (CXX flags: '${CXX_BUILD_FLAGS}')"
     cmake -Wno-dev -B "${build_dir}" -S "${source_dir}" -C "${config_file}" \
-          -DCMAKE_CXX_FLAGS="${MARCH_FLAG}" -DCMAKE_C_FLAGS="${MARCH_FLAG}"
+          -DCMAKE_CXX_FLAGS="${CXX_BUILD_FLAGS}" -DCMAKE_C_FLAGS="${C_BUILD_FLAGS}"
     check_exit_code "BOUT++ configuration failed"
 
     local jobs="${HERMES_BUILD_JOBS:-4}"
@@ -113,10 +112,10 @@ build_hermes () {
         info "Build directory ${build_dir} is empty."
     fi
 
-    notice "Configuring Hermes-3 from ${source_dir} using the config file ${config_file} (march: '${MARCH_FLAG}')"
+    notice "Configuring Hermes-3 from ${source_dir} using the config file ${config_file} (CXX flags: '${CXX_BUILD_FLAGS}')"
     cmake -Wno-dev -B "${build_dir}" -S "${source_dir}" -C "${config_file}" \
            -DCMAKE_PREFIX_PATH="${boutpp_dir}" \
-           -DCMAKE_CXX_FLAGS="${MARCH_FLAG}" -DCMAKE_C_FLAGS="${MARCH_FLAG}"
+           -DCMAKE_CXX_FLAGS="${CXX_BUILD_FLAGS}" -DCMAKE_C_FLAGS="${C_BUILD_FLAGS}"
     check_exit_code "Hermes-3 configuration failed"
 
     local jobs="${HERMES_BUILD_JOBS:-4}"

--- a/docker/image_ingredients/seed_gnu_mirror.sh
+++ b/docker/image_ingredients/seed_gnu_mirror.sh
@@ -4,14 +4,18 @@
 # Files are laid out by sha256 in Spack's source-cache format; Spack verifies
 # the sha256 on use, so transport integrity does not matter.
 #
-# Usage: seed_gnu_mirror.sh "<GNU_BASE_URL> [GNU_BASE_URL ...]" <MIRROR_DIR>
+# Usage: seed_gnu_mirror.sh "<GNU_BASE_URL> [GNU_BASE_URL ...]" <MIRROR_DIR> [VERSIONS]
 #   GNU_BASE_URLs  space-separated bases serving readline/..., tried in order
 #                  per file (e.g. "https://ftp.gnu.org/gnu https://mirrors.kernel.org/gnu")
 #   MIRROR_DIR     output dir; register with `spack mirror add <name> file://<dir>`
+#   VERSIONS       optional space-separated readline versions to seed patches for
+#                  (defaults below); extend when Spack pins a newer readline, or
+#                  patches for that version silently won't be seeded.
 set -eu
 
 BASES="$1"
 MIRROR="$2"
+VERSIONS="${3:-8.0 8.1 8.2 8.3 8.4 8.5 8.6}"
 ARCHIVE="${MIRROR}/_source-cache/archive"
 mkdir -p "${ARCHIVE}"
 
@@ -29,9 +33,9 @@ fetch_first() {
 
 seeded=0
 # readline patches are published as contiguous series per version
-# (readline-<v>-patches/readline<vj>-001, -002, ...). Walk plausible versions,
-# and within each, sequential patch numbers until the first gap (all mirrors miss).
-for v in 8.0 8.1 8.2 8.3 8.4 8.5; do
+# (readline-<v>-patches/readline<vj>-001, -002, ...). Walk each version, and
+# within it sequential patch numbers until the first gap (all mirrors miss).
+for v in ${VERSIONS}; do
   vj=$(printf '%s' "$v" | tr -d '.')
   n=1
   while :; do

--- a/docker/image_ingredients/seed_gnu_mirror.sh
+++ b/docker/image_ingredients/seed_gnu_mirror.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Seed GNU readline patches into a local Spack source mirror, since Spack fetches
+# them from ftpmirror.gnu.org, which is unreachable from our build network.
+# Files are laid out by sha256 in Spack's source-cache format; Spack verifies
+# the sha256 on use, so transport integrity does not matter.
+#
+# Usage: seed_gnu_mirror.sh "<GNU_BASE_URL> [GNU_BASE_URL ...]" <MIRROR_DIR>
+#   GNU_BASE_URLs  space-separated bases serving readline/..., tried in order
+#                  per file (e.g. "https://ftp.gnu.org/gnu https://mirrors.kernel.org/gnu")
+#   MIRROR_DIR     output dir; register with `spack mirror add <name> file://<dir>`
+set -eu
+
+BASES="$1"
+MIRROR="$2"
+ARCHIVE="${MIRROR}/_source-cache/archive"
+mkdir -p "${ARCHIVE}"
+
+# Fetch a path (relative to a base) trying each base in turn; on success writes
+# to the given output file and returns 0, else returns 1.
+fetch_first() {
+  _path="$1"; _out="$2"
+  for _base in ${BASES}; do
+    if curl -fsSL --retry 3 -o "${_out}" "${_base}/${_path}" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+seeded=0
+# readline patches are published as contiguous series per version
+# (readline-<v>-patches/readline<vj>-001, -002, ...). Walk plausible versions,
+# and within each, sequential patch numbers until the first gap (all mirrors miss).
+for v in 8.0 8.1 8.2 8.3 8.4 8.5; do
+  vj=$(printf '%s' "$v" | tr -d '.')
+  n=1
+  while :; do
+    num=$(printf '%03d' "$n")
+    tmp=$(mktemp)
+    if fetch_first "readline/readline-${v}-patches/readline${vj}-${num}" "${tmp}"; then
+      sha=$(sha256sum "${tmp}" | awk '{print $1}')
+      dest="${ARCHIVE}/$(printf '%s' "${sha}" | cut -c1-2)"
+      mkdir -p "${dest}"
+      mv "${tmp}" "${dest}/${sha}"
+      seeded=$((seeded + 1))
+      n=$((n + 1))
+    else
+      rm -f "${tmp}"
+      break
+    fi
+  done
+done
+
+echo "seed_gnu_mirror: seeded ${seeded} GNU patch file(s) into ${MIRROR} (mirrors: ${BASES})"
+if [ "${seeded}" -eq 0 ]; then
+  echo "seed_gnu_mirror: ERROR: nothing seeded; none of the mirrors reachable: ${BASES}" >&2
+  exit 1
+fi

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -13,7 +13,6 @@ echo "HERMES_BUILD_JOBS=4" >> .env
 # for a fixed -march (a later -march here wins, so you can also retarget):
 #   hermes-3:latest            -> -march=x86-64-v3  (armv8-a on arm64)
 #   hermes-3:latest-x86_64_v2  -> -march=x86-64-v2
-#   hermes-3:latest-x86_64_v1  -> -march=x86-64
 # e.g. CMAKE_CXX_FLAGS="-march=native" or "-funroll-loops".
 cat >> .env <<'EOF'
 # See setup.sh for the image <-> -march correspondence.

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -7,3 +7,16 @@ echo "HOST_DIR=$PWD" >> .env
 echo "HERMES_TAG=latest" >> .env
 echo "JUPYTER_TAG=latest" >> .env
 echo "HERMES_BUILD_JOBS=4" >> .env
+
+# Extra compiler flags appended when rebuilding in-container (build_hermes /
+# build_boutpp). Leave empty to match the pulled image, which is already built
+# for a fixed -march (a later -march here wins, so you can also retarget):
+#   hermes-3:latest            -> -march=x86-64-v3  (armv8-a on arm64)
+#   hermes-3:latest-x86_64_v2  -> -march=x86-64-v2
+#   hermes-3:latest-x86_64_v1  -> -march=x86-64
+# e.g. CMAKE_CXX_FLAGS="-march=native" or "-funroll-loops".
+cat >> .env <<'EOF'
+# See setup.sh for the image <-> -march correspondence.
+CMAKE_CXX_FLAGS=
+CMAKE_C_FLAGS=
+EOF


### PR DESCRIPTION
### Purpose
The multi-arch Docker pipeline (#601) publishes images built for x86_64_v3 (AVX2/FMA) on amd64, which fail with Illegal instruction on older x86 CPUs. This adds an older-arch-compatible image variant so users on pre-Haswell hardware can run Hermes-3 in Docker. It also closes a gap in #601: the microarch was only pinned for the Spack dependencies, not the BOUT++/Hermes-3 code itself.

### Change Summary
- Parameterised the microarch. HERMES_TARGET is now a build arg in hermes-3-builder.dockerfile (empty → the previous uname -m default), replacing the hardcoded case.
- Compat image variant. build_builder_image.yml and build_docker_image.yml gained a matrix variant for x86_64_v2, published as suffixed tags (:latest-x86_64_v2 and the edge equivalent for the builder) via metadata-action flavor: suffix. The default multi-arch tags are unchanged.
- Application code now respects the target. hermes-3.dockerfile maps HERMES_TARGET → a GCC -march string, bakes it into /etc/hermes-march, and passes it to the BOUT++/Hermes-3 CMake builds — previously these compiled at GCC's generic baseline regardless of the image's target.
- In-container rebuilds stay consistent. docker_image_commands.sh reads /etc/hermes-march so build_hermes/build_boutpp match the image; standard CMAKE_CXX_FLAGS/CMAKE_C_FLAGS (plumbed through .env → docker-compose.yaml) are appended, letting users add flags or retarget (a later -march wins).

### Validation
- YAML-linted the workflows and docker-compose.yaml; bash -n on setup.sh and docker_image_commands.sh.
- Verified the HERMES_TARGET → -march mapping and the flag-append logic (empty → image default; -march=native and -funroll-loops append correctly) by running the shell snippets standalone.
- Confirmed the config .cmake files set no CMAKE_CXX_FLAGS, so the injected -D flags don't clobber existing settings.
- Exercised end to end in CI via test_docker_build.yml, which builds the default (amd64 v3 + arm64) and x86_64_v2 variants.

### AI Assistance
Developed with Claude Code. It made the dockerfile/workflow/script edits, cross-referenced the parallel PR #603 to pull in the -march-on-final-builds idea (while rejecting its unsafe x86_64_v4 default and armv8.6a ARM floor), diagnosed the CI failure that led to dropping the v1 variant, and validated the shell/YAML locally. All changes were reviewed by me before committing.

### Documentation
Added a "Compiler flags and the per-image -march" section to docker/README.md: a table mapping each tag to its baked -march, and how CMAKE_CXX_FLAGS/CMAKE_C_FLAGS append to it for rebuilds.

### Review Notes
- x86_64 (v1) variant removed due to a failing build. It was originally included alongside v2, but its builder leg fails in CI: v1 is a cold-cache target (nothing prebuilt in the OCI Spack cache), so it must build readline@8.3 from source, and Spack cannot fetch the required readline83-00x patches — they 404 on binaries.spack.io/develop's source-cache and the only fallback (ftpmirror.gnu.org → mirror.latigo.net) is unreachable from the runners. The v2 variant is unaffected because it pulls readline prebuilt from the cache. v1 can be re-added once the readline@8.3 patches are mirrored (or by pinning readline to a mirrored version, e.g. readline@8.2, in spack.yaml).
- Bootstrap ordering: the compat final image builds FROM builder:latest-x86_64_v2, which only exists after build_builder_image.yml has run with this variant. The first master push after merge will fail the compat final leg until the builder workflow is dispatched once to seed that tag. Suggest running build_builder_image.yml manually first.
- Build cost: each builder rebuild now compiles the PETSc/OpenMPI/SLEPc/SUNDIALS chain twice on amd64 (v3 + v2).
- No ARM compat variants: ARMv9 can't be safely built on the GitHub N1 (ARMv8.2) runners, and the existing aarch64 baseline is already the most portable ARM target, so ARM was left as-is.
