### PR TITLE
ci: skip docker build workflows outside boutproject/hermes-3

### DIFF
--- a/.github/actions/build-push-digest/action.yml
+++ b/.github/actions/build-push-digest/action.yml
@@ -28,6 +28,12 @@ inputs:
   token:
     description: Registry password / token (pass secrets.GITHUB_TOKEN).
     required: true
+  push:
+    description: >
+      Whether to push the built image. Set false to build for validation only
+      (e.g. a fork that can't publish); the digest is then not exported, so no
+      merge step should run.
+    default: "true"
   build-args:
     description: Newline-separated build args passed to the build.
     default: ""
@@ -92,9 +98,10 @@ runs:
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ steps.vars.outputs.arch }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
-        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
 
     - name: Export digest
+      if: inputs.push == 'true'
       shell: bash
       run: |
         mkdir -p /tmp/digests
@@ -102,6 +109,7 @@ runs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
+      if: inputs.push == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.cache-scope }}-digests-${{ steps.vars.outputs.arch }}

--- a/.github/actions/build-push-digest/action.yml
+++ b/.github/actions/build-push-digest/action.yml
@@ -28,11 +28,11 @@ inputs:
   token:
     description: Registry password / token (pass secrets.GITHUB_TOKEN).
     required: true
-  push:
+  publish_image:
     description: >
-      Whether to push the built image. Set false to build for validation only
-      (e.g. a fork that can't publish); the digest is then not exported, so no
-      merge step should run.
+      Whether to publish (push to the registry) the built image. Set false to
+      build for validation only (e.g. a fork that can't publish); the digest is
+      then not exported, so no merge step should run.
     default: "true"
   build-args:
     description: Newline-separated build args passed to the build.
@@ -98,10 +98,10 @@ runs:
         cache-to: type=gha,mode=max,scope=${{ inputs.cache-scope }}-${{ steps.vars.outputs.arch }}
         build-args: ${{ inputs.build-args }}
         secrets: ${{ inputs.build-secrets }}
-        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
+        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=${{ inputs.publish_image }}
 
     - name: Export digest
-      if: inputs.push == 'true'
+      if: inputs.publish_image == 'true'
       shell: bash
       run: |
         mkdir -p /tmp/digests
@@ -109,7 +109,7 @@ runs:
         touch "/tmp/digests/${digest#sha256:}"
 
     - name: Upload digest
-      if: inputs.push == 'true'
+      if: inputs.publish_image == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.cache-scope }}-digests-${{ steps.vars.outputs.arch }}

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -33,7 +33,7 @@ jobs:
   # multi-arch manifest.
   build-builder-image:
     # Scheduled/release runs only on the canonical repo; forks may still manually
-    # dispatch to validate the build, but must not push (see 'push' below).
+    # dispatch to validate the build, but must not publish (see 'publish_image').
     if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
 
     strategy:
@@ -64,7 +64,7 @@ jobs:
           cache-scope: builder
           # Only the canonical repo publishes; a fork's manual dispatch builds
           # for validation without pushing.
-          push: ${{ github.repository == 'boutproject/hermes-3' }}
+          publish_image: ${{ github.repository == 'boutproject/hermes-3' }}
           token: ${{ secrets.GITHUB_TOKEN }}
           # Credentials for the self-hosted OCI Spack build cache, so the build
           # can pull previously-compiled binaries and push newly-built ones.

--- a/.github/workflows/build_builder_image.yml
+++ b/.github/workflows/build_builder_image.yml
@@ -32,6 +32,9 @@ jobs:
   # each by digest only. The merge job below assembles them into a single
   # multi-arch manifest.
   build-builder-image:
+    # Scheduled/release runs only on the canonical repo; forks may still manually
+    # dispatch to validate the build, but must not push (see 'push' below).
+    if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
 
     strategy:
       fail-fast: false
@@ -59,6 +62,9 @@ jobs:
           dockerfile: ${{ env.BUILDER_DOCKERFILE }}
           platform: ${{ matrix.platform }}
           cache-scope: builder
+          # Only the canonical repo publishes; a fork's manual dispatch builds
+          # for validation without pushing.
+          push: ${{ github.repository == 'boutproject/hermes-3' }}
           token: ${{ secrets.GITHUB_TOKEN }}
           # Credentials for the self-hosted OCI Spack build cache, so the build
           # can pull previously-compiled binaries and push newly-built ones.
@@ -69,7 +75,9 @@ jobs:
 
   # Combine the per-arch builder images into one multi-arch manifest and apply tags.
   merge-builder-image:
-
+    # On a fork dispatch the builder was built without pushing, so there are no
+    # digests to merge; publishing only happens on the canonical repo.
+    if: github.repository == 'boutproject/hermes-3'
     needs: build-builder-image
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -29,6 +29,8 @@ concurrency:
 jobs:
 
   cleanup-images:
+    # Skip scheduled runs on forks; still allow manual dispatch anywhere.
+    if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,6 +64,8 @@ jobs:
   # next build). Prune untagged + entries >6 months, but keep the index tag so
   # `spack buildcache push --update-index` state is not orphaned.
   cleanup-spack-cache:
+    # Skip scheduled runs on forks; still allow manual dispatch anywhere.
+    if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Delete untagged cache blobs (hermes-3-spack-cache)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   stale:
+    # Skip scheduled runs on forks; still allow manual dispatch anywhere.
+    if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -99,13 +99,14 @@ jobs:
   # each by digest only.
   build-builder:
     needs: changes
-    # Publishing needs registry write access, which fork PRs don't have, so skip
-    # cleanly on forks instead of failing on the push step. (Non-PR events such
-    # as workflow_dispatch always run from this repo.)
+    # Publishing needs write access to the boutproject registry, so skip cleanly
+    # anywhere else (fork PRs and downstream forks) instead of failing on the
+    # push step.
     if: |
       needs.changes.outputs.builder == 'true' &&
+      github.repository == 'boutproject/hermes-3' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == 'boutproject/hermes-3')
     strategy:
       fail-fast: false
       matrix:
@@ -173,11 +174,12 @@ jobs:
     # Runs when the builder changed (only after the experimental builder is
     # (re)published successfully) OR when only the final image changed (using the
     # experimental builder from a previous run, so merge-builder is skipped).
-    # Skips on fork PRs, which can't publish.
+    # Skips anywhere that can't publish (fork PRs, and downstream forks).
     if: |
       always() &&
+      github.repository == 'boutproject/hermes-3' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository) &&
+       github.event.pull_request.head.repo.full_name == 'boutproject/hermes-3') &&
       (
         (needs.changes.outputs.builder == 'true' && needs.merge-builder.result == 'success') ||
         (needs.changes.outputs.builder != 'true' && needs.changes.outputs.final == 'true')
@@ -244,12 +246,14 @@ jobs:
   # 'experimental_docker_build' tag directly.
   build-jupyter:
     needs: changes
-    # Publishing needs registry write access, which fork PRs don't have, so skip
-    # cleanly on forks instead of failing on the push step.
+    # Publishing needs write access to the boutproject registry, so skip cleanly
+    # anywhere else (fork PRs and downstream forks) instead of failing on the
+    # push step.
     if: |
       needs.changes.outputs.jupyter == 'true' &&
+      github.repository == 'boutproject/hermes-3' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == 'boutproject/hermes-3')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/update-python-test-dependencies.yml
+++ b/.github/workflows/update-python-test-dependencies.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   update-python-test-dependencies:
+    # Skip scheduled runs on forks; still allow manual dispatch anywhere.
+    if: github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Purpose

Fixes #623. CI workflows were running on downstream forks of `boutproject/hermes-3` when they shouldn't. Two distinct causes, both addressed here:

1. **`pull_request`-triggered docker builds** — the fork guard used `github.event.pull_request.head.repo.full_name == github.repository`, which resolves to the repo the workflow runs in. On a fork, internal branch-to-branch PRs still matched, so the jobs ran and then failed at the publish step.
2. **Scheduled workflows** (raised as a follow-up in the issue) — `build_builder_image`, `cleanup-old-images`, `stale`, and `update-python-test-dependencies` fired on forks via their `schedule` triggers, doing unwanted work (marking a fork's PRs stale, opening dependency PRs) or failing when they tried to publish into the `boutproject` namespace.

### Change Summary

- **`test_docker_build.yml`** — gate the publishing jobs (`build-builder`, `build-final`, `build-jupyter`) on the literal `boutproject/hermes-3` instead of `github.repository`, so they run only where they can publish.
- **Scheduled workflows** — gate each on `github.repository == 'boutproject/hermes-3' || github.event_name == 'workflow_dispatch'`: scheduled/release runs happen only on the canonical repo, but a fork can still manually dispatch.
- **`build_builder_image.yml` (publishing)** — add a `publish_image` toggle to the `build-push-digest` composite action so a fork's manual dispatch builds for validation *without* pushing; the merge/publish jobs are gated to the canonical repo and skip cleanly (via `needs`) on a fork.

| Context | Before | After |
|---|---|---|
| canonical repo, internal PR / schedule / dispatch | runs | runs |
| canonical repo, fork PR | skips | skips |
| downstream fork, scheduled run | runs -> fails | skips |
| downstream fork, manual dispatch | runs -> fails | builds without publishing |

### Validation

Each changed workflow/action parsed with a YAML loader and by the repo's `Validate GitHub Workflows` pre-commit hook. The job-dependency cascade was traced by hand and confirmed with an independent review: on a fork `workflow_dispatch`, `build-builder-image` runs with `publish_image=false`, and `merge-builder-image` -> `build-final-image` -> `merge-final-image` all skip via `needs` rather than fail; on the canonical repo all jobs run normally. Not exercised on a live fork.

### AI Assistance

Changes and this description were drafted with Claude Code. Output was verified by reading the workflow logic, confirming GitHub Actions context/skip semantics (`env` is unavailable in job-level `if`; `inputs` is available in composite-action step `if`), and an independent code-review pass over both commits.

### Documentation

No separate docs needed; the rationale lives in in-file comments next to each guard and in the `publish_image` input description.

### Review Notes

- The `|| github.event_name == 'workflow_dispatch'` clause lets a fork manually run `cleanup-old-images`, `stale`, and `update-python-test-dependencies` too. That is intentional (forks may want to run these against their own repo) and harmless, since those act only on the triggering repo's own resources.
- `boutproject/hermes-3` is left as a literal in the guards (rather than a variable) because `env` is not available in job-level `if:`, and a `vars.*` variable would silently skip everything if unset — the literal is safer and a rename is a simple find/replace.
