### PR TITLE
Reactions performance improvements

### DIFF
--- a/docs/sphinx/developer.rst
+++ b/docs/sphinx/developer.rst
@@ -1078,7 +1078,7 @@ Source term calculation
 Density, momentum and energy source fields are constructed in `Reaction::transform_impl` using the
 `RateHelper` class to calculate reaction rates and collision frequencies.
 
-On instantiation, :code:`RateHelper` assembles maps containing (pointers to) all reactant densities
+On instantiation, :code:`RateHelper` assembles vectors containing (pointers to) all reactant densities
 and any other fields required as inputs.
 
 `RateHelper::calc_rates` is "run-time templated", allowing it to accept rate functions with 1D and

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -16,14 +16,24 @@
 
 namespace hermes {
 
-/// Struct to hold pre-averaged data for each cell
-struct CellData {
-  CellData() : CellData(0, 0, 0) {}
-  CellData(BoutReal c, BoutReal l, BoutReal r) : centre(c), left(l), right(r) {}
+/// Struct to hold values used in cell averaging
+struct DataTriple {
+  DataTriple() : DataTriple(0, 0, 0) {}
+  DataTriple(BoutReal c, BoutReal l, BoutReal r) : centre(c), left(l), right(r) {}
   BoutReal centre, left, right;
 };
 
-typedef std::map<std::string, CellData> CellProps;
+// Temporary storage for central,left,right vals of various properties at each cell index
+struct CellProps {
+  CellProps(size_t num_reactants)
+      : densities(num_reactants), collision_freqs(num_reactants) {}
+
+  DataTriple mass_action = {1, 1, 1};
+  DataTriple rate;
+
+  std::vector<DataTriple> densities;
+  std::vector<DataTriple> collision_freqs;
+};
 
 /// Signatures for different rate calculations.
 /// N.B. one extra arg required for the mass action factor.
@@ -31,7 +41,7 @@ using OneDRateFunc = std::function<BoutReal(BoutReal, BoutReal)>;
 using TwoDRateFunc = std::function<BoutReal(BoutReal, BoutReal, BoutReal)>;
 using RateFuncVariant = std::variant<OneDRateFunc, TwoDRateFunc>;
 
-/// Struct to hold reaction rate and collision frequency data
+/// Struct to hold final (possibly averaged) reaction rate and collision frequency fields that get returned by calc_rates()
 struct RateData {
   /// The reaction rate Field3D
   Field3D rate;
@@ -89,7 +99,7 @@ struct RateHelper {
     for (const auto& reactant : reactant_names) {
       // Hold the wrapper in a local so the referenced field lifetime is obvious to GCC.
       const GuardedOptions reactant_density = state["species"][reactant]["density"];
-      this->reactant_densities[reactant] = &reactant_density.GetRef<Field3D>();
+      this->reactant_densities.push_back(&reactant_density.GetRef<Field3D>());
     }
 
     // Compute / extract fields that are required as parameters for the rate calculations
@@ -97,14 +107,14 @@ struct RateHelper {
       static_assert(dependent_false<RateParamsType>,
                     "RateParamsTypes::ET not implemented");
     } else if constexpr (RateParamsType == RateParamsTypes::nT) {
-      for (auto field_lbl : {"e:density", "e:temperature"}) {
-        // Split the access to avoid dangling-reference warnings through temporary wrappers.
-        const GuardedOptions rate_param = state["species"][field_lbl];
-        add_rate_param(field_lbl, rate_param.template GetRef<Field3D>());
-      }
+
+      const GuardedOptions n_e = state["species"]["e:density"];
+      const GuardedOptions T_e = state["species"]["e:temperature"];
+      this->rate_params.push_back(&n_e.GetRef<Field3D>());
+      this->rate_params.push_back(&T_e.GetRef<Field3D>());
     } else if constexpr (RateParamsType == RateParamsTypes::T) {
       calc_Teff(state, units, reactant_names, Teff_storage);
-      add_rate_param("Teff", Teff_storage);
+      this->rate_params.push_back(&Teff_storage);
     } else {
       // Compile-time error if any other RateParamsType enum exists
       static_assert(dependent_false<RateParamsType>, "Unhandled RateParamsType");
@@ -125,28 +135,20 @@ struct RateHelper {
 
     // Initialize result data structure
     RateData result;
-    std::string first_key = str_keys(this->rate_params)[0];
-    result.rate = emptyFrom(*this->rate_params[first_key]);
+    result.rate = emptyFrom(*this->rate_params[0]);
     for (const std::string& reactant : this->reactant_names) {
-      result.collision_frequencies[reactant] = emptyFrom(*this->rate_params[first_key]);
+      result.collision_frequencies[reactant] = emptyFrom(*this->rate_params[0]);
     }
 
-    // Temporary storage for central,left,right vals of each property at each cell index
-    CellProps cell_props;
-    cell_props["rate"] = CellData();
-    for (const std::string& reactant : this->reactant_names) {
-      // CellData for the collision frequency associated with each reactant
-      cell_props[reactant] = CellData();
-      // CellData for the density associated with each reactant
-      cell_props[reactant + "_density"] = CellData();
-    }
+    // Temporary storage for densities, rate and collision frequencies associated with a cell
+    CellProps cell_props(this->num_reactants);
 
     // Populate cell_props differently according to the rate function type
     std::visit(
         [this, &cell_props, &do_averaging, &result](auto&& rate_calc_func) {
           auto J = result.rate.getCoordinates()->J;
           BOUT_FOR(i, region) {
-            // Add densities and mass action-factor to cell_props
+            // Get densities and mass action-factor for this cell
             add_densities_and_mass_action(i, cell_props, do_averaging);
 
             using RateFuncType = std::decay_t<decltype(rate_calc_func)>;
@@ -154,16 +156,16 @@ struct RateHelper {
               // 1D rate function
               if constexpr (RateParamsType == RateParamsTypes::T) {
                 // Get rate params
-                CellData T_data = compute_rate_param(Teff_name, i, do_averaging);
+                DataTriple T_data = compute_rate_param(0, i, do_averaging);
 
                 // Compute rate(s)
-                cell_props["rate"].centre =
-                    rate_calc_func(cell_props["mass_action"].centre, T_data.centre);
+                cell_props.rate.centre =
+                    rate_calc_func(cell_props.mass_action.centre, T_data.centre);
                 if (do_averaging) {
-                  cell_props["rate"].left =
-                      rate_calc_func(cell_props["mass_action"].left, T_data.left);
-                  cell_props["rate"].right =
-                      rate_calc_func(cell_props["mass_action"].right, T_data.right);
+                  cell_props.rate.left =
+                      rate_calc_func(cell_props.mass_action.left, T_data.left);
+                  cell_props.rate.right =
+                      rate_calc_func(cell_props.mass_action.right, T_data.right);
                 }
               } else {
                 throw BoutException(
@@ -173,17 +175,17 @@ struct RateHelper {
               // 2D rate function
               if constexpr (RateParamsType == RateParamsTypes::nT) {
                 // Get rate params
-                CellData ne_data = compute_rate_param("e:density", i, do_averaging);
-                CellData Te_data = compute_rate_param("e:temperature", i, do_averaging);
+                DataTriple ne_data = compute_rate_param(0, i, do_averaging);
+                DataTriple Te_data = compute_rate_param(1, i, do_averaging);
 
                 // Compute rate(s)
-                cell_props["rate"].centre = rate_calc_func(
-                    cell_props["mass_action"].centre, ne_data.centre, Te_data.centre);
+                cell_props.rate.centre = rate_calc_func(cell_props.mass_action.centre,
+                                                        ne_data.centre, Te_data.centre);
                 if (do_averaging) {
-                  cell_props["rate"].left = rate_calc_func(cell_props["mass_action"].left,
-                                                           ne_data.left, Te_data.left);
-                  cell_props["rate"].right = rate_calc_func(
-                      cell_props["mass_action"].right, ne_data.right, Te_data.right);
+                  cell_props.rate.left = rate_calc_func(cell_props.mass_action.left,
+                                                        ne_data.left, Te_data.left);
+                  cell_props.rate.right = rate_calc_func(cell_props.mass_action.right,
+                                                         ne_data.right, Te_data.right);
                 }
 
               } else if constexpr (RateParamsType == RateParamsTypes::ET) {
@@ -196,10 +198,8 @@ struct RateHelper {
               }
             }
 
-            // Add the collision freqs (the rate(s) divided by the reactant densit(y/ies)
-            for (const auto& reactant : this->reactant_names) {
-              add_collision_freq(reactant, cell_props, do_averaging);
-            }
+            // Add the collision freqs (rate(s) divided by each reactant density)
+            add_collision_freqs(cell_props, do_averaging);
 
             if (do_averaging) {
               // Compute averaged rate, collision frequencies and store in result
@@ -207,20 +207,28 @@ struct RateHelper {
               auto Jm = J.yup()[i.ym()];
               auto Jp = J.ydown()[i.yp()];
 
-              result.rate[i] = 4. / 6 * cell_props["rate"].centre
-                               + (Ji + Jm) / (12. * Ji) * cell_props["rate"].left
-                               + (Ji + Jp) / (12. * Ji) * cell_props["rate"].right;
-              for (const std::string& reactant : this->reactant_names) {
-                result.collision_frequencies[reactant][i] =
-                    4. / 6 * cell_props[reactant].centre
-                    + (Ji + Jm) / (12. * Ji) * cell_props[reactant].left
-                    + (Ji + Jp) / (12. * Ji) * cell_props[reactant].right;
+              result.rate[i] = 4. / 6 * cell_props.rate.centre
+                               + (Ji + Jm) / (12. * Ji) * cell_props.rate.left
+                               + (Ji + Jp) / (12. * Ji) * cell_props.rate.right;
+              for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
+                   reactant_idx++) {
+
+                std::string reactant_name = this->reactant_names[reactant_idx];
+                result.collision_frequencies[reactant_name][i] =
+                    4. / 6 * cell_props.collision_freqs[reactant_idx].centre
+                    + (Ji + Jm) / (12. * Ji)
+                          * cell_props.collision_freqs[reactant_idx].left
+                    + (Ji + Jp) / (12. * Ji)
+                          * cell_props.collision_freqs[reactant_idx].right;
               }
             } else {
               // Extract rate, collision frequencies at cell centre and store in result
-              result.rate[i] = cell_props["rate"].centre;
-              for (const std::string& reactant : this->reactant_names) {
-                result.collision_frequencies[reactant][i] = cell_props[reactant].centre;
+              result.rate[i] = cell_props.rate.centre;
+              for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
+                   reactant_idx++) {
+                std::string reactant_name = this->reactant_names[reactant_idx];
+                result.collision_frequencies[reactant_name][i] =
+                    cell_props.collision_freqs[reactant_idx].centre;
               }
             }
           }
@@ -237,7 +245,7 @@ private:
   RateFuncVariant rate_calc_func;
 
   /// Reactant densities, keyed by species name (stored as pointers to avoid copying)
-  std::map<std::string, const Field3D*> reactant_densities;
+  std::vector<const Field3D*> reactant_densities;
 
   /// Reactant names in the order provided to the constructor
   std::vector<std::string> reactant_names;
@@ -246,20 +254,10 @@ private:
   const Region<Ind3D> region;
 
   // Rate parameter fields (stored as pointers to avoid copying)
-  std::map<std::string, const Field3D*> rate_params;
+  std::vector<const Field3D*> rate_params;
 
   // Storage for Teff when RateParamsType == T (needed to keep the object alive)
   Field3D Teff_storage;
-
-  /**
-   * @brief Store a field associated with a rate parameter
-   *
-   * @param field_lbl Label/tag associated with the field
-   * @param fld reference to the field object
-   */
-  void add_rate_param(const std::string& field_lbl, const Field3D& fld) {
-    this->rate_params.insert(std::make_pair(field_lbl, &fld));
-  }
 
   /**
    * @brief Compute the effective temperature (in eV) of heavy reactants.
@@ -300,41 +298,47 @@ private:
   }
 
   /**
-   * @brief Divide the reaction rate by a reactant's density to compute the collision frequency, accounting for cell averaging.
-   * Add the result(s) to cell_props.
+   * @brief For each reactant, divide the reaction rate by reactant density to compute the associated collision frequency
    *
-   * @param reactant[in] name of the reactant species
-   * @param cell_props[inout] cell-centered properties including reaction rates
-   * @param do_averaging[in] whether to compute left and right averaged values
+   * @param cell_props[inout] temporary struct already containing reaction rates and densities
+   * @param do_averaging[in] whether to compute left and right values for averaging
    */
-  inline void add_collision_freq(const std::string& reactant, CellProps& cell_props,
-                                 bool do_averaging = true) {
-    std::string density_key = reactant + "_density";
-    cell_props[reactant].centre =
-        cell_props["rate"].centre / cell_props[density_key].centre;
-    if (do_averaging) {
-      cell_props[reactant].left = cell_props["rate"].left / cell_props[density_key].left;
-      cell_props[reactant].right =
-          cell_props["rate"].right / cell_props[density_key].right;
+  inline void add_collision_freqs(CellProps& cell_props, bool do_averaging = true) {
+    for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
+         reactant_idx++) {
+      cell_props.collision_freqs[reactant_idx].centre =
+          cell_props.rate.centre / cell_props.densities[reactant_idx].centre;
+      if (do_averaging) {
+        cell_props.collision_freqs[reactant_idx].left =
+            cell_props.rate.left / cell_props.densities[reactant_idx].left;
+        cell_props.collision_freqs[reactant_idx].right =
+            cell_props.rate.right / cell_props.densities[reactant_idx].right;
+      }
     }
   }
 
   inline void add_densities_and_mass_action(Ind3D i, CellProps& cell_props,
                                             bool do_averaging) {
-    cell_props["mass_action"] = CellData{1, 1, 1};
-    for (const auto& [sp_name, dens] : this->reactant_densities) {
-      std::string density_key = sp_name + "_density";
-      cell_props[density_key].centre = (*dens)[i];
-      cell_props["mass_action"].centre *= (*dens)[i];
+    // Reset mass action products
+    cell_props.mass_action.centre = 1.0;
+    cell_props.mass_action.left = 1.0;
+    cell_props.mass_action.right = 1.0;
+
+    // Store interpolated densities and mass action
+    for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
+         ++reactant_idx) {
+      auto* dens = this->reactant_densities[reactant_idx];
+      cell_props.densities[reactant_idx].centre = (*dens)[i];
+      cell_props.mass_action.centre *= (*dens)[i];
       if (do_averaging) {
         auto ym = i.ym();
         auto yp = i.yp();
-        cell_props[density_key].left =
+        cell_props.densities[reactant_idx].left =
             cellLeft<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
-        cell_props[density_key].right =
+        cell_props.densities[reactant_idx].right =
             cellRight<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
-        cell_props["mass_action"].left *= cell_props[density_key].left;
-        cell_props["mass_action"].right *= cell_props[density_key].right;
+        cell_props.mass_action.left *= cell_props.densities[reactant_idx].left;
+        cell_props.mass_action.right *= cell_props.densities[reactant_idx].right;
       }
     }
   }
@@ -347,12 +351,11 @@ private:
    * @param do_averaging whether to compute left and right values
    * @return CellData struct containing centre, left, and right values
    */
-  inline CellData compute_rate_param(const std::string& name, Ind3D i,
-                                     bool do_averaging) {
+  inline DataTriple compute_rate_param(std::size_t idx, Ind3D i, bool do_averaging) {
     auto ym = i.ym();
     auto yp = i.yp();
-    const auto& field = *this->rate_params[name];
-    CellData result;
+    const auto& field = *this->rate_params[idx];
+    DataTriple result;
     result.centre = field[i];
     if (do_averaging) {
       result.left = cellLeft<Limiter>(field[i], field[ym], field[yp]);

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -244,7 +244,7 @@ private:
   /// Size of reactant_names, cached to avoid repeated .size() calls
   size_t num_reactants;
 
-  /// Function to calculate reaction rate as a function of n_e, T_e
+  /// Function to calculate reaction rate
   RateFuncVariant rate_calc_func;
 
   /// Reactant densities, keyed by species name (stored as pointers to avoid copying)

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -23,6 +23,8 @@ struct CellData {
   BoutReal centre, left, right;
 };
 
+typedef std::map<std::string, CellData> CellProps;
+
 /// Signatures for different rate calculations.
 /// N.B. one extra arg required for the mass action factor.
 using OneDRateFunc = std::function<BoutReal(BoutReal, BoutReal)>;
@@ -130,76 +132,58 @@ struct RateHelper {
     }
 
     // Temporary storage for central,left,right vals of each property at each cell index
-    std::map<std::string, CellData> cell_data;
-    cell_data["rate"] = CellData();
+    CellProps cell_props;
+    cell_props["rate"] = CellData();
     for (const std::string& reactant : this->reactant_names) {
-      cell_data[reactant] = CellData();
+      // CellData for the collision frequency associated with each reactant
+      cell_props[reactant] = CellData();
+      // CellData for the density associated with each reactant
+      cell_props[reactant + "_density"] = CellData();
     }
 
-    // Populate cell_data differently according to rate function type
+    // Populate cell_props differently according to the rate function type
     std::visit(
-        [this, &cell_data, &do_averaging, &result](auto&& rate_calc_func) {
+        [this, &cell_props, &do_averaging, &result](auto&& rate_calc_func) {
           auto J = result.rate.getCoordinates()->J;
           BOUT_FOR(i, region) {
+            // Add densities and mass action-factor to cell_props
+            add_densities_and_mass_action(i, cell_props, do_averaging);
+
             using RateFuncType = std::decay_t<decltype(rate_calc_func)>;
             if constexpr (std::is_same_v<RateFuncType, OneDRateFunc>) {
+              // 1D rate function
               if constexpr (RateParamsType == RateParamsTypes::T) {
+                // Get rate params
                 CellData T_data = compute_rate_param(Teff_name, i, do_averaging);
 
-                CellData mass_actions = compute_mass_actions(i, do_averaging);
-                cell_data["rate"].centre =
-                    rate_calc_func(mass_actions.centre, T_data.centre);
+                // Compute rate(s)
+                cell_props["rate"].centre =
+                    rate_calc_func(cell_props["mass_action"].centre, T_data.centre);
                 if (do_averaging) {
-                  cell_data["rate"].left = rate_calc_func(mass_actions.left, T_data.left);
-                  cell_data["rate"].right =
-                      rate_calc_func(mass_actions.right, T_data.right);
-                }
-
-                // collision freqs. at centre, left, right
-                for (const auto& reactant : this->reactant_names) {
-                  CellData coll_freq_dens = compute_collision_freq_density(
-                      i, do_averaging, reactant, mass_actions);
-                  cell_data[reactant].centre =
-                      rate_calc_func(coll_freq_dens.centre, T_data.centre);
-                  if (do_averaging) {
-                    cell_data[reactant].left =
-                        rate_calc_func(coll_freq_dens.left, T_data.left);
-                    cell_data[reactant].right =
-                        rate_calc_func(coll_freq_dens.right, T_data.right);
-                  }
+                  cell_props["rate"].left =
+                      rate_calc_func(cell_props["mass_action"].left, T_data.left);
+                  cell_props["rate"].right =
+                      rate_calc_func(cell_props["mass_action"].right, T_data.right);
                 }
               } else {
                 throw BoutException(
                     "Unhandled RateParamsType (1D rate function being passed)");
               }
             } else if constexpr (std::is_same_v<RateFuncType, TwoDRateFunc>) {
+              // 2D rate function
               if constexpr (RateParamsType == RateParamsTypes::nT) {
+                // Get rate params
                 CellData ne_data = compute_rate_param("e:density", i, do_averaging);
                 CellData Te_data = compute_rate_param("e:temperature", i, do_averaging);
 
-                // reaction rates at centre, left, right
-                CellData mass_actions = compute_mass_actions(i, do_averaging);
-                cell_data["rate"].centre =
-                    rate_calc_func(mass_actions.centre, ne_data.centre, Te_data.centre);
+                // Compute rate(s)
+                cell_props["rate"].centre = rate_calc_func(
+                    cell_props["mass_action"].centre, ne_data.centre, Te_data.centre);
                 if (do_averaging) {
-                  cell_data["rate"].left =
-                      rate_calc_func(mass_actions.left, ne_data.left, Te_data.left);
-                  cell_data["rate"].right =
-                      rate_calc_func(mass_actions.right, ne_data.right, Te_data.right);
-                }
-
-                // collision freqs. at centre, left, right
-                for (const auto& reactant : this->reactant_names) {
-                  CellData dens_prods = compute_collision_freq_density(
-                      i, do_averaging, reactant, mass_actions);
-                  cell_data[reactant].centre =
-                      rate_calc_func(dens_prods.centre, ne_data.centre, Te_data.centre);
-                  if (do_averaging) {
-                    cell_data[reactant].left =
-                        rate_calc_func(dens_prods.left, ne_data.left, Te_data.left);
-                    cell_data[reactant].right =
-                        rate_calc_func(dens_prods.right, ne_data.right, Te_data.right);
-                  }
+                  cell_props["rate"].left = rate_calc_func(cell_props["mass_action"].left,
+                                                           ne_data.left, Te_data.left);
+                  cell_props["rate"].right = rate_calc_func(
+                      cell_props["mass_action"].right, ne_data.right, Te_data.right);
                 }
 
               } else if constexpr (RateParamsType == RateParamsTypes::ET) {
@@ -212,26 +196,31 @@ struct RateHelper {
               }
             }
 
+            // Add the collision freqs (the rate(s) divided by the reactant densit(y/ies)
+            for (const auto& reactant : this->reactant_names) {
+              add_collision_freq(reactant, cell_props, do_averaging);
+            }
+
             if (do_averaging) {
               // Compute averaged rate, collision frequencies and store in result
               auto Ji = J[i];
               auto Jm = J.yup()[i.ym()];
               auto Jp = J.ydown()[i.yp()];
 
-              result.rate[i] = 4. / 6 * cell_data["rate"].centre
-                               + (Ji + Jm) / (12. * Ji) * cell_data["rate"].left
-                               + (Ji + Jp) / (12. * Ji) * cell_data["rate"].right;
+              result.rate[i] = 4. / 6 * cell_props["rate"].centre
+                               + (Ji + Jm) / (12. * Ji) * cell_props["rate"].left
+                               + (Ji + Jp) / (12. * Ji) * cell_props["rate"].right;
               for (const std::string& reactant : this->reactant_names) {
                 result.collision_frequencies[reactant][i] =
-                    4. / 6 * cell_data[reactant].centre
-                    + (Ji + Jm) / (12. * Ji) * cell_data[reactant].left
-                    + (Ji + Jp) / (12. * Ji) * cell_data[reactant].right;
+                    4. / 6 * cell_props[reactant].centre
+                    + (Ji + Jm) / (12. * Ji) * cell_props[reactant].left
+                    + (Ji + Jp) / (12. * Ji) * cell_props[reactant].right;
               }
             } else {
               // Extract rate, collision frequencies at cell centre and store in result
-              result.rate[i] = cell_data["rate"].centre;
+              result.rate[i] = cell_props["rate"].centre;
               for (const std::string& reactant : this->reactant_names) {
-                result.collision_frequencies[reactant][i] = cell_data[reactant].centre;
+                result.collision_frequencies[reactant][i] = cell_props[reactant].centre;
               }
             }
           }
@@ -311,59 +300,43 @@ private:
   }
 
   /**
-   * @brief Compute the density product to use in a collision frequency by dividing the
-   * total mass action factor by a specific reactant's density.
+   * @brief Divide the reaction rate by a reactant's density to compute the collision frequency, accounting for cell averaging.
+   * Add the result(s) to cell_props.
    *
-   * @param i central index
-   * @param do_averaging whether to compute left and right values
-   * @param reactant_name name of the reactant to exclude from the product
-   * @param mass_actions pre-computed mass action factor
-   * @return CellData struct containing centre, left, and right values
+   * @param reactant[in] name of the reactant species
+   * @param cell_props[inout] cell-centered properties including reaction rates
+   * @param do_averaging[in] whether to compute left and right averaged values
    */
-  inline CellData compute_collision_freq_density(Ind3D i, bool do_averaging,
-                                                 const std::string& reactant_name,
-                                                 const CellData& mass_actions) {
-    auto ym = i.ym();
-    auto yp = i.yp();
-    const auto& dens = *this->reactant_densities.at(reactant_name);
-    CellData result = mass_actions;
-
-    if (result.centre > 0) {
-      result.centre /= dens[i];
-    }
-
+  inline void add_collision_freq(const std::string& reactant, CellProps& cell_props,
+                                 bool do_averaging = true) {
+    std::string density_key = reactant + "_density";
+    cell_props[reactant].centre =
+        cell_props["rate"].centre / cell_props[density_key].centre;
     if (do_averaging) {
-      if (result.left > 0) {
-        result.left /= cellLeft<Limiter>(dens[i], dens[ym], dens[yp]);
-      }
-      if (result.right > 0) {
-        result.right /= cellRight<Limiter>(dens[i], dens[ym], dens[yp]);
-      }
+      cell_props[reactant].left = cell_props["rate"].left / cell_props[density_key].left;
+      cell_props[reactant].right =
+          cell_props["rate"].right / cell_props[density_key].right;
     }
-
-    return result;
   }
 
-  /**
-   * @brief Compute the product of all reactant densities at centre, left, and right
-   * positions.
-   *
-   * @param i central index
-   * @param do_averaging whether to compute left and right values
-   * @return CellData struct containing centre, left, and right mass action factors
-   */
-  inline CellData compute_mass_actions(Ind3D i, bool do_averaging) {
-    auto ym = i.ym();
-    auto yp = i.yp();
-    CellData result{1, 1, 1};
+  inline void add_densities_and_mass_action(Ind3D i, CellProps& cell_props,
+                                            bool do_averaging) {
+    cell_props["mass_action"] = CellData{1, 1, 1};
     for (const auto& [sp_name, dens] : this->reactant_densities) {
-      result.centre *= (*dens)[i];
+      std::string density_key = sp_name + "_density";
+      cell_props[density_key].centre = (*dens)[i];
+      cell_props["mass_action"].centre *= (*dens)[i];
       if (do_averaging) {
-        result.left *= cellLeft<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
-        result.right *= cellRight<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
+        auto ym = i.ym();
+        auto yp = i.yp();
+        cell_props[density_key].left =
+            cellLeft<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
+        cell_props[density_key].right =
+            cellRight<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
+        cell_props["mass_action"].left *= cell_props[density_key].left;
+        cell_props["mass_action"].right *= cell_props[density_key].right;
       }
     }
-    return result;
   }
 
   /**

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -41,10 +41,19 @@ using RateFuncVariant = std::variant<OneDRateFunc, TwoDRateFunc>;
 
 /// Struct to hold final (possibly averaged) reaction rate and collision frequency fields that get returned by calc_rates()
 struct RateData {
+public:
+  RateData(const std::vector<std::string>& reactant_names)
+      : collision_frequencies(reactant_names.size()) {
+    for (size_t i = 0; i < reactant_names.size(); ++i) {
+      reactant_indices[reactant_names[i]] = i;
+    }
+  }
+
   /// The reaction rate Field3D
   Field3D rate;
+
   /// Collision frequencies keyed by reactant name
-  std::map<std::string, Field3D> collision_frequencies;
+  std::vector<Field3D> collision_frequencies;
 
   /**
    * @brief Extract collision frequency for a reactant.
@@ -54,13 +63,17 @@ struct RateData {
    * @throws BoutException if reactant name not found
    */
   const Field3D& coll_freq(const std::string& reactant_name) const {
-    auto it = this->collision_frequencies.find(reactant_name);
-    if (it == this->collision_frequencies.end()) {
+    auto it = this->reactant_indices.find(reactant_name);
+    if (it == this->reactant_indices.end()) {
       throw BoutException(
           fmt::format("Collision frequency not found for reactant '{}'", reactant_name));
     }
-    return it->second;
+    return collision_frequencies[it->second];
   }
+
+private:
+  /// Reactant indices keyed by reactant name
+  std::map<std::string, size_t> reactant_indices;
 };
 
 // This is a workaround before CWG2518/P2593R1, taken from cppreference.com
@@ -130,10 +143,11 @@ struct RateHelper {
                       bool do_averaging = true) {
 
     // Initialize result data structure
-    RateData result;
+    RateData result(reactant_names);
     result.rate = emptyFrom(*this->rate_params[0]);
-    for (const std::string& reactant : this->reactant_names) {
-      result.collision_frequencies[reactant] = emptyFrom(*this->rate_params[0]);
+    for (std::size_t reactant_idx = 0; reactant_idx < this->reactant_names.size();
+         ++reactant_idx) {
+      result.collision_frequencies[reactant_idx] = emptyFrom(*this->rate_params[0]);
     }
 
     // Temporary storage for densities, rate and collision frequencies associated with a cell
@@ -205,9 +219,7 @@ struct RateHelper {
                                + (Ji + Jp) / (12. * Ji) * cell_props.rate.right;
               for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
                    reactant_idx++) {
-
-                const std::string& reactant_name = this->reactant_names[reactant_idx];
-                result.collision_frequencies[reactant_name][i] =
+                result.collision_frequencies[reactant_idx][i] =
                     4. / 6 * cell_props.collision_freqs[reactant_idx].centre
                     + (Ji + Jm) / (12. * Ji)
                           * cell_props.collision_freqs[reactant_idx].left
@@ -219,8 +231,7 @@ struct RateHelper {
               result.rate[i] = cell_props.rate.centre;
               for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
                    reactant_idx++) {
-                const std::string& reactant_name = this->reactant_names[reactant_idx];
-                result.collision_frequencies[reactant_name][i] =
+                result.collision_frequencies[reactant_idx][i] =
                     cell_props.collision_freqs[reactant_idx].centre;
               }
             }

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -145,14 +145,15 @@ struct RateHelper {
           auto J = result.rate.getCoordinates()->J;
           BOUT_FOR(i, region) {
             // Get densities for this cell
-            add_densities(i, cell_props, do_averaging);
+            collect_densities(i, cell_props, do_averaging);
 
             using RateFuncType = std::decay_t<decltype(rate_calc_func)>;
             if constexpr (std::is_same_v<RateFuncType, OneDRateFunc>) {
               // 1D rate function
               if constexpr (RateParamsType == RateParamsTypes::T) {
                 // Get rate params
-                DataTriple T_data = compute_rate_param(0, i, do_averaging);
+                constexpr std::size_t T_idx = 0;
+                DataTriple T_data = compute_rate_param(T_idx, i, do_averaging);
 
                 // Compute rate(s)
                 cell_props.rate.centre = rate_calc_func(T_data.centre);
@@ -167,9 +168,11 @@ struct RateHelper {
             } else if constexpr (std::is_same_v<RateFuncType, TwoDRateFunc>) {
               // 2D rate function
               if constexpr (RateParamsType == RateParamsTypes::nT) {
+                constexpr std::size_t ne_idx = 0;
+                constexpr std::size_t Te_idx = 1;
                 // Get rate params
-                DataTriple ne_data = compute_rate_param(0, i, do_averaging);
-                DataTriple Te_data = compute_rate_param(1, i, do_averaging);
+                DataTriple ne_data = compute_rate_param(ne_idx, i, do_averaging);
+                DataTriple Te_data = compute_rate_param(Te_idx, i, do_averaging);
 
                 // Compute rate(s)
                 cell_props.rate.centre = rate_calc_func(ne_data.centre, Te_data.centre);
@@ -189,7 +192,7 @@ struct RateHelper {
             }
 
             // Apply density factors to rate and compute collision frequencies
-            add_density_factors(cell_props, do_averaging);
+            apply_density_factors(cell_props, do_averaging);
 
             if (do_averaging) {
               // Compute averaged rate, collision frequencies and store in result
@@ -203,7 +206,7 @@ struct RateHelper {
               for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
                    reactant_idx++) {
 
-                std::string reactant_name = this->reactant_names[reactant_idx];
+                const std::string& reactant_name = this->reactant_names[reactant_idx];
                 result.collision_frequencies[reactant_name][i] =
                     4. / 6 * cell_props.collision_freqs[reactant_idx].centre
                     + (Ji + Jm) / (12. * Ji)
@@ -216,7 +219,7 @@ struct RateHelper {
               result.rate[i] = cell_props.rate.centre;
               for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
                    reactant_idx++) {
-                std::string reactant_name = this->reactant_names[reactant_idx];
+                const std::string& reactant_name = this->reactant_names[reactant_idx];
                 result.collision_frequencies[reactant_name][i] =
                     cell_props.collision_freqs[reactant_idx].centre;
               }
@@ -293,7 +296,7 @@ private:
    * @param cell_props[inout] temporary struct already containing rates, collision freqs, densities
    * @param do_averaging[in] whether to compute left and right values for averaging
    */
-  inline void add_density_factors(CellProps& cell_props, bool do_averaging = true) {
+  inline void apply_density_factors(CellProps& cell_props, bool do_averaging = true) {
     // Save <sigma.v> (before any density factors are applied)
     const DataTriple sigma_v = cell_props.rate;
 
@@ -324,7 +327,7 @@ private:
     }
   }
 
-  inline void add_densities(Ind3D i, CellProps& cell_props, bool do_averaging) {
+  inline void collect_densities(Ind3D i, CellProps& cell_props, bool do_averaging) {
     // Store interpolated densities
     for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
          ++reactant_idx) {

--- a/include/rate_helper.hxx
+++ b/include/rate_helper.hxx
@@ -28,17 +28,15 @@ struct CellProps {
   CellProps(size_t num_reactants)
       : densities(num_reactants), collision_freqs(num_reactants) {}
 
-  DataTriple mass_action = {1, 1, 1};
   DataTriple rate;
 
   std::vector<DataTriple> densities;
   std::vector<DataTriple> collision_freqs;
 };
 
-/// Signatures for different rate calculations.
-/// N.B. one extra arg required for the mass action factor.
-using OneDRateFunc = std::function<BoutReal(BoutReal, BoutReal)>;
-using TwoDRateFunc = std::function<BoutReal(BoutReal, BoutReal, BoutReal)>;
+/// Signatures for different rate calculations
+using OneDRateFunc = std::function<BoutReal(BoutReal)>;
+using TwoDRateFunc = std::function<BoutReal(BoutReal, BoutReal)>;
 using RateFuncVariant = std::variant<OneDRateFunc, TwoDRateFunc>;
 
 /// Struct to hold final (possibly averaged) reaction rate and collision frequency fields that get returned by calc_rates()
@@ -86,8 +84,6 @@ struct RateHelper {
    *
    * @param state
    * @param reactant_names vector of reactant names
-   * @param rate_calc_func function with which to compute the rate from the mass action
-   * factor, n_e and T_e
    * @param region the region in which to calculate the rate
    */
   RateHelper(const GuardedOptions state, const Options& units,
@@ -148,8 +144,8 @@ struct RateHelper {
         [this, &cell_props, &do_averaging, &result](auto&& rate_calc_func) {
           auto J = result.rate.getCoordinates()->J;
           BOUT_FOR(i, region) {
-            // Get densities and mass action-factor for this cell
-            add_densities_and_mass_action(i, cell_props, do_averaging);
+            // Get densities for this cell
+            add_densities(i, cell_props, do_averaging);
 
             using RateFuncType = std::decay_t<decltype(rate_calc_func)>;
             if constexpr (std::is_same_v<RateFuncType, OneDRateFunc>) {
@@ -159,13 +155,10 @@ struct RateHelper {
                 DataTriple T_data = compute_rate_param(0, i, do_averaging);
 
                 // Compute rate(s)
-                cell_props.rate.centre =
-                    rate_calc_func(cell_props.mass_action.centre, T_data.centre);
+                cell_props.rate.centre = rate_calc_func(T_data.centre);
                 if (do_averaging) {
-                  cell_props.rate.left =
-                      rate_calc_func(cell_props.mass_action.left, T_data.left);
-                  cell_props.rate.right =
-                      rate_calc_func(cell_props.mass_action.right, T_data.right);
+                  cell_props.rate.left = rate_calc_func(T_data.left);
+                  cell_props.rate.right = rate_calc_func(T_data.right);
                 }
               } else {
                 throw BoutException(
@@ -179,13 +172,10 @@ struct RateHelper {
                 DataTriple Te_data = compute_rate_param(1, i, do_averaging);
 
                 // Compute rate(s)
-                cell_props.rate.centre = rate_calc_func(cell_props.mass_action.centre,
-                                                        ne_data.centre, Te_data.centre);
+                cell_props.rate.centre = rate_calc_func(ne_data.centre, Te_data.centre);
                 if (do_averaging) {
-                  cell_props.rate.left = rate_calc_func(cell_props.mass_action.left,
-                                                        ne_data.left, Te_data.left);
-                  cell_props.rate.right = rate_calc_func(cell_props.mass_action.right,
-                                                         ne_data.right, Te_data.right);
+                  cell_props.rate.left = rate_calc_func(ne_data.left, Te_data.left);
+                  cell_props.rate.right = rate_calc_func(ne_data.right, Te_data.right);
                 }
 
               } else if constexpr (RateParamsType == RateParamsTypes::ET) {
@@ -198,8 +188,8 @@ struct RateHelper {
               }
             }
 
-            // Add the collision freqs (rate(s) divided by each reactant density)
-            add_collision_freqs(cell_props, do_averaging);
+            // Apply density factors to rate and compute collision frequencies
+            add_density_factors(cell_props, do_averaging);
 
             if (do_averaging) {
               // Compute averaged rate, collision frequencies and store in result
@@ -298,38 +288,48 @@ private:
   }
 
   /**
-   * @brief For each reactant, divide the reaction rate by reactant density to compute the associated collision frequency
+   * @brief Multiply rates by all reactant densities, collision frequencies by all densities except the target species.
    *
-   * @param cell_props[inout] temporary struct already containing reaction rates and densities
+   * @param cell_props[inout] temporary struct already containing rates, collision freqs, densities
    * @param do_averaging[in] whether to compute left and right values for averaging
    */
-  inline void add_collision_freqs(CellProps& cell_props, bool do_averaging = true) {
-    for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
-         reactant_idx++) {
-      cell_props.collision_freqs[reactant_idx].centre =
-          cell_props.rate.centre / cell_props.densities[reactant_idx].centre;
+  inline void add_density_factors(CellProps& cell_props, bool do_averaging = true) {
+    // Save <sigma.v> (before any density factors are applied)
+    const DataTriple sigma_v = cell_props.rate;
+
+    // Multiply rate by all reactant densities (mass action factor)
+    for (std::size_t ridx = 0; ridx < this->num_reactants; ridx++) {
+      cell_props.rate.centre *= cell_props.densities[ridx].centre;
       if (do_averaging) {
-        cell_props.collision_freqs[reactant_idx].left =
-            cell_props.rate.left / cell_props.densities[reactant_idx].left;
-        cell_props.collision_freqs[reactant_idx].right =
-            cell_props.rate.right / cell_props.densities[reactant_idx].right;
+        cell_props.rate.left *= cell_props.densities[ridx].left;
+        cell_props.rate.right *= cell_props.densities[ridx].right;
+      }
+    }
+
+    // Collision frequency = <sigma.v> * (density product excluding target reactant)
+    for (std::size_t target_ridx = 0; target_ridx < this->num_reactants; target_ridx++) {
+      cell_props.collision_freqs[target_ridx] = sigma_v;
+      for (std::size_t other_ridx = 0; other_ridx < this->num_reactants; ++other_ridx) {
+        if (target_ridx != other_ridx) {
+          cell_props.collision_freqs[target_ridx].centre *=
+              cell_props.densities[other_ridx].centre;
+          if (do_averaging) {
+            cell_props.collision_freqs[target_ridx].left *=
+                cell_props.densities[other_ridx].left;
+            cell_props.collision_freqs[target_ridx].right *=
+                cell_props.densities[other_ridx].right;
+          }
+        }
       }
     }
   }
 
-  inline void add_densities_and_mass_action(Ind3D i, CellProps& cell_props,
-                                            bool do_averaging) {
-    // Reset mass action products
-    cell_props.mass_action.centre = 1.0;
-    cell_props.mass_action.left = 1.0;
-    cell_props.mass_action.right = 1.0;
-
-    // Store interpolated densities and mass action
+  inline void add_densities(Ind3D i, CellProps& cell_props, bool do_averaging) {
+    // Store interpolated densities
     for (std::size_t reactant_idx = 0; reactant_idx < this->num_reactants;
          ++reactant_idx) {
       auto* dens = this->reactant_densities[reactant_idx];
       cell_props.densities[reactant_idx].centre = (*dens)[i];
-      cell_props.mass_action.centre *= (*dens)[i];
       if (do_averaging) {
         auto ym = i.ym();
         auto yp = i.yp();
@@ -337,8 +337,6 @@ private:
             cellLeft<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
         cell_props.densities[reactant_idx].right =
             cellRight<Limiter>((*dens)[i], (*dens)[ym], (*dens)[yp]);
-        cell_props.mass_action.left *= cell_props.densities[reactant_idx].left;
-        cell_props.mass_action.right *= cell_props.densities[reactant_idx].right;
       }
     }
   }

--- a/src/amjuel_data.cxx
+++ b/src/amjuel_data.cxx
@@ -12,8 +12,8 @@ namespace hermes {
 /// @brief Helper functions for evaluating Amjuel fits.
 
 /**
- * @brief Evaluate an Amjuel double polynomial fit in n and T, given a table of
- * coefficients (see page 20 of amjuel.pdf).
+ * @brief Evaluate an Amjuel double polynomial fit in n and T.
+ * This function user's Honer's method rather than the formulation on page 20 of amjuel.pdf.
  *
  * @param T temperature in eV
  * @param n number density in m^-3
@@ -24,27 +24,26 @@ namespace hermes {
 static BoutReal
 eval_amjuel_nT_fit(BoutReal T, BoutReal n,
                    const std::vector<std::vector<BoutReal>>& coeff_table) {
-  // Enforce range of validity
-  n = std::clamp(n, 1e14, 1e22); // 1e8 - 1e16 cm^-3
+  n = std::clamp(n, 1e14, 1e22);
   T = std::clamp(T, 0.1, 1e4);
 
-  BoutReal logntilde = log(n / 1e14); // Note: 1e8 cm^-3
-  BoutReal logT = log(T);
+  const BoutReal logntilde = log(n / 1e14);
+  const BoutReal logT = log(T);
+
+  const std::size_t nrows = coeff_table.size();
+  const std::size_t ncols = coeff_table[0].size();
+
   BoutReal result = 0.0;
 
-  BoutReal logT_n = 1.0; // log(T) ** n
-  std::size_t num_n = coeff_table.size();
-  std::size_t num_T = coeff_table[0].size();
-  for (size_t n_idx = 0; n_idx < num_n; ++n_idx) {
-    BoutReal logn_m = 1.0; // log(ntilde) ** m
-    const auto& nrow = coeff_table[n_idx];
-    for (size_t T_idx = 0; T_idx < num_T; ++T_idx) {
-      result += nrow[T_idx] * logn_m * logT_n;
-      logn_m *= logntilde;
+  for (std::size_t irow = nrows; irow-- > 0;) {
+    BoutReal row_result = 0.0;
+    for (std::size_t icol = ncols; icol-- > 0;) {
+      row_result = row_result * logntilde + coeff_table[irow][icol];
     }
-    logT_n *= logT;
+    result = result * logT + row_result;
   }
-  return exp(result) * 1e-6; // Note: convert cm^3 to m^3
+
+  return exp(result) * 1e-6;
 }
 
 /**

--- a/src/amjuel_data.cxx
+++ b/src/amjuel_data.cxx
@@ -43,6 +43,7 @@ eval_amjuel_nT_fit(BoutReal T, BoutReal n,
     result = result * logT + row_result;
   }
 
+  // Note: convert cm^3 to m^3
   return exp(result) * 1e-6;
 }
 

--- a/src/amjuel_data.cxx
+++ b/src/amjuel_data.cxx
@@ -13,7 +13,7 @@ namespace hermes {
 
 /**
  * @brief Evaluate an Amjuel double polynomial fit in n and T.
- * This function user's Honer's method rather than the formulation on page 20 of amjuel.pdf.
+ * This function user's Horner's method rather than the formulation on page 20 of amjuel.pdf.
  *
  * @param T temperature in eV
  * @param n number density in m^-3

--- a/src/reaction.cxx
+++ b/src/reaction.cxx
@@ -243,9 +243,8 @@ void Reaction::transform_impl(GuardedOptions& state) {
   if (rate_params_type == RateParamsTypes::ET) {
     throw BoutException("RateParamsTypes::ET not implemented");
   } else if (rate_params_type == RateParamsTypes::nT) {
-    TwoDRateFunc calc_rate = [&](BoutReal mass_action, BoutReal ne, BoutReal te) {
-      BoutReal result = mass_action
-                        * this->rate_data->eval_sigma_v_nT(te * Tnorm, ne * Nnorm) * Nnorm
+    TwoDRateFunc calc_rate = [&](BoutReal ne, BoutReal te) {
+      BoutReal result = this->rate_data->eval_sigma_v_nT(te * Tnorm, ne * Nnorm) * Nnorm
                         / FreqNorm * rate_multiplier;
       return result;
     };
@@ -253,9 +252,9 @@ void Reaction::transform_impl(GuardedOptions& state) {
         RateHelper<RateParamsTypes::nT>(state, units, reactant_names, rng_nobndry);
     rate_calc_results = rate_helper.calc_rates(calc_rate, this->do_parallel_averaging);
   } else if (rate_params_type == RateParamsTypes::T) {
-    OneDRateFunc calc_rate = [&](BoutReal mass_action, BoutReal Teff) {
-      BoutReal result = mass_action * 1e-6 * this->rate_data->eval_sigma_v_T(Teff) * Nnorm
-                        / FreqNorm * rate_multiplier;
+    OneDRateFunc calc_rate = [&](BoutReal Teff) {
+      BoutReal result = 1e-6 * this->rate_data->eval_sigma_v_T(Teff) * Nnorm / FreqNorm
+                        * rate_multiplier;
       return result;
     };
 

--- a/src/reaction.cxx
+++ b/src/reaction.cxx
@@ -238,7 +238,7 @@ void Reaction::transform_impl(GuardedOptions& state) {
                                   .getRegion("RGN_NOBNDRY");
 
   // Create rate helper and compute reaction rate, collision frequencies
-  RateData rate_calc_results;
+  RateData rate_calc_results(reactant_names);
   RateParamsTypes rate_params_type = this->rate_data->get_fit_type();
   if (rate_params_type == RateParamsTypes::ET) {
     throw BoutException("RateParamsTypes::ET not implemented");


### PR DESCRIPTION
### Purpose
Get rid of some inefficiencies in the calculation of reaction rates, particularly from Amjuel data.

Aims to resolve #625.

### Change Summary
- Rejigs `RateHelper::calc_rates()` to 
  1. reduce the number of calls to rate_calc_func (and therefore to the expensive AmjuelData::eval_* functions)
  2. reduce the use of `std::map` in favour of `std::vector`, particularly inside the `BOUT_FOR` loop
- Uses [Horner's method](https://en.wikipedia.org/wiki/Horner%27s_method) for evaluating the bivariate polynomials.

### Validation
I ran the `1D-threshold` example and an abbreviated version of the (2D) `annulus-te-he-fixedneutrals` example in vtune, then examined the hotspot data. Bout++/hermes libs and execs generated with -O3 and -DCHECK=0.

Total time spent in reaction polynomial evaluation (orange), other parts of Reaction::transform (yellow) and the rest of the code (blue)  for `1D-threshold`:
<img width="919" height="492" alt="image" src="https://github.com/user-attachments/assets/5c751cba-1750-4ff5-b2cf-0d913dc7ccb4" />

and for `annulus-te-he-fixedneutrals`:
<img width="920" height="521" alt="image" src="https://github.com/user-attachments/assets/311eef75-cef2-437a-857e-c2fc120bbcb1" />


### AI Assistance
GitHub copilot used for code-completion and assistance with refactoring. 

### Documentation
None; developer interface largely unchanged.
