### PR TITLE
Update BOUT-Spack: fixes python dependency versions for tests.

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
   develop:
     boutpp:
       path: ./external/BOUT-dev
-      spec: boutpp@develop
+      spec: boutpp@develop build_type=RelWithDebInfo
     hermes-3:
       path: .
-      spec: hermes-3@develop
+      spec: hermes-3@develop build_type=RelWithDebInfo


### PR DESCRIPTION
### Purpose
Update spack package definitions to pull versions of the python dependencies that are compatible with the current test suite.

### Change Summary
See [BOUT-spack PRs](https://github.com/boutproject/BOUT-spack/pulls?q=is%3Apr+), particularly [this one](https://github.com/boutproject/BOUT-spack/pull/24).

In addition to fixing the python dependencies, these updates cause the hermes and bout packages to build in RelWithDebInfo by default, rather than Release (specify build_type=Release to override).

### Validation
```
. activate_h3env
spack install
spack cd -b hermes-3 && ctest
```
(Checked with both spack 1.1.0 and 1.2.0)

### AI Assistance
None
