### PR TITLE
3/initiliaze from mesh

### DIFF
--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -89,8 +89,8 @@ private:
   bool diagnose;                ///< Output additional diagnostics?
   Field3D flow_xlow, flow_ylow; ///< Particle flow diagnostics
 
-  bool initialize_from_mesh;  ///< Initilize the Field3D N from 2D profiles stored in the mesh file. 
-
+  bool
+      initialize_from_mesh; ///< Initilize the Field3D N from 2D profiles stored in the mesh file.
 
   /// This sets in the state
   /// - species

--- a/include/evolve_density.hxx
+++ b/include/evolve_density.hxx
@@ -89,6 +89,9 @@ private:
   bool diagnose;                ///< Output additional diagnostics?
   Field3D flow_xlow, flow_ylow; ///< Particle flow diagnostics
 
+  bool initialize_from_mesh;  ///< Initilize the Field3D N from 2D profiles stored in the mesh file. 
+
+
   /// This sets in the state
   /// - species
   ///   - <name>

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -107,7 +107,8 @@ private:
   Field3D E_PdivV,
       E_VgradP; ///< Diagnostic energy source terms for p*Div(V) and V*Grad(P)
 
-  bool initialize_from_mesh;  ///< Initilize the Field3D P from 2D profiles stored in the mesh file. 
+  bool
+      initialize_from_mesh; ///< Initilize the Field3D P from 2D profiles stored in the mesh file.
 
   /// Inputs
   /// - species

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -107,6 +107,8 @@ private:
   Field3D E_PdivV,
       E_VgradP; ///< Diagnostic energy source terms for p*Div(V) and V*Grad(P)
 
+  bool initialize_from_mesh;  ///< Initilize the Field3D P from 2D profiles stored in the mesh file. 
+
   /// Inputs
   /// - species
   ///   - <name>

--- a/include/fixed_density.hxx
+++ b/include/fixed_density.hxx
@@ -3,6 +3,7 @@
 #define FIXED_DENSITY_H
 
 #include "component.hxx"
+using bout::globals::mesh;
 
 /// Set ion density to a fixed value
 ///
@@ -26,6 +27,18 @@ struct FixedDensity : public NamedComponent<FixedDensity> {
 
     // Get the density and normalise
     N = options["density"].as<Field3D>() / Nnorm;
+
+    // Initilize the Field3D N from 2D profiles stored in the mesh file.
+    initialize_from_mesh = options["initialize_from_mesh"]
+      .doc("Initilize field from 2D profiles stored in the mesh file?")
+      .withDefault<bool>(false);
+
+    if (initialize_from_mesh) {
+      // Try to read the initial field from the mesh
+      mesh->get(N, std::string("N") + name + "_init"); // Units: [m^-3/s]
+      N /= Nnorm; // Normalization
+    }    
+
     substitutePermissions("name", {name});
     substitutePermissions("vars", {"AA", "charge", "density"});
   }
@@ -51,6 +64,8 @@ private:
   BoutReal AA;     ///< Atomic mass e.g. proton = 1
 
   Field3D N; ///< Species density (normalised)
+
+  bool initialize_from_mesh;  ///< Initilize the Field3D N from 2D profiles stored in the mesh file. 
 
   /// Sets in the state the density, mass and charge of the species
   ///

--- a/include/fixed_density.hxx
+++ b/include/fixed_density.hxx
@@ -29,15 +29,16 @@ struct FixedDensity : public NamedComponent<FixedDensity> {
     N = options["density"].as<Field3D>() / Nnorm;
 
     // Initilize the Field3D N from 2D profiles stored in the mesh file.
-    initialize_from_mesh = options["initialize_from_mesh"]
-      .doc("Initilize field from 2D profiles stored in the mesh file?")
-      .withDefault<bool>(false);
+    initialize_from_mesh =
+        options["initialize_from_mesh"]
+            .doc("Initilize field from 2D profiles stored in the mesh file?")
+            .withDefault<bool>(false);
 
     if (initialize_from_mesh) {
       // Try to read the initial field from the mesh
       mesh->get(N, std::string("N") + name + "_init"); // Units: [m^-3/s]
-      N /= Nnorm; // Normalization
-    }    
+      N /= Nnorm;                                      // Normalization
+    }
 
     substitutePermissions("name", {name});
     substitutePermissions("vars", {"AA", "charge", "density"});
@@ -65,7 +66,8 @@ private:
 
   Field3D N; ///< Species density (normalised)
 
-  bool initialize_from_mesh;  ///< Initilize the Field3D N from 2D profiles stored in the mesh file. 
+  bool
+      initialize_from_mesh; ///< Initilize the Field3D N from 2D profiles stored in the mesh file.
 
   /// Sets in the state the density, mass and charge of the species
   ///

--- a/include/isothermal.hxx
+++ b/include/isothermal.hxx
@@ -14,8 +14,10 @@ struct Isothermal : public NamedComponent<Isothermal> {
   static constexpr auto type = "isothermal";
 
 private:
-  BoutReal T; ///< The normalised temperature
+  Field3D T;  ///< The normalised temperature
   Field3D P;  ///< The normalised pressure
+
+  bool initialize_from_mesh;  ///< Initilize the Field3D T from 2D profiles stored in the mesh file. 
 
   bool diagnose; ///< Output additional diagnostics?
 

--- a/include/isothermal.hxx
+++ b/include/isothermal.hxx
@@ -17,7 +17,8 @@ private:
   Field3D T;  ///< The normalised temperature
   Field3D P;  ///< The normalised pressure
 
-  bool initialize_from_mesh;  ///< Initilize the Field3D T from 2D profiles stored in the mesh file. 
+  bool
+      initialize_from_mesh; ///< Initilize the Field3D T from 2D profiles stored in the mesh file.
 
   bool diagnose; ///< Output additional diagnostics?
 

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -149,6 +149,17 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
           .doc("Apply neumann boundary with Z average?")
           .withDefault<bool>(false);
 
+  // Initilize the Field3D N from 2D profiles stored in the mesh file.
+  initialize_from_mesh = n_options["initialize_from_mesh"]
+    .doc("Initilize field from 2D profiles stored in the mesh file?")
+    .withDefault<bool>(false);
+
+  if (initialize_from_mesh) {
+  // Try to read the initial field from the mesh
+    mesh->get(N, std::string("N") + name + "_init"); // Units: [m^-3/s]
+    N /= Nnorm; // Normalization
+  }
+
   std::vector<std::string> outputs = {"AA", "density", "density_source"};
   if (charge != 0.) {
     outputs.push_back("charge");

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -150,14 +150,15 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
           .withDefault<bool>(false);
 
   // Initilize the Field3D N from 2D profiles stored in the mesh file.
-  initialize_from_mesh = n_options["initialize_from_mesh"]
-    .doc("Initilize field from 2D profiles stored in the mesh file?")
-    .withDefault<bool>(false);
+  initialize_from_mesh =
+      n_options["initialize_from_mesh"]
+          .doc("Initilize field from 2D profiles stored in the mesh file?")
+          .withDefault<bool>(false);
 
   if (initialize_from_mesh) {
-  // Try to read the initial field from the mesh
+    // Try to read the initial field from the mesh
     mesh->get(N, std::string("N") + name + "_init"); // Units: [m^-3/s]
-    N /= Nnorm; // Normalization
+    N /= Nnorm;                                      // Normalization
   }
 
   std::vector<std::string> outputs = {"AA", "density", "density_source"};

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -113,10 +113,10 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
   const BoutReal Nnorm = units["inv_meters_cubed"];
   const BoutReal Tnorm = units["eV"];
   const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
+  const BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
 
   auto& p_options = alloptions[std::string("P") + name];
-  source_normalisation =
-      SI::qe * Nnorm * Tnorm * Omega_ci; // [Pa/s] or [W/m^3] if converted to energy
+  source_normalisation = Pnorm * Omega_ci; // [Pa/s] or [W/m^3] if converted to energy
   time_normalisation = 1. / Omega_ci;    // [s]
 
   // Try to read the pressure source from the mesh
@@ -176,6 +176,17 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
   thermal_conduction = options["thermal_conduction"]
                            .doc("Include parallel heat conduction?")
                            .withDefault<bool>(true);
+
+  // Initilize the Field3D P from 2D profiles stored in the mesh file.
+  initialize_from_mesh = p_options["initialize_from_mesh"]
+    .doc("Initilize field from 2D profiles stored in the mesh file?")
+    .withDefault<bool>(false);
+
+  if (initialize_from_mesh) {
+  // Try to read the initial field from the mesh
+    mesh->get(P, std::string("P") + name + "_init"); // Units: Pascal [Pa]
+    P /= Pnorm; // Normalization
+  }
 
   if (source_time_dependent) {
     setPermissions(readOnly("time"));

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -178,14 +178,15 @@ EvolvePressure::EvolvePressure(std::string name, Options& alloptions, Solver* so
                            .withDefault<bool>(true);
 
   // Initilize the Field3D P from 2D profiles stored in the mesh file.
-  initialize_from_mesh = p_options["initialize_from_mesh"]
-    .doc("Initilize field from 2D profiles stored in the mesh file?")
-    .withDefault<bool>(false);
+  initialize_from_mesh =
+      p_options["initialize_from_mesh"]
+          .doc("Initilize field from 2D profiles stored in the mesh file?")
+          .withDefault<bool>(false);
 
   if (initialize_from_mesh) {
-  // Try to read the initial field from the mesh
+    // Try to read the initial field from the mesh
     mesh->get(P, std::string("P") + name + "_init"); // Units: Pascal [Pa]
-    P /= Pnorm; // Normalization
+    P /= Pnorm;                                      // Normalization
   }
 
   if (source_time_dependent) {

--- a/src/isothermal.cxx
+++ b/src/isothermal.cxx
@@ -1,8 +1,8 @@
 
 #include <bout/constants.hxx>
 #include <bout/mesh.hxx>
-
 #include "../include/isothermal.hxx"
+using bout::globals::mesh;
 
 Isothermal::Isothermal(std::string name, Options& alloptions, Solver* UNUSED(solver))
     : NamedComponent(
@@ -15,6 +15,17 @@ Isothermal::Isothermal(std::string name, Options& alloptions, Solver* UNUSED(sol
   auto Tnorm = get<BoutReal>(alloptions["units"]["eV"]);
   T = options["temperature"].doc("Constant temperature [eV]").as<BoutReal>()
       / Tnorm; // Normalise
+
+  // Initilize the Field3D T from 2D profiles stored in the mesh file.
+  initialize_from_mesh = options["initialize_from_mesh"]
+    .doc("Initilize field from 2D profiles stored in the mesh file?")
+    .withDefault<bool>(false);
+
+  if (initialize_from_mesh) {
+  // Try to read the initial field from the mesh
+    mesh->get(T, std::string("T") + name + "_init"); // Units: [eV]
+    T /= Tnorm; // Normalization
+  }
 
   diagnose = options["diagnose"]
                  .doc("Save additional output diagnostics")

--- a/src/isothermal.cxx
+++ b/src/isothermal.cxx
@@ -1,7 +1,7 @@
 
+#include "../include/isothermal.hxx"
 #include <bout/constants.hxx>
 #include <bout/mesh.hxx>
-#include "../include/isothermal.hxx"
 using bout::globals::mesh;
 
 Isothermal::Isothermal(std::string name, Options& alloptions, Solver* UNUSED(solver))
@@ -17,14 +17,15 @@ Isothermal::Isothermal(std::string name, Options& alloptions, Solver* UNUSED(sol
       / Tnorm; // Normalise
 
   // Initilize the Field3D T from 2D profiles stored in the mesh file.
-  initialize_from_mesh = options["initialize_from_mesh"]
-    .doc("Initilize field from 2D profiles stored in the mesh file?")
-    .withDefault<bool>(false);
+  initialize_from_mesh =
+      options["initialize_from_mesh"]
+          .doc("Initilize field from 2D profiles stored in the mesh file?")
+          .withDefault<bool>(false);
 
   if (initialize_from_mesh) {
-  // Try to read the initial field from the mesh
+    // Try to read the initial field from the mesh
     mesh->get(T, std::string("T") + name + "_init"); // Units: [eV]
-    T /= Tnorm; // Normalization
+    T /= Tnorm;                                      // Normalization
   }
 
   diagnose = options["diagnose"]


### PR DESCRIPTION
### Purpose
Added a functionality to initialize number density and pressure from grid variables with names **varName_init**. 
You can set up 2D profiles in the grid e.g. **Nd+_init** from example from EFIT files (1D omp profiles and no polidal variation) and then in the input file you set: 
  [Nd+]
  initialize_from_mesh = true  # Should be in SI units with name: <variable name>_init

### Change Summary
I changed the isothermal component as well. I made the T variable a Field3D var instead of BoutReal so that it can be set up from grid. 

### Validation
I tested it with my cases for 2D and 3D. 

### AI Assistance
No.

### Documentation
None

### Review Notes
None