### PR TITLE
Connection-length flux limiter for conduction

### DIFF
--- a/include/braginskii_conduction.hxx
+++ b/include/braginskii_conduction.hxx
@@ -27,7 +27,11 @@ struct BraginskiiConduction : public NamedComponent<BraginskiiConduction> {
   ///   - diagnose                     Output additional diagnostic fields?
   ///   - kappa_coefficient            Heat conduction constant. Default is 3.16 for
   ///                                  electrons, 3.9 otherwise
-  ///   - kappa_limit_alpha            Flux limiter, off by default.
+  ///   - kappa_limit_alpha            Flux limiter, off by default. Free-streaming coefficient.
+  ///   - kappa_limit_model            Limiter model: "local" or "connection_length".
+  ///   - kappa_limit_q95              Safety factor used by the connection-length limiter.
+  ///   - kappa_limit_R                Major radius used by the connection-length limiter [m].  
+  /// 
   ///   - conduction_collisions_mode   Can be multispecies: all collisions, or braginskii:
   ///                                  self collisions and ie
   ///
@@ -54,6 +58,16 @@ private:
       all_kappa_coefficient; ///< Leading numerical coefficient in parallel heat flux
                              ///< calculation
   std::map<std::string, BoutReal> all_kappa_limit_alpha; ///< Flux limit if >0
+
+  std::map<std::string, std::string>
+      all_kappa_limit_model; ///< "local" or "connection_length"
+
+  std::map<std::string, BoutReal>
+      all_kappa_limit_q95; ///< Safety factor used by connection-length limiter
+
+  std::map<std::string, BoutReal>
+      all_kappa_limit_R; ///< Major radius, normalised to the Hermes length unit rho_s0
+
   std::map<std::string, Field3D>
       all_flow_ylow_conduction; ///< Conduction energy flow diagnostics
   /// Save more diagnostics?

--- a/include/braginskii_conduction.hxx
+++ b/include/braginskii_conduction.hxx
@@ -30,8 +30,8 @@ struct BraginskiiConduction : public NamedComponent<BraginskiiConduction> {
   ///   - kappa_limit_alpha            Flux limiter, off by default. Free-streaming coefficient.
   ///   - kappa_limit_model            Limiter model: "local" or "connection_length".
   ///   - kappa_limit_q95              Safety factor used by the connection-length limiter.
-  ///   - kappa_limit_R                Major radius used by the connection-length limiter [m].  
-  /// 
+  ///   - kappa_limit_R                Major radius used by the connection-length limiter [m].
+  ///
   ///   - conduction_collisions_mode   Can be multispecies: all collisions, or braginskii:
   ///                                  self collisions and ie
   ///

--- a/include/braginskii_conduction.hxx
+++ b/include/braginskii_conduction.hxx
@@ -68,6 +68,12 @@ private:
   std::map<std::string, BoutReal>
       all_kappa_limit_R; ///< Major radius, normalised to the Hermes length unit rho_s0
 
+  std::map<std::string, bool> 
+      all_neoclassical_ion_conduction; ///< Apply neoclassical correction to ion parallel heat conductivity
+
+  std::map<std::string, BoutReal>
+      all_kappa_epsilon; ///< Inverse aspect ratio used by neoclassical ion conduction correction
+
   std::map<std::string, Field3D>
       all_flow_ylow_conduction; ///< Conduction energy flow diagnostics
   /// Save more diagnostics?

--- a/include/braginskii_conduction.hxx
+++ b/include/braginskii_conduction.hxx
@@ -68,7 +68,7 @@ private:
   std::map<std::string, BoutReal>
       all_kappa_limit_R; ///< Major radius, normalised to the Hermes length unit rho_s0
 
-  std::map<std::string, bool> 
+  std::map<std::string, bool>
       all_neoclassical_ion_conduction; ///< Apply neoclassical correction to ion parallel heat conductivity
 
   std::map<std::string, BoutReal>

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -86,48 +86,44 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
     all_kappa_limit_model[name] =
         options["kappa_limit_model"]
             .doc("Parallel heat-flux limiter model. Options are 'local' and "
-                "'connection_length'. The connection_length model corresponds "
-                "to the local free-streaming approximation used in GRILLIX.")
+                 "'connection_length'. The connection_length model corresponds "
+                 "to the local free-streaming approximation used in GRILLIX.")
             .withDefault<std::string>("local");
 
     if ((all_kappa_limit_model[name] != "local")
         and (all_kappa_limit_model[name] != "connection_length")) {
-      throw BoutException(
-          "kappa_limit_model for species '{}' must be either 'local' or "
-          "'connection_length', but '{}' was given",
-          name, all_kappa_limit_model[name]);
+      throw BoutException("kappa_limit_model for species '{}' must be either 'local' or "
+                          "'connection_length', but '{}' was given",
+                          name, all_kappa_limit_model[name]);
     }
 
     all_kappa_limit_q95[name] =
         options["kappa_limit_q95"]
             .doc("Safety factor q95 used by the connection-length "
-                "parallel heat-flux limiter")
+                 "parallel heat-flux limiter")
             .withDefault(-1.0);
 
     const BoutReal Lnorm = alloptions["units"]["meters"];
 
-    all_kappa_limit_R[name] =
-        options["kappa_limit_R"]
-            .doc("Major radius R used by the connection-length "
-                "parallel heat-flux limiter [m]")
-            .withDefault(-1.0)
-        / Lnorm;    
+    all_kappa_limit_R[name] = options["kappa_limit_R"]
+                                  .doc("Major radius R used by the connection-length "
+                                       "parallel heat-flux limiter [m]")
+                                  .withDefault(-1.0)
+                              / Lnorm;
 
     if ((all_kappa_limit_model[name] == "connection_length")
         and (all_kappa_limit_alpha[name] > 0.0)) {
 
       if (all_kappa_limit_q95[name] <= 0.0) {
-        throw BoutException(
-            "kappa_limit_q95 must be positive for species '{}' when "
-            "kappa_limit_model = connection_length",
-            name);
+        throw BoutException("kappa_limit_q95 must be positive for species '{}' when "
+                            "kappa_limit_model = connection_length",
+                            name);
       }
 
       if (all_kappa_limit_R[name] <= 0.0) {
-        throw BoutException(
-            "kappa_limit_R must be positive for species '{}' when "
-            "kappa_limit_model = connection_length",
-            name);
+        throw BoutException("kappa_limit_R must be positive for species '{}' when "
+                            "kappa_limit_model = connection_length",
+                            name);
       }
     }
 
@@ -327,7 +323,6 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
         // This results in a harmonic average of the heat fluxes
         kappa_par /= (1. + abs(q_SH / softFloor(q_fl, 1e-10)));
 
-
       } else if (kappa_limit_model == "connection_length") {
         /*
         * Connection-length free-streaming limiter used in GRILLIX.
@@ -343,8 +338,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
         const Field3D Nfloor = floor(N, 0.0);
         const Field3D Tfloor = floor(T, 0.0);
 
-        const BoutReal parallel_length =
-            kappa_limit_q95 * kappa_limit_R;
+        const BoutReal parallel_length = kappa_limit_q95 * kappa_limit_R;
 
         const Field3D kappa_free_streaming =
             kappa_limit_alpha * Nfloor * sqrt(Tfloor / AA) * parallel_length;

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -82,6 +82,55 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
             .doc("Flux limiter factor. < 0 means no limit. Typical is 0.2 "
                  "for electrons, 1 for ions.")
             .withDefault(-1.0);
+
+    all_kappa_limit_model[name] =
+        options["kappa_limit_model"]
+            .doc("Parallel heat-flux limiter model. Options are 'local' and "
+                "'connection_length'. The connection_length model corresponds "
+                "to the local free-streaming approximation used in GRILLIX.")
+            .withDefault<std::string>("local");
+
+    if ((all_kappa_limit_model[name] != "local")
+        and (all_kappa_limit_model[name] != "connection_length")) {
+      throw BoutException(
+          "kappa_limit_model for species '{}' must be either 'local' or "
+          "'connection_length', but '{}' was given",
+          name, all_kappa_limit_model[name]);
+    }
+
+    all_kappa_limit_q95[name] =
+        options["kappa_limit_q95"]
+            .doc("Safety factor q95 used by the connection-length "
+                "parallel heat-flux limiter")
+            .withDefault(-1.0);
+
+    const BoutReal Lnorm = alloptions["units"]["meters"];
+
+    all_kappa_limit_R[name] =
+        options["kappa_limit_R"]
+            .doc("Major radius R used by the connection-length "
+                "parallel heat-flux limiter [m]")
+            .withDefault(-1.0)
+        / Lnorm;    
+
+    if ((all_kappa_limit_model[name] == "connection_length")
+        and (all_kappa_limit_alpha[name] > 0.0)) {
+
+      if (all_kappa_limit_q95[name] <= 0.0) {
+        throw BoutException(
+            "kappa_limit_q95 must be positive for species '{}' when "
+            "kappa_limit_model = connection_length",
+            name);
+      }
+
+      if (all_kappa_limit_R[name] <= 0.0) {
+        throw BoutException(
+            "kappa_limit_R must be positive for species '{}' when "
+            "kappa_limit_model = connection_length",
+            name);
+      }
+    }
+
     all_conduction_collisions_mode[name] =
         options["conduction_collisions_mode"]
             .doc("Can be multispecies: all collisions, or "
@@ -219,6 +268,9 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     Field3D& flow_ylow_conduction = all_flow_ylow_conduction[name];
     const BoutReal kappa_coefficient = all_kappa_coefficient[name];
     const BoutReal kappa_limit_alpha = all_kappa_limit_alpha[name];
+    const std::string& kappa_limit_model = all_kappa_limit_model[name];
+    const BoutReal kappa_limit_q95 = all_kappa_limit_q95[name];
+    const BoutReal kappa_limit_R = all_kappa_limit_R[name];
 
     /// Collect the collisionalities based on list of names
     nu = 0;
@@ -250,24 +302,56 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     kappa_par = kappa_coefficient * Pfloor * tau / AA;
 
     if (kappa_limit_alpha > 0.0) {
-      /*
-       * Flux limiter, as used in SOLPS.
-       *
-       * Calculate the heat flux from Spitzer-Harm and flux limit
-       *
-       * Typical value of alpha ~ 0.2 for electrons
-       *
-       * R.Schneider et al. Contrib. Plasma Phys. 46, No. 1-2, 3 – 191 (2006)
-       * DOI 10.1002/ctpp.200610001
-       */
+      if (kappa_limit_model == "local") {
+        /*
+        * Local gradient-dependent heat-flux limiter, as used in SOLPS.
+        *
+        * Calculate the heat flux from Spitzer-Harm and flux limit
+        *
+        * Typical value of alpha ~ 0.2 for electrons
+        *
+        * R.Schneider et al. Contrib. Plasma Phys. 46, No. 1-2, 3 – 191 (2006)
+        * DOI 10.1002/ctpp.200610001
+        *  
+        * q_SH = -kappa_parallel * Grad_parallel(T)
+        * q_FS = alpha * n * T * sqrt(T / m)
+        *
+        * The effective heat flux is the harmonic average of q_SH and q_FS.
+        */
 
-      // Spitzer-Harm heat flux
-      const Field3D q_SH = kappa_par * Grad_par(T);
-      // Free-streaming flux
-      const Field3D q_fl = kappa_limit_alpha * N * T * sqrt(T / AA);
+        // Spitzer-Harm heat flux
+        const Field3D q_SH = kappa_par * Grad_par(T);
+        // Free-streaming flux
+        const Field3D q_fl = kappa_limit_alpha * N * T * sqrt(T / AA);
 
-      // This results in a harmonic average of the heat fluxes
-      kappa_par /= (1. + abs(q_SH / softFloor(q_fl, 1e-10)));
+        // This results in a harmonic average of the heat fluxes
+        kappa_par /= (1. + abs(q_SH / softFloor(q_fl, 1e-10)));
+
+
+      } else if (kappa_limit_model == "connection_length") {
+        /*
+        * Connection-length free-streaming limiter used in GRILLIX.
+        *
+        * kappa_FS = f_FS * n * v_th * q95 * R,
+        *
+        * where R is normalised to the Hermes length unit and
+        * v_th = sqrt(T / m).
+        *
+        * 1 / kappa_eff = 1 / kappa_B + 1 / kappa_FS
+        */
+
+        const Field3D Nfloor = floor(N, 0.0);
+        const Field3D Tfloor = floor(T, 0.0);
+
+        const BoutReal parallel_length =
+            kappa_limit_q95 * kappa_limit_R;
+
+        const Field3D kappa_free_streaming =
+            kappa_limit_alpha * Nfloor * sqrt(Tfloor / AA) * parallel_length;
+
+        const Field3D kappa_sum = kappa_par + kappa_free_streaming;
+        kappa_par = kappa_par * kappa_free_streaming / softFloor(kappa_sum, 1e-10);
+      }
 
       // Values of kappa on cell boundaries are needed for fluxes
       mesh->communicate(kappa_par);

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -114,17 +114,17 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
     all_neoclassical_ion_conduction[name] =
         options["neoclassical_ion_conduction"]
             .doc("Apply the SOLPS neoclassical correction to ion parallel "
-                "heat conductivity")
+                 "heat conductivity")
             .withDefault(false);
 
     all_kappa_epsilon[name] =
         options["kappa_epsilon"]
             .doc("Inverse aspect ratio used in the SOLPS ion conduction correction")
-            .withDefault(0.3);        
+            .withDefault(0.3);
 
     if ((((all_kappa_limit_model[name] == "connection_length")
           and (all_kappa_limit_alpha[name] > 0.0))
-        or all_neoclassical_ion_conduction[name])) {
+         or all_neoclassical_ion_conduction[name])) {
 
       if (all_kappa_limit_q95[name] <= 0.0) {
         throw BoutException("kappa_limit_q95 must be positive for species '{}' when "
@@ -138,7 +138,6 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
                             name);
       }
     }
-
 
     if (all_neoclassical_ion_conduction[name]) {
       const BoutReal charge = options["charge"].as<BoutReal>();
@@ -159,7 +158,8 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
 
   std::vector<std::string> coll_types;
 
-  substitutePermissions("input_vars", {"AA", "charge", "density", "pressure", "temperature"});
+  substitutePermissions("input_vars",
+                        {"AA", "charge", "density", "pressure", "temperature"});
   substitutePermissions("output_vars",
                         {"energy_source", "kappa_par", "energy_flow_ylow"});
   std::vector<std::string> species;
@@ -323,27 +323,25 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     kappa_par = kappa_coefficient * Pfloor * tau / AA;
 
     if (neoclassical_ion_conduction) {
-      // neoclassical corrections for ion kappa_par as implemented in: 
-      // Rozhansky, V., et al. "New B2SOLPS5. 2 transport code for H-mode 
+      // neoclassical corrections for ion kappa_par as implemented in:
+      // Rozhansky, V., et al. "New B2SOLPS5. 2 transport code for H-mode
       // regimes in tokamaks." Nuclear fusion 49.2 (2009): 025007.
 
       const Field3D Tfloor = floor(T, 0.0);
 
-      const BoutReal parallel_length =
-          kappa_limit_q95 * kappa_limit_R;          
+      const BoutReal parallel_length = kappa_limit_q95 * kappa_limit_R;
 
       const Field3D v_thermal = sqrt(2.0 * Tfloor / AA);
 
-      const Field3D nu_star =  parallel_length / tau /
-          (pow(kappa_epsilon, 1.5) * v_thermal);
+      const Field3D nu_star =
+          parallel_length / tau / (pow(kappa_epsilon, 1.5) * v_thermal);
 
       const Field3D sqrt2_nu_star = sqrt(2.0) * nu_star;
 
-      const Field3D K2 =
-            (0.66 + 1.88 * sqrt(kappa_epsilon) - 1.54 * kappa_epsilon)
-          / (1.0 + 1.03 * sqrt(sqrt2_nu_star) + 0.31 * sqrt2_nu_star)
-          + (1.17 * pow(kappa_epsilon, 3.0) * sqrt2_nu_star)
-          / (1.0 + 0.74 * pow(kappa_epsilon, 1.5) * sqrt2_nu_star);
+      const Field3D K2 = (0.66 + 1.88 * sqrt(kappa_epsilon) - 1.54 * kappa_epsilon)
+                             / (1.0 + 1.03 * sqrt(sqrt2_nu_star) + 0.31 * sqrt2_nu_star)
+                         + (1.17 * pow(kappa_epsilon, 3.0) * sqrt2_nu_star)
+                               / (1.0 + 0.74 * pow(kappa_epsilon, 1.5) * sqrt2_nu_star);
 
       const Field3D neoclassical_factor = 1.6 * pow(kappa_epsilon, 1.5) / K2;
 

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -309,7 +309,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
         * R.Schneider et al. Contrib. Plasma Phys. 46, No. 1-2, 3 – 191 (2006)
         * DOI 10.1002/ctpp.200610001
         *  
-        * q_SH = -kappa_parallel * Grad_parallel(T)
+        * q_SH = -kappa_par * Grad_par(T)
         * q_FS = alpha * n * T * sqrt(T / m)
         *
         * The effective heat flux is the harmonic average of q_SH and q_FS.
@@ -346,10 +346,9 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
         const Field3D kappa_sum = kappa_par + kappa_free_streaming;
         kappa_par = kappa_par * kappa_free_streaming / softFloor(kappa_sum, 1e-10);
       }
-
-      // Values of kappa on cell boundaries are needed for fluxes
-      mesh->communicate(kappa_par);
     }
+    // Values of kappa on cell boundaries are needed for fluxes
+    mesh->communicate(kappa_par);
 
     for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
       for (int jz = 0; jz < mesh->LocalNz; jz++) {

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -111,8 +111,20 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
                                   .withDefault(-1.0)
                               / Lnorm;
 
-    if ((all_kappa_limit_model[name] == "connection_length")
-        and (all_kappa_limit_alpha[name] > 0.0)) {
+    all_neoclassical_ion_conduction[name] =
+        options["neoclassical_ion_conduction"]
+            .doc("Apply the SOLPS neoclassical correction to ion parallel "
+                "heat conductivity")
+            .withDefault(false);
+
+    all_kappa_epsilon[name] =
+        options["kappa_epsilon"]
+            .doc("Inverse aspect ratio used in the SOLPS ion conduction correction")
+            .withDefault(0.3);        
+
+    if ((((all_kappa_limit_model[name] == "connection_length")
+          and (all_kappa_limit_alpha[name] > 0.0))
+        or all_neoclassical_ion_conduction[name])) {
 
       if (all_kappa_limit_q95[name] <= 0.0) {
         throw BoutException("kappa_limit_q95 must be positive for species '{}' when "
@@ -127,6 +139,17 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
       }
     }
 
+
+    if (all_neoclassical_ion_conduction[name]) {
+      const BoutReal charge = options["charge"].as<BoutReal>();
+      if (charge < 0.0) {
+        throw BoutException(
+            "The SOLPS neoclassical ion conductivity correction is only implemented for "
+            "positively charged ions (species '{}' has charge = {})",
+            name, charge);
+      }
+    }
+
     all_conduction_collisions_mode[name] =
         options["conduction_collisions_mode"]
             .doc("Can be multispecies: all collisions, or "
@@ -136,7 +159,7 @@ BraginskiiConduction::BraginskiiConduction(const std::string& name, Options& all
 
   std::vector<std::string> coll_types;
 
-  substitutePermissions("input_vars", {"AA", "density", "pressure", "temperature"});
+  substitutePermissions("input_vars", {"AA", "charge", "density", "pressure", "temperature"});
   substitutePermissions("output_vars",
                         {"energy_source", "kappa_par", "energy_flow_ylow"});
   std::vector<std::string> species;
@@ -267,6 +290,8 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     const std::string& kappa_limit_model = all_kappa_limit_model[name];
     const BoutReal kappa_limit_q95 = all_kappa_limit_q95[name];
     const BoutReal kappa_limit_R = all_kappa_limit_R[name];
+    const bool neoclassical_ion_conduction = all_neoclassical_ion_conduction[name];
+    const BoutReal kappa_epsilon = all_kappa_epsilon[name];
 
     /// Collect the collisionalities based on list of names
     nu = 0;
@@ -296,6 +321,34 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     //
     // Note: Coefficient is slightly different for electrons (3.16) and ions (3.9)
     kappa_par = kappa_coefficient * Pfloor * tau / AA;
+
+    if (neoclassical_ion_conduction) {
+      // neoclassical corrections for ion kappa_par as implemented in: 
+      // Rozhansky, V., et al. "New B2SOLPS5. 2 transport code for H-mode 
+      // regimes in tokamaks." Nuclear fusion 49.2 (2009): 025007.
+
+      const Field3D Tfloor = floor(T, 0.0);
+
+      const BoutReal parallel_length =
+          kappa_limit_q95 * kappa_limit_R;          
+
+      const Field3D v_thermal = sqrt(2.0 * Tfloor / AA);
+
+      const Field3D nu_star =  parallel_length / tau /
+          (pow(kappa_epsilon, 1.5) * v_thermal);
+
+      const Field3D sqrt2_nu_star = sqrt(2.0) * nu_star;
+
+      const Field3D K2 =
+            (0.66 + 1.88 * sqrt(kappa_epsilon) - 1.54 * kappa_epsilon)
+          / (1.0 + 1.03 * sqrt(sqrt2_nu_star) + 0.31 * sqrt2_nu_star)
+          + (1.17 * pow(kappa_epsilon, 3.0) * sqrt2_nu_star)
+          / (1.0 + 0.74 * pow(kappa_epsilon, 1.5) * sqrt2_nu_star);
+
+      const Field3D neoclassical_factor = 1.6 * pow(kappa_epsilon, 1.5) / K2;
+
+      kappa_par *= neoclassical_factor;
+    }
 
     if (kappa_limit_alpha > 0.0) {
       if (kappa_limit_model == "local") {


### PR DESCRIPTION

WORK IN PROGRESS
More tests are needed. 



## Summary

1) 
-   Added an optional connection-length-based limiter for the parallel  Braginskii heat conductivity in `braginskii_conduction`.
-   The new model follows the free-streaming approximation used in GRILLIX [Zholobenko et al., Nuclear Fusion 64, 106066 (2024)].
-   The existing local, gradient-dependent heat-flux limiter is retained and remains the default, so existing input files should produce the same results as before.
-   The major radius is provided in metres and converted internally to the Hermes-3 length normalization.



2) 
-   Implement the SOLPS Rozhansky et al. (2009) neoclassical correction to the ion parallel thermal conductivity using fixed q95, major radius, and inverse aspect ratio inputs.
-   Reuse the q95 and major-radius options from the connection-length heat-flux limiter and check that all required parameters are positive when either model is enabled.
-   Not implemented for electrons.



## New input options

The limiter model can be selected independently for each species:

```ini
[e]
kappa_limit_model = connection_length
kappa_limit_alpha = 1.0
kappa_limit_q95 = 4.0
kappa_limit_R = 2

[d+]
kappa_limit_model = connection_length
kappa_limit_alpha = 1.0
kappa_limit_q95 = 4.0
kappa_limit_R = 2