### PR TITLE
Cleanup tests: Do not download if present

### DIFF
--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -41,48 +41,66 @@ expected_filenames = [
 ]
 
 
-## Download files
-tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
+def download_data():
+    ## Download files
+    tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
 
-with urllib.request.urlopen(url, timeout=60) as response:
-    if response.status != 200:
-        raise RuntimeError(
-            f"2D-Production test: download failed - HTTP {response.status}"
-        )
+    with urllib.request.urlopen(url, timeout=60) as response:
+        if response.status != 200:
+            raise RuntimeError(
+                f"2D-Production test: download failed - HTTP {response.status}"
+            )
 
-    # Copy bits of the file from response to a temp file
-    # This ensures no partial files are left if the download fails
-    with open(tmp_path, "wb") as out_file:
-        shutil.copyfileobj(response, out_file)
+        # Copy bits of the file from response to a temp file
+        # This ensures no partial files are left if the download fails
+        with open(tmp_path, "wb") as out_file:
+            shutil.copyfileobj(response, out_file)
+
+    if verbose:
+        print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+
+    # Rename temp file with the correct name
+    tmp_path.replace(zipfile_path)
+
+
+def extractZip():
+    with zipfile.ZipFile(zipfile_path, "r") as zf:
+        zip_contents = set(zf.namelist())
+        try:
+            # Extract only expected grids
+            for filename in expected_filenames:
+                if filename in zip_contents:
+                    zf.extract(filename, path=this_dir)
+
+        except Exception as e:
+            print("2D-Production test: extracting test grids failed:", e)
+            raise
+
+
+def checkHash(doRaise=True):
+    # Check hash
+    try:
+        with open(zipfile_path, "rb") as f:
+            file_hash = hashlib.sha256(f.read()).hexdigest()
+    except FileNotFoundError:
+        if doRaise:
+            raise
+        return False
+
+    if doRaise:
+        if file_hash != expected_hash:
+            raise RuntimeError(
+                "2D-Production test: downloaded zip file hash does not match expected value"
+            )
+    return file_hash == expected_hash
+
 
 t_download = time()
-if verbose:
-    print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+if not checkHash(False):
+    download_data()
+    checkHash()
 
-# Rename temp file with the correct name
-tmp_path.replace(zipfile_path)
-
-
-with zipfile.ZipFile(zipfile_path, "r") as zf:
-    zip_contents = set(zf.namelist())
-    try:
-        # Extract only expected grids
-        for filename in expected_filenames:
-            if filename in zip_contents:
-                zf.extract(filename, path=this_dir)
-
-    except Exception as e:
-        print("2D-Production test: extracting test grids failed:", e)
-
-# Check hash
-with open(zipfile_path, "rb") as f:
-    file_hash = hashlib.sha256(f.read()).hexdigest()
-# print(file_hash)
-
-if file_hash != expected_hash:
-    raise RuntimeError(
-        "2D-Production test: downloaded zip file hash does not match expected value"
-    )
+extractZip()
 
 t_extract = time()
 if verbose:

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -30,7 +30,6 @@ atol = 1e-8
 ### Setup
 this_dir = Path(__file__).parent
 data_dir = this_dir / "data"
-hermes_exec = this_dir.parent.parent.parent / "hermes-3"
 output_path = data_dir / "BOUT.dmp.*.nc"
 
 zipfile_path = this_dir / "test-2D-recycling.zip"
@@ -124,7 +123,9 @@ if not debug:
     # which does not enforce slot limits and does not support --oversubscribe)
     os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "yes"
 
-    s, out = launch_safe("./hermes-3 -d data", runcmd=runcmd, nproc=10, pipe=True)
+    s, out = launch_safe(
+        "../../../hermes-3 -d data", runcmd=runcmd, nproc=10, pipe=True
+    )
 
     if s != 0:
         print(" => 2D-recycling test failed: ")

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from boututils.run_wrapper import shell, launch_safe, getmpirun
+from boututils.run_wrapper import launch_safe, getmpirun
 import numpy as np
 import matplotlib.pyplot as plt
 import shutil
@@ -51,8 +51,8 @@ expected_filenames = [
 ]
 
 
-### Download files
-if not debug:
+def download_data():
+    ## Download files
     tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
 
     with urllib.request.urlopen(url, timeout=60) as response:
@@ -66,13 +66,14 @@ if not debug:
         with open(tmp_path, "wb") as out_file:
             shutil.copyfileobj(response, out_file)
 
-    t_download = time()
     if verbose:
         print(f"2D-Recycling test: download took {t_download - t0:.2f} seconds")
 
     # Rename temp file with the correct name
     tmp_path.replace(zipfile_path)
 
+
+def extractZip():
     with zipfile.ZipFile(zipfile_path, "r") as zf:
         zip_contents = set(zf.namelist())
         try:
@@ -83,28 +84,41 @@ if not debug:
 
         except Exception as e:
             print("2D-recycling test: extracting test grids failed:", e)
+            raise
 
+
+def checkHash(doRaise=True):
     # Check hash
-    with open(zipfile_path, "rb") as f:
-        file_hash = hashlib.sha256(f.read()).hexdigest()
-        # print(file_hash)
+    try:
+        with open(zipfile_path, "rb") as f:
+            file_hash = hashlib.sha256(f.read()).hexdigest()
+    except FileNotFoundError:
+        if doRaise:
+            raise
+        return False
 
-    if file_hash != expected_hash:
-        raise RuntimeError(
-            "2D-recycling test: downloaded zip file hash does not match expected value"
-        )
+    if doRaise:
+        if file_hash != expected_hash:
+            raise RuntimeError(
+                "2D-recycling test: downloaded zip file hash does not match expected value"
+            )
+    return file_hash == expected_hash
+
+
+if not debug:
+    t_download = time()
+    if not checkHash(False):
+        download_data()
+        checkHash()
+
+    extractZip()
+    runcmd = getmpirun().split(" ")[0] + " -np"
 
     t_extract = time()
     if verbose:
         print(
-            f"2D-Recycling test: zip extraction took {t_extract - t_download:.2f} seconds"
+            f"2D-Production test: zip extraction took {t_extract - t_download:.2f} seconds"
         )
-
-    ## Run test
-    if not Path("hermes-3").is_file():
-        shell("ln -s ../../../hermes-3 hermes-3")
-
-    runcmd = getmpirun().split(" ")[0] + " -np"
 
     # Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,
     # which does not enforce slot limits and does not support --oversubscribe)

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -116,7 +116,7 @@ if not debug:
     t_extract = time()
     if verbose:
         print(
-            f"2D-Production test: zip extraction took {t_extract - t_download:.2f} seconds"
+            f"2D-recycling test: zip extraction took {t_extract - t_download:.2f} seconds"
         )
 
     # Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,


### PR DESCRIPTION
### Purpose
Right now the tests always download the data, even if it is present.

This is a waste of resources, and causes problems in restricted environments, where the download is blocked.

This is partially pulled from #577 

### Change Summary
Only download if not present

### Validation
Tests still run in CI, downloading data if needed.
I tested manually that it also works if the direct download is not possible.

### AI Assistance
None

### Documentation
Things should just keep working

### Review Notes
<!-- Anything reviewers should pay particular attention to? For example: risks, limitations, things you're not sure about. -->
This should be farily limited in scope and easy to review.